### PR TITLE
WIP: Implement analysis of formals in association lists

### DIFF
--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -795,8 +795,10 @@ impl Search for QualifiedExpression {
 
 impl Search for AssociationElement {
     fn search(&self, searcher: &mut impl Searcher) -> SearchResult {
-        // @TODO more formal
-        let AssociationElement { actual, .. } = self;
+        let AssociationElement { formal, actual } = self;
+        if let Some(formal) = formal {
+            return_if_found!(formal.search(searcher));
+        }
         match actual.item {
             ActualPart::Expression(ref expr) => {
                 return_if_found!(search_pos_expr(&actual.pos, expr, searcher));


### PR DESCRIPTION
This is very much a work in progress, but I want to share my initial efforts in order to avoid running in the wrong direction.

Everything I've tested works fine, but is much too lenient.

Some things that are yet to be solved:
1. Interface lists do not have their own regions, so associating generics in the port map and vice-versa is not diagnosed.
2. Indexed names are parsed as function calls due to syntax ambiguity. As a result Name::IndexedName is never instantiated, and indexed formals have to be disambiguated based on the function call's name.
3. Type conversions and conversion functions are not checked for arity.
4. Components do not currently have a region associated with themselves.

Feedback is welcome - if I am going in the wrong direction with this please let me know.