### PR TITLE
Update Cargo.toml

### DIFF
--- a/vhdl_lang/Cargo.toml
+++ b/vhdl_lang/Cargo.toml
@@ -14,20 +14,20 @@ repository = "https://github.com/kraigher/rust_hdl"
 edition = "2018"
 
 [dependencies]
-pad = "^0"
+pad = "^0.1"
 fnv = "^1"
 clap = "^2"
-toml = "^0"
-glob = "^0"
+toml = "^0.3"
+glob = "^0.3"
 dirs = "^2"
 rayon = "^1.3"
-parking_lot = "^0"
+parking_lot = "^0.12"
 dunce = "^1"
 arc-swap = {version = "^1.2.0", features = ["weak"]}
 
 [dev-dependencies]
 tempfile = "^3"
-pretty_assertions = "^0"
+pretty_assertions = "^1"
 assert_matches = "^1"
 
 [features]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.