### PR TITLE
Search the installed libraries in a hardcoded set of locations

### DIFF
--- a/.github/workflows/build-test-all.yml
+++ b/.github/workflows/build-test-all.yml
@@ -49,13 +49,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }} --features "packaged"
+          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }}
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }} --features "packaged"
+          args: --manifest-path ${{ matrix.crate }}/Cargo.toml --release --target ${{ matrix.target }}
 
       - name: rustfmt
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM clux/muslrust:$RUST_VERSION as builder
 WORKDIR /volume
 COPY . /volume/
 ARG CRATE
-RUN cargo build --manifest-path $CRATE/Cargo.toml --release --features "packaged"
+RUN cargo build --manifest-path $CRATE/Cargo.toml --release
 
 FROM scratch
 ARG CRATE

--- a/vhdl_lang/Cargo.toml
+++ b/vhdl_lang/Cargo.toml
@@ -32,4 +32,3 @@ assert_matches = "1"
 
 [features]
 default = []
-packaged = []

--- a/vhdl_ls/Cargo.toml
+++ b/vhdl_ls/Cargo.toml
@@ -30,4 +30,3 @@ pretty_assertions = "1"
 
 [features]
 default = []
-packaged = ["vhdl_lang/packaged"]


### PR DESCRIPTION
As discussed in #136, I removed the "packaged" feature and instead search in hardcoded places for the installed vhdl libraries. The current list looks like that:

```rust
 let search_paths = [
            "/usr/lib/rust_hdl/vhdl_libraries",
            "../vhdl_libraries",
            "../../vhdl_libraries",
        ];
```

Since I'm new to rust I would appreciate some comments on the code.