### PR TITLE
Analyze bit strings

### DIFF
--- a/vhdl_lang/src/analysis.rs
+++ b/vhdl_lang/src/analysis.rs
@@ -25,9 +25,9 @@ mod root;
 mod semantic;
 mod sequential;
 mod standard;
+mod static_expression;
 mod target;
 mod visibility;
-mod static_expression;
 
 #[cfg(test)]
 mod tests;

--- a/vhdl_lang/src/analysis.rs
+++ b/vhdl_lang/src/analysis.rs
@@ -27,6 +27,7 @@ mod sequential;
 mod standard;
 mod target;
 mod visibility;
+mod static_expression;
 
 #[cfg(test)]
 mod tests;

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -105,6 +105,7 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             Literal::BitString(bitstring) => {
+                self.analyze_bit_string(pos, bitstring, diagnostics);
                 if let Some((elem_type, literals)) = as_single_index_enum_array(target_base) {
                     let needs_1 = bitstring.value.chars().any(|c| *c != b'0');
                     let c0 = Designator::Character(b'0');

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -107,32 +107,19 @@ impl<'a> AnalyzeContext<'a> {
             Literal::BitString(bitstring) => {
                 if let Ok(string) =  self.analyze_bit_string(pos, bitstring, diagnostics) {
                     if let Some((elem_type, literals)) = as_single_index_enum_array(target_base) {
-                        let needs_1 = string.chars().any(|c| *c != b'0');
-                        let c0 = Designator::Character(b'0');
-                        let c1 = Designator::Character(b'1');
-
-                        if !literals.contains(&c0) {
-                            diagnostics.push(Diagnostic::error(
-                                pos,
-                                format!(
-                                    "element {} of {} does not define character {}",
-                                    elem_type.describe(),
-                                    target_type.describe(),
-                                    c0
-                                ),
-                            ))
-                        }
-
-                        if needs_1 && !literals.contains(&c1) {
-                            diagnostics.push(Diagnostic::error(
-                                pos,
-                                format!(
-                                    "element {} of {} does not define character {}",
-                                    elem_type.describe(),
-                                    target_type.describe(),
-                                    c1
-                                ),
-                            ))
+                        for chr in string.chars() {
+                            let chr = Designator::Character(*chr);
+                            if !literals.contains(&chr) {
+                                diagnostics.push(Diagnostic::error(
+                                    pos,
+                                    format!(
+                                        "{} does not define character {}",
+                                        elem_type.describe(),
+                                        chr
+                                    ),
+                                ));
+                                break;
+                            }
                         }
                     } else {
                         diagnostics.push(Diagnostic::error(

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -105,7 +105,7 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             Literal::BitString(bitstring) => {
-                if let Ok(string) =  self.analyze_bit_string(pos, bitstring, diagnostics) {
+                if let Ok(string) = self.analyze_bit_string(pos, bitstring, diagnostics) {
                     if let Some((elem_type, literals)) = as_single_index_enum_array(target_base) {
                         for chr in string.chars() {
                             let chr = Designator::Character(*chr);

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -134,10 +134,7 @@ impl<'a> AnalyzeContext<'a> {
                                 );
                             }
                             BitStringConversionError::EmptySignedExpansion => {
-                                diagnostics.error(
-                                    pos,
-                                    "Cannot expand an empty signed bit string",
-                                );
+                                diagnostics.error(pos, "Cannot expand an empty signed bit string");
                             }
                         }
                     }

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -133,6 +133,12 @@ impl<'a> AnalyzeContext<'a> {
                                     ),
                                 );
                             }
+                            BitStringConversionError::EmptySignedExpansion => {
+                                diagnostics.error(
+                                    pos,
+                                    format!("Cannot expand an empty signed bit string",),
+                                );
+                            }
                         }
                     }
                 }

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -136,7 +136,7 @@ impl<'a> AnalyzeContext<'a> {
                             BitStringConversionError::EmptySignedExpansion => {
                                 diagnostics.error(
                                     pos,
-                                    format!("Cannot expand an empty signed bit string",),
+                                    "Cannot expand an empty signed bit string",
                                 );
                             }
                         }

--- a/vhdl_lang/src/analysis/region.rs
+++ b/vhdl_lang/src/analysis/region.rs
@@ -206,17 +206,12 @@ impl<'a> NamedEntities<'a> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Default)]
 pub(crate) enum RegionKind {
     PackageDeclaration,
     PackageBody,
+    #[default]
     Other,
-}
-
-impl Default for RegionKind {
-    fn default() -> RegionKind {
-        RegionKind::Other
-    }
 }
 
 #[derive(Default, Clone)]

--- a/vhdl_lang/src/analysis/standard.rs
+++ b/vhdl_lang/src/analysis/standard.rs
@@ -598,7 +598,7 @@ impl<'a> AnalyzeContext<'a> {
             .into_iter()
             .flatten(),
         )
-        .chain(self.comparators(typ).into_iter())
+        .chain(self.comparators(typ))
     }
 
     pub fn universal_implicits(
@@ -643,7 +643,7 @@ impl<'a> AnalyzeContext<'a> {
             .into_iter()
             .flatten(),
         )
-        .chain(self.comparators(typ).into_iter())
+        .chain(self.comparators(typ))
     }
 
     pub fn physical_implicits(&self, typ: TypeEnt<'a>) -> impl Iterator<Item = EntRef<'a>> {
@@ -676,7 +676,7 @@ impl<'a> AnalyzeContext<'a> {
             self.symmetric_binary(Operator::Rem, typ),
         ]
         .into_iter()
-        .chain(self.comparators(typ).into_iter())
+        .chain(self.comparators(typ))
     }
 
     pub fn enum_implicits(
@@ -690,7 +690,7 @@ impl<'a> AnalyzeContext<'a> {
             self.maximum(typ),
         ]
         .into_iter()
-        .chain(self.comparators(typ).into_iter())
+        .chain(self.comparators(typ))
         .chain(
             if matching_op {
                 Some(

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -4,10 +4,10 @@ use crate::Latin1String;
 use itertools::Itertools;
 use std::iter;
 
-macro_rules! byte_is_odd_decimal {
-    ($byte: expr) => {
-        ($byte - b'0') % 2 == 1
-    };
+/// returns whether `byte` is  an odd number when interpreted as decimal.
+/// byte must be between '0' and '9', but it is up to the caller to enforce this.
+fn byte_is_odd_decimal(byte: u8) -> bool {
+    (byte - b'0') % 2 == 1
 }
 
 /// Converts a decimal string (i.e. "123") to a binary string (i.e. "1111011").
@@ -32,7 +32,7 @@ pub(crate) fn decimal_str_to_binary_str(
         for ch in value {
             let new_digit = (ch + b'0') / 2 + add_next;
             new_s.push(new_digit);
-            add_next = if byte_is_odd_decimal!(ch) { 5 } else { 0 };
+            add_next = if byte_is_odd_decimal(ch) { 5 } else { 0 };
         }
 
         // remove the first element if it's '0'
@@ -61,7 +61,7 @@ pub(crate) fn decimal_str_to_binary_str(
     let mut stack: Vec<u8> = Vec::new();
 
     while !num.is_empty() {
-        if byte_is_odd_decimal!(*num.last().unwrap()) {
+        if byte_is_odd_decimal(*num.last().unwrap()) {
             stack.push(b'1');
         } else {
             stack.push(b'0');
@@ -216,7 +216,6 @@ pub(crate) fn bit_string_to_string(
     // According to the standard, the padding value should be the leftmost character in the string
     // but an empty string does not have a leftmost character.
     if simplified_value.len() == 0 {
-        println!("");
         return match bit_string.length {
             None => Ok(Latin1String::empty()),
             Some(value) => {

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -1,0 +1,389 @@
+use std::iter;
+use assert_matches::assert_matches;
+use itertools::{enumerate, Itertools};
+use crate::ast::{BaseSpecifier, BitString};
+use crate::{Latin1String, SrcPos};
+use crate::analysis::analyze::{AnalyzeContext, FatalResult};
+use crate::data::{DiagnosticHandler, WithPos};
+
+impl BaseSpecifier {
+    /// Returns whether this base specifier represents a signed value
+    /// (i.e. `SX` for signed hexadecimal) or an unsigned value
+    /// (i.e. `UX` or `X` for unsigned hexadecimal)
+    pub fn is_signed(&self) -> bool {
+        match self {
+            | BaseSpecifier::SX
+            | BaseSpecifier::SO
+            | BaseSpecifier::SB
+            => true,
+            | BaseSpecifier::B
+            | BaseSpecifier::UB
+            | BaseSpecifier::O
+            | BaseSpecifier::UO
+            | BaseSpecifier::X
+            | BaseSpecifier::UX
+            | BaseSpecifier::D
+            => false,
+        }
+    }
+
+    /// Get the digits that are obtained by replacing `byte` with the
+    /// appropriate sequence of characters as defined in the standard (section 15.8).
+    ///
+    /// # Special Cases
+    /// If the base specifier is `D`, i.e. decimal, return the byte itself (wrapped as array)
+    ///
+    /// # Example
+    /// ```
+    /// let digits: &[u8] = BaseSpecifier::UX.get_extended_digits(b'C');
+    /// assert_eq!(digits, b"1100");
+    ///
+    /// let digits: &[u8] = BaseSpecifier::O.get_extended_digits(b'F');
+    /// assert_eq!(digits, b"FFF")
+    /// ```
+    pub fn get_extended_digits(&self, byte: u8) -> Vec<u8> {
+        match self {
+            // For O, UO and SO, the values 1-7 are replaced.
+            // All other values are left as-is.
+            | BaseSpecifier::O
+            | BaseSpecifier::UO
+            | BaseSpecifier::SO => {
+                match byte {
+                    b'0' => Vec::from("000"),
+                    b'1' => Vec::from("001"),
+                    b'2' => Vec::from("010"),
+                    b'3' => Vec::from("011"),
+                    b'4' => Vec::from("100"),
+                    b'5' => Vec::from("101"),
+                    b'6' => Vec::from("110"),
+                    b'7' => Vec::from("111"),
+                    _ => vec![byte; 3]
+                }
+            }
+            // For U, UX and SX, the values 1-9 and A-F are replaced.
+            // All other values are left as-is.
+            | BaseSpecifier::X
+            | BaseSpecifier::UX
+            | BaseSpecifier::SX => {
+                match byte {
+                    b'0' => Vec::from("0000"),
+                    b'1' => Vec::from("0001"),
+                    b'2' => Vec::from("0010"),
+                    b'3' => Vec::from("0011"),
+                    b'4' => Vec::from("0100"),
+                    b'5' => Vec::from("0101"),
+                    b'6' => Vec::from("0110"),
+                    b'7' => Vec::from("0111"),
+                    b'8' => Vec::from("1000"),
+                    b'9' => Vec::from("1001"),
+                    b'A' | b'a' => Vec::from("1010"),
+                    b'B' | b'b' => Vec::from("1011"),
+                    b'C' | b'c' => Vec::from("1100"),
+                    b'D' | b'd' => Vec::from("1101"),
+                    b'E' | b'e' => Vec::from("1110"),
+                    b'F' | b'f' => Vec::from("1111"),
+                    _ => vec![byte; 4]
+                }
+            }
+            // Binary values are simply the values left as they are.
+            | BaseSpecifier::B
+            | BaseSpecifier::UB
+            | BaseSpecifier::SB
+            | BaseSpecifier::D => vec![byte],
+        }
+    }
+}
+
+/// Represents errors that occur when converting a bit string to a regular string
+#[derive(PartialEq, Eq, Clone, Debug)]
+enum BitStringConversionError {
+    /// Illegal decimal character encountered while converting a decimal bit string (i.e. D"12AFFE")
+    /// The `usize` argument represent the position for the first illegal character in the
+    /// bit_string's `value` string, (i.e. 2 for the example above)
+    IllegalDecimalCharacter(usize),
+    /// The converted integer is too large to fit into a 64-bit container.
+    IntegerToLarge,
+    /// Signals that when converting a value and truncating, information would be lost.
+    /// # Example
+    /// 5B"111111" => The first '0' would be lost
+    /// 8SX"0FF"   => The bit-string is positive but would be converted to a negative value
+    /// The `usize` argument is the index of the first character that cannot be truncated.
+    /// The `Latin1String` argument is the expanded (erroneous) String
+    IllegalTruncate(usize, Latin1String),
+}
+
+/// Converts a `BitString` to a `Latin1String` respecting the replacement values defined in LRM
+/// Returns the string as Latin1String when successful and a `BitStringConversionError` else
+/// 15.8 Bit string literals
+fn bit_string_to_string(bit_string: &BitString) -> Result<Latin1String, BitStringConversionError> {
+    // Simplifies the bit string by removing all occurrences of the underscore
+    // character
+    let simplified_value: Vec<u8> = bit_string.value.bytes
+        .clone()
+        .into_iter()
+        .filter(|&b| b != b'_')
+        .collect();
+
+    // TODO: For empty signed bit-strings it is unclear what the expanded value should be:
+    // For example, 2SB""
+    // 1) A string containing '0's, i.e. "00"
+    // 2) An error
+    // According to the standard, the padding value should be the leftmost character in the string
+    // but an empty string does not have a leftmost character.
+    if simplified_value.len() == 0 {
+        return match bit_string.length {
+            None =>
+                Ok(Latin1String::empty()),
+            Some(value) =>
+                Ok(Latin1String::from_vec(iter::repeat(b'0').take(value as usize).collect_vec()))
+        };
+    }
+
+    let mut extended_value = Vec::new();
+
+    if bit_string.base == BaseSpecifier::D {
+        // special case for decimal bit strings: convert them directly.
+        let mut decimal_value = Some(0_u64);
+        for (i, element) in enumerate(simplified_value) {
+            if element < b'0' || element > b'9' {
+                return Err(BitStringConversionError::IllegalDecimalCharacter(i));
+            }
+            let digit = (element - b'0') as u64;
+            decimal_value = decimal_value
+                .and_then(|x| 10_u64.checked_mul(x))
+                .and_then(|x| x.checked_add(digit));
+        }
+        match decimal_value {
+            Some(mut value) => {
+                loop {
+                    if value % 2 == 0 {
+                        extended_value.push(b'0');
+                    } else {
+                        extended_value.push(b'1');
+                    }
+                    value /= 2;
+                    if value == 0 {
+                        break;
+                    }
+                }
+                extended_value.reverse();
+            }
+            None => return Err(BitStringConversionError::IntegerToLarge)
+        }
+    } else {
+        for ch in simplified_value {
+            extended_value.append(&mut bit_string.base.get_extended_digits(ch));
+        }
+    }
+
+    // append, truncate or leave the bit-string dependent on the user-specified length
+    match bit_string.length {
+        None => Ok(Latin1String::from_vec(extended_value)),
+        Some(_length) => {
+            let length = _length as usize;
+            if length == extended_value.len() {
+                Ok(Latin1String::from_vec(extended_value))
+            } else {
+                if length < extended_value.len() {
+                    let pivot = extended_value.len() - length;
+                    let first_elements = &extended_value[..pivot];
+                    let last_elements = &extended_value[pivot..];
+                    // This char is allowed and may be truncated from the vector
+                    let allowed_char = if bit_string.base.is_signed() {
+                        last_elements[0]
+                    } else {
+                        b'0'
+                    };
+
+                    let idx = first_elements
+                        .iter()
+                        .rev()
+                        .position(|el| *el != allowed_char);
+                    match idx {
+                        Some(value) => {
+                            let real_idx = last_elements.len() + value - 1;
+                            let erroneous_string = Latin1String::from_vec(extended_value);
+                            Err(BitStringConversionError::IllegalTruncate(real_idx, erroneous_string))
+                        }
+                        None =>
+                            Ok(Latin1String::new(last_elements))
+                    }
+                } else {
+                    let pad_char = if bit_string.base.is_signed() {
+                        extended_value[0]
+                    } else {
+                        b'0'
+                    };
+                    let pad_vector = iter::repeat(pad_char)
+                        .take(length - extended_value.len())
+                        .chain(extended_value)
+                        .collect_vec();
+                    Ok(Latin1String::from_vec(pad_vector))
+                }
+            }
+        }
+    }
+}
+
+impl BitString {
+    fn new(length: Option<u32>, base: BaseSpecifier, value: &str) -> BitString {
+        BitString {
+            length,
+            base,
+            value: Latin1String::from_utf8_unchecked(value),
+        }
+    }
+}
+/*
+#[test]
+fn an_empty_bit_string_converts_to_an_empty_string() {
+    let all_base_specifiers = [
+        BaseSpecifier::O,
+        BaseSpecifier::UO,
+        BaseSpecifier::SO,
+        BaseSpecifier::X,
+        BaseSpecifier::UX,
+        BaseSpecifier::SX,
+        BaseSpecifier::B,
+        BaseSpecifier::UB,
+        BaseSpecifier::SB,
+        BaseSpecifier::D
+    ];
+    for base_specifier in all_base_specifiers {
+        assert_eq!(
+            bit_string_to_string(&BitString::new(None, base_specifier, "")).unwrap(),
+            Latin1String::empty()
+        )
+    }
+}
+
+#[test]
+fn test_illegal_decimal_character() {
+    assert_eq!(
+        bit_string_to_string(&BitString::new(None, BaseSpecifier::D, "12AFFE")),
+        Err(BitStringConversionError::IllegalDecimalCharacter(2))
+    );
+
+    assert_eq!(
+        bit_string_to_string(&BitString::new(None, BaseSpecifier::D, "?")),
+        Err(BitStringConversionError::IllegalDecimalCharacter(0))
+    );
+
+    assert_eq!(
+        bit_string_to_string(&BitString::new(None, BaseSpecifier::D, "78234+")),
+        Err(BitStringConversionError::IllegalDecimalCharacter(5))
+    );
+}
+
+#[test]
+fn test_decimal_conversion() {
+    let test_cases = [
+        (BitString::new(None, BaseSpecifier::D, ""), ""),
+        (BitString::new(None, BaseSpecifier::D, "0"), "0"),
+        (BitString::new(None, BaseSpecifier::D, "00"), "0"),
+        (BitString::new(None, BaseSpecifier::D, "000"), "0"),
+        (BitString::new(None, BaseSpecifier::D, "1"), "1"),
+        (BitString::new(None, BaseSpecifier::D, "01"), "1"),
+        (BitString::new(None, BaseSpecifier::D, "10"), "1010"),
+        (BitString::new(None, BaseSpecifier::D, "164824"), "101000001111011000"),
+    ];
+
+    for (bit_string, result_string) in test_cases {
+        assert_eq!(
+            bit_string_to_string(bit_string).unwrap(),
+            Latin1String::from_utf8_unchecked(result_string)
+        )
+    }
+}
+
+#[test]
+fn test_illegal_truncate_position() {
+    assert_eq!(
+        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "0FF")),
+        Err(BitStringConversionError::IllegalTruncate(7, Latin1String::new(b"000011111111")))
+    );
+
+    assert_eq!(
+        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "1FF")),
+        Err(BitStringConversionError::IllegalTruncate(8, Latin1String::new(b"000111111111")))
+    );
+
+    assert_eq!(
+        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "3FF")),
+        Err(BitStringConversionError::IllegalTruncate(9, Latin1String::new(b"001111111111")))
+    );
+}
+
+// Examples defined in 15.8
+#[test]
+fn spec_examples() {
+    let test_cases = [
+        (BitString::new(None, BaseSpecifier::B, "1111_1111_1111"), "111111111111"),
+        (BitString::new(None, BaseSpecifier::X, "FFF"), "111111111111"),
+        (BitString::new(None, BaseSpecifier::O, "777"), "111111111"),
+        (BitString::new(None, BaseSpecifier::X, "777"), "011101110111"),
+        (BitString::new(None, BaseSpecifier::B, "XXXX_01LH"), "XXXX01LH"),
+        (BitString::new(None, BaseSpecifier::UO, "27"), "010111"),
+        // (BitString::new(None, BaseSpecifier::UO, "2C"), "011CCC"), // TODO: is this an error in the spec?
+        (BitString::new(None, BaseSpecifier::SX, "3W"), "0011WWWW"),
+        (BitString::new(None, BaseSpecifier::D, "35"), "100011"),
+        (BitString::new(Some(12), BaseSpecifier::UB, "X1"), "0000000000X1"),
+        (BitString::new(Some(12), BaseSpecifier::SB, "X1"), "XXXXXXXXXXX1"),
+        (BitString::new(Some(12), BaseSpecifier::UX, "F-"), "00001111----"),
+        (BitString::new(Some(12), BaseSpecifier::SX, "F-"), "11111111----"),
+        (BitString::new(Some(12), BaseSpecifier::UX, "000WWW"), "WWWWWWWWWWWW"),
+        (BitString::new(Some(12), BaseSpecifier::SX, "FFFC00"), "110000000000"),
+    ];
+
+    let error_cases = [
+        BitString::new(Some(8), BaseSpecifier::D, "511"),
+        BitString::new(Some(8), BaseSpecifier::UO, "477"),
+        BitString::new(Some(8), BaseSpecifier::SX, "0FF"),
+        BitString::new(Some(8), BaseSpecifier::SX, "FXX"),
+    ];
+
+    for bit_string in error_cases {
+        assert_matches!(
+            bit_string_to_string(bit_string),
+            Err(BitStringConversionError::IllegalTruncate(_, _))
+        );
+    }
+
+    for (bit_string, result_string) in test_cases {
+        assert_eq!(
+            bit_string_to_string(bit_string).unwrap(),
+            Latin1String::from_utf8_unchecked(result_string)
+        )
+    }
+}
+ */
+
+impl<'a> AnalyzeContext<'a> {
+    pub fn analyze_bit_string(
+        &self,
+        pos: &SrcPos,
+        bit_string: &BitString,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) {
+        match bit_string_to_string(bit_string) {
+            Ok(_) => {}
+            Err(err) => {
+                match err {
+                    BitStringConversionError::IllegalDecimalCharacter(rel_pos) =>
+                        diagnostics.error(pos, format!(
+                            "Illegal digit '{}' for base 10",
+                            Latin1String::new(&[bit_string.value.bytes[rel_pos]]),
+                        )),
+                    BitStringConversionError::IntegerToLarge =>
+                        diagnostics.error(pos, "Integer too large for 64-bit unsigned"),
+                    BitStringConversionError::IllegalTruncate(_, _) => {
+                        diagnostics.error(pos, format!(
+                            "Truncating to {} bit would loose information",
+                            bit_string.length.unwrap()), // Safe as this error can only happen when there is a length
+                        );
+                    },
+                }
+            }
+        }
+    }
+}

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -34,11 +34,13 @@ impl BaseSpecifier {
     ///
     /// # Example
     /// ```
-    /// let digits: &[u8] = BaseSpecifier::UX.get_extended_digits(b'C');
-    /// assert_eq!(digits, b"1100");
+    /// use vhdl_lang::ast::BaseSpecifier;
     ///
-    /// let digits: &[u8] = BaseSpecifier::O.get_extended_digits(b'F');
-    /// assert_eq!(digits, b"FFF")
+    /// let digits: Vec<u8> = BaseSpecifier::UX.get_extended_digits(b'C');
+    /// assert_eq!(digits, Vec::from("1100"));
+    ///
+    /// let digits: Vec<u8> = BaseSpecifier::O.get_extended_digits(b'F');
+    /// assert_eq!(digits, Vec::from("FFF"))
     /// ```
     pub fn get_extended_digits(&self, byte: u8) -> Vec<u8> {
         match self {

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -1,8 +1,8 @@
-use std::cmp::Ordering;
 use crate::analysis::static_expression::BitStringConversionError::EmptySignedExpansion;
 use crate::ast::{BaseSpecifier, BitString};
 use crate::Latin1String;
 use itertools::Itertools;
+use std::cmp::Ordering;
 use std::iter;
 
 /// returns whether `byte` is  an odd number when interpreted as decimal.
@@ -250,8 +250,7 @@ pub(crate) fn bit_string_to_string(
         Some(_length) => {
             let length = _length as usize;
             match length.cmp(&extended_value.len()) {
-                Ordering::Equal =>
-                    Ok(Latin1String::from_vec(extended_value)),
+                Ordering::Equal => Ok(Latin1String::from_vec(extended_value)),
                 Ordering::Less => {
                     let pivot = extended_value.len() - length;
                     let first_elements = &extended_value[..pivot];
@@ -278,7 +277,7 @@ pub(crate) fn bit_string_to_string(
                         }
                         None => Ok(Latin1String::new(last_elements)),
                     }
-                },
+                }
                 Ordering::Greater => {
                     let pad_char = if bit_string.base.is_signed() {
                         extended_value[0]
@@ -290,7 +289,7 @@ pub(crate) fn bit_string_to_string(
                         .chain(extended_value)
                         .collect_vec();
                     Ok(Latin1String::from_vec(pad_vector))
-                },
+                }
             }
         }
     }

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -3,8 +3,8 @@ use assert_matches::assert_matches;
 use itertools::{enumerate, Itertools};
 use crate::ast::{BaseSpecifier, BitString};
 use crate::{Latin1String, SrcPos};
-use crate::analysis::analyze::{AnalyzeContext, FatalResult};
-use crate::data::{DiagnosticHandler, WithPos};
+use crate::analysis::analyze::{AnalyzeContext};
+use crate::data::{DiagnosticHandler};
 
 impl BaseSpecifier {
     /// Returns whether this base specifier represents a signed value
@@ -234,7 +234,7 @@ impl BitString {
         }
     }
 }
-/*
+
 #[test]
 fn an_empty_bit_string_converts_to_an_empty_string() {
     let all_base_specifiers = [
@@ -290,7 +290,7 @@ fn test_decimal_conversion() {
 
     for (bit_string, result_string) in test_cases {
         assert_eq!(
-            bit_string_to_string(bit_string).unwrap(),
+            bit_string_to_string(&bit_string).unwrap(),
             Latin1String::from_utf8_unchecked(result_string)
         )
     }
@@ -299,17 +299,17 @@ fn test_decimal_conversion() {
 #[test]
 fn test_illegal_truncate_position() {
     assert_eq!(
-        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "0FF")),
+        bit_string_to_string(&BitString::new(Some(8), BaseSpecifier::SX, "0FF")),
         Err(BitStringConversionError::IllegalTruncate(7, Latin1String::new(b"000011111111")))
     );
 
     assert_eq!(
-        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "1FF")),
+        bit_string_to_string(&BitString::new(Some(8), BaseSpecifier::SX, "1FF")),
         Err(BitStringConversionError::IllegalTruncate(8, Latin1String::new(b"000111111111")))
     );
 
     assert_eq!(
-        bit_string_to_string(BitString::new(Some(8), BaseSpecifier::SX, "3FF")),
+        bit_string_to_string(&BitString::new(Some(8), BaseSpecifier::SX, "3FF")),
         Err(BitStringConversionError::IllegalTruncate(9, Latin1String::new(b"001111111111")))
     );
 }
@@ -344,19 +344,18 @@ fn spec_examples() {
 
     for bit_string in error_cases {
         assert_matches!(
-            bit_string_to_string(bit_string),
+            bit_string_to_string(&bit_string),
             Err(BitStringConversionError::IllegalTruncate(_, _))
         );
     }
 
     for (bit_string, result_string) in test_cases {
         assert_eq!(
-            bit_string_to_string(bit_string).unwrap(),
+            bit_string_to_string(&bit_string).unwrap(),
             Latin1String::from_utf8_unchecked(result_string)
         )
     }
 }
- */
 
 impl<'a> AnalyzeContext<'a> {
     pub fn analyze_bit_string(

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -194,10 +194,19 @@ constant e: bit_vector := X\"F\"; -- this is Ok
         diagnostics,
         vec![
             Diagnostic::error(code.s1("D\"1AFFE\""), "Illegal digit 'A' for base 10"),
-            Diagnostic::error(code.s1("D\"28446744073709551615\""), "Integer too large for 64-bit unsigned"),
-            Diagnostic::error(code.s1("8SX\"0FF\""), "Truncating to 8 bit would loose information"),
+            Diagnostic::error(
+                code.s1("D\"28446744073709551615\""),
+                "Integer too large for 64-bit unsigned",
+            ),
+            Diagnostic::error(
+                code.s1("8SX\"0FF\""),
+                "Truncating to 8 bit would loose information",
+            ),
             Diagnostic::hint(code.s1("8SX\"0FF\""), "Expanded value is 000011111111"),
-            Diagnostic::error(code.s1("X\"G\""), "type 'BIT' does not define character 'G'"),
+            Diagnostic::error(
+                code.s1("X\"G\""),
+                "type 'BIT' does not define character 'G'",
+            ),
         ],
     )
 }

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -197,7 +197,6 @@ constant e: bit_vector := X\"F\"; -- this is Ok
                 code.s1("8SX\"0FF\""),
                 "Truncating to 8 bit would loose information",
             ),
-            Diagnostic::hint(code.s1("8SX\"0FF\""), "Expanded value is 000011111111"),
             Diagnostic::error(
                 code.s1("X\"G\""),
                 "type 'BIT' does not define character 'G'",
@@ -753,11 +752,11 @@ constant bad5 : arr0_t := x\"6\";
         vec![
             Diagnostic::error(
                 code.s1("x\"2\""),
-                "bit string literal does not match integer type 'INTEGER'",
+                "string literal does not match integer type 'INTEGER'",
             ),
             Diagnostic::error(
                 code.s1("x\"3\""),
-                "bit string literal does not match array type 'INTEGER_VECTOR'",
+                "string literal does not match array type 'INTEGER_VECTOR'",
             ),
             Diagnostic::error(
                 code.s1("x\"4\""),

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -182,7 +182,6 @@ fn test_illegal_bit_strings() {
     let code = builder.in_declarative_region(
         "
 constant a: bit_vector := D\"1AFFE\";
-constant b: bit_vector := D\"28446744073709551615\";
 constant c: bit_vector := 8SX\"0FF\";
 constant d: bit_vector := X\"G\";
 constant e: bit_vector := X\"F\"; -- this is Ok
@@ -194,10 +193,6 @@ constant e: bit_vector := X\"F\"; -- this is Ok
         diagnostics,
         vec![
             Diagnostic::error(code.s1("D\"1AFFE\""), "Illegal digit 'A' for base 10"),
-            Diagnostic::error(
-                code.s1("D\"28446744073709551615\""),
-                "Integer too large for 64-bit unsigned",
-            ),
             Diagnostic::error(
                 code.s1("8SX\"0FF\""),
                 "Truncating to 8 bit would loose information",
@@ -743,7 +738,7 @@ constant bad2 : integer_vector := x\"3\";
 type enum_t is (alpha, beta);
 type arr_t is array (natural range <>) of enum_t;
 constant bad3 : arr_t := x\"4\";
-constant bad4 : arr_t := x\"5\";
+constant bad4 : arr_t := x\"D\";
 
 type enum0_t is ('0', alpha);
 type arr0_t is array (natural range <>) of enum0_t;
@@ -766,23 +761,15 @@ constant bad5 : arr0_t := x\"6\";
             ),
             Diagnostic::error(
                 code.s1("x\"4\""),
-                "element type 'enum_t' of array type 'arr_t' does not define character '0'",
+                "type 'enum_t' does not define character '0'",
             ),
             Diagnostic::error(
-                code.s1("x\"4\""),
-                "element type 'enum_t' of array type 'arr_t' does not define character '1'",
-            ),
-            Diagnostic::error(
-                code.s1("x\"5\""),
-                "element type 'enum_t' of array type 'arr_t' does not define character '0'",
-            ),
-            Diagnostic::error(
-                code.s1("x\"5\""),
-                "element type 'enum_t' of array type 'arr_t' does not define character '1'",
+                code.s1("x\"D\""),
+                "type 'enum_t' does not define character '1'",
             ),
             Diagnostic::error(
                 code.s1("x\"6\""),
-                "element type 'enum0_t' of array type 'arr0_t' does not define character '1'",
+                "type 'enum0_t' does not define character '1'",
             ),
         ],
     );

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -181,9 +181,11 @@ fn test_illegal_bit_strings() {
     let mut builder = LibraryBuilder::new();
     let code = builder.in_declarative_region(
         "
-constant x: bit_vector := D\"1AFFE\";
-constant y: bit_vector := D\"28446744073709551615\";
-constant z: bit_vector := 8SX\"0FF\";
+constant a: bit_vector := D\"1AFFE\";
+constant b: bit_vector := D\"28446744073709551615\";
+constant c: bit_vector := 8SX\"0FF\";
+constant d: bit_vector := X\"G\";
+constant e: bit_vector := X\"F\"; -- this is Ok
         ",
     );
 
@@ -195,6 +197,7 @@ constant z: bit_vector := 8SX\"0FF\";
             Diagnostic::error(code.s1("D\"28446744073709551615\""), "Integer too large for 64-bit unsigned"),
             Diagnostic::error(code.s1("8SX\"0FF\""), "Truncating to 8 bit would loose information"),
             Diagnostic::hint(code.s1("8SX\"0FF\""), "Expanded value is 000011111111"),
+            Diagnostic::error(code.s1("X\"G\""), "type 'BIT' does not define character 'G'"),
         ],
     )
 }

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -177,6 +177,28 @@ signal bad5 : enum_vec3_t(1 to 1) := \"a\";
 }
 
 #[test]
+fn test_illegal_bit_strings() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.in_declarative_region(
+        "
+constant x: bit_vector := D\"1AFFE\";
+constant y: bit_vector := D\"28446744073709551615\";
+constant z: bit_vector := 8SX\"0FF\";
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![
+            Diagnostic::error(code.s1("D\"1AFFE\""), "Illegal digit 'A' for base 10"),
+            Diagnostic::error(code.s1("D\"28446744073709551615\""), "Integer too large for 64-bit unsigned"),
+            Diagnostic::error(code.s1("8SX\"0FF\""), "Truncating to 8 bit would loose information"),
+        ],
+    )
+}
+
+#[test]
 fn test_integer_selected_name_expression_typecheck() {
     let mut builder = LibraryBuilder::new();
     let code = builder.in_declarative_region(

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -194,6 +194,7 @@ constant z: bit_vector := 8SX\"0FF\";
             Diagnostic::error(code.s1("D\"1AFFE\""), "Illegal digit 'A' for base 10"),
             Diagnostic::error(code.s1("D\"28446744073709551615\""), "Integer too large for 64-bit unsigned"),
             Diagnostic::error(code.s1("8SX\"0FF\""), "Truncating to 8 bit would loose information"),
+            Diagnostic::hint(code.s1("8SX\"0FF\""), "Expanded value is 000011111111"),
         ],
     )
 }

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -185,6 +185,7 @@ constant a: bit_vector := D\"1AFFE\";
 constant c: bit_vector := 8SX\"0FF\";
 constant d: bit_vector := X\"G\";
 constant e: bit_vector := X\"F\"; -- this is Ok
+constant f: bit_vector := 2SX\"\";
         ",
     );
 
@@ -200,6 +201,10 @@ constant e: bit_vector := X\"F\"; -- this is Ok
             Diagnostic::error(
                 code.s1("X\"G\""),
                 "type 'BIT' does not define character 'G'",
+            ),
+            Diagnostic::error(
+                code.s1("2SX\"\""),
+                "Cannot expand an empty signed bit string",
             ),
         ],
     )

--- a/vhdl_lang/src/data/source.rs
+++ b/vhdl_lang/src/data/source.rs
@@ -222,6 +222,14 @@ impl Position {
     pub fn range_to(self, end: Position) -> Range {
         Range { start: self, end }
     }
+
+    /// Shift the position `count` values to the right on the same line
+    pub fn shifted_same_line(&self, count: u32) -> Position {
+        return Position {
+            line: self.line,
+            character: self.character + count,
+        }
+    }
 }
 
 /// A lexical range in a source.
@@ -236,6 +244,14 @@ pub struct Range {
 impl Range {
     pub fn new(start: Position, end: Position) -> Range {
         Range { start, end }
+    }
+
+    pub fn shifted_same_line(&self, count: u32) -> Range {
+        assert_eq!(self.start.line, self.end.line);
+        Range {
+            start: self.start.shifted_same_line(count),
+            end: self.end.shifted_same_line(count),
+        }
     }
 }
 
@@ -536,6 +552,13 @@ impl SrcPos {
 
     pub fn combine(&self, other: &dyn AsRef<Self>) -> Self {
         self.clone().combine_into(other)
+    }
+
+    pub fn shifted_on_same_line(&self, count: u32) -> SrcPos {
+        return SrcPos {
+            source: self.source.clone(),
+            range: self.range.shifted_same_line(count)
+        }
     }
 }
 

--- a/vhdl_lang/src/data/source.rs
+++ b/vhdl_lang/src/data/source.rs
@@ -222,14 +222,6 @@ impl Position {
     pub fn range_to(self, end: Position) -> Range {
         Range { start: self, end }
     }
-
-    /// Shift the position `count` values to the right on the same line
-    pub fn shifted_same_line(&self, count: u32) -> Position {
-        return Position {
-            line: self.line,
-            character: self.character + count,
-        }
-    }
 }
 
 /// A lexical range in a source.
@@ -244,14 +236,6 @@ pub struct Range {
 impl Range {
     pub fn new(start: Position, end: Position) -> Range {
         Range { start, end }
-    }
-
-    pub fn shifted_same_line(&self, count: u32) -> Range {
-        assert_eq!(self.start.line, self.end.line);
-        Range {
-            start: self.start.shifted_same_line(count),
-            end: self.end.shifted_same_line(count),
-        }
     }
 }
 
@@ -552,13 +536,6 @@ impl SrcPos {
 
     pub fn combine(&self, other: &dyn AsRef<Self>) -> Self {
         self.clone().combine_into(other)
-    }
-
-    pub fn shifted_on_same_line(&self, count: u32) -> SrcPos {
-        return SrcPos {
-            source: self.source.clone(),
-            range: self.range.shifted_same_line(count)
-        }
     }
 }
 


### PR DESCRIPTION
Analyze `BitString`s and report when they are not setup correctly.

```vhdl
constant v: bit_vector := 2SX""; -- Cannot expand an empty signed bit string
constant w: bit_vector := X"10G"; -- type 'BIT' does not define character 'G'
constant x: bit_vector := D"1AFFE"; -- Illegal digit 'A' for base 10
constant z: bit_vector := 8SX"0FF"; -- Truncating to 8 bit would loose information
```

I want to start collaborating on this project as I am currently using and enjoying it. This project fills an important gap for us HDL developers, so thank you for making this Open Source.