### PR TITLE
Enable initial support for static expressions

### DIFF
--- a/vhdl_lang/src/analysis/assignment.rs
+++ b/vhdl_lang/src/analysis/assignment.rs
@@ -9,6 +9,7 @@ use super::analyze::*;
 use super::named_entity::*;
 use super::region::*;
 use super::target::AssignmentType;
+use crate::analysis::static_expression::StaticValue;
 use crate::ast::*;
 use crate::data::*;
 
@@ -127,12 +128,12 @@ impl<'a> AnalyzeContext<'a> {
         ttyp: Option<TypeEnt<'a>>,
         expr: &mut WithPos<Expression>,
         diagnostics: &mut dyn DiagnosticHandler,
-    ) -> FatalResult {
+    ) -> FatalResult<StaticValue> {
         if let Some(ttyp) = ttyp {
-            self.expr_with_ttyp(scope, ttyp, expr, diagnostics)?;
+            self.expr_with_ttyp(scope, ttyp, expr, diagnostics)
         } else {
-            self.expr_unknown_ttyp(scope, expr, diagnostics)?;
+            self.expr_unknown_ttyp(scope, expr, diagnostics)
+                .and(Ok(StaticValue::Unimplemented))
         }
-        Ok(())
     }
 }

--- a/vhdl_lang/src/analysis/named_entity/types.rs
+++ b/vhdl_lang/src/analysis/named_entity/types.rs
@@ -16,6 +16,7 @@ use crate::ast::{HasDesignator, Ident};
 use crate::data::WithPos;
 use crate::{Diagnostic, SrcPos};
 
+use crate::analysis::static_expression::StaticConstraint;
 use fnv::FnvHashSet;
 
 use super::{Arena, EntRef, Related};
@@ -433,11 +434,22 @@ impl<'a> Deref for BaseType<'a> {
 #[derive(Clone, Copy)]
 pub struct Subtype<'a> {
     pub(crate) type_mark: TypeEnt<'a>,
+    pub(crate) constraint: Option<StaticConstraint>,
 }
 
 impl<'a> Subtype<'a> {
     pub fn new(type_mark: TypeEnt<'a>) -> Subtype<'a> {
-        Subtype { type_mark }
+        Subtype {
+            type_mark,
+            constraint: None,
+        }
+    }
+
+    pub fn constrained(type_mark: TypeEnt<'a>, constraint: StaticConstraint) -> Subtype<'a> {
+        Subtype {
+            type_mark,
+            constraint: Some(constraint),
+        }
     }
 
     pub fn type_mark(&self) -> TypeEnt<'a> {

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -130,13 +130,15 @@ impl<'a> AnalyzeContext<'a> {
 
                         mapping.insert(uninst_typ.id(), typ);
                     }
-                    GpkgInterfaceEnt::Constant(obj) => self.expr_pos_with_ttyp(
-                        scope,
-                        self.map_type_ent(&mapping, obj.type_mark()),
-                        &assoc.actual.pos,
-                        expr,
-                        diagnostics,
-                    )?,
+                    GpkgInterfaceEnt::Constant(obj) => self
+                        .expr_pos_with_ttyp(
+                            scope,
+                            self.map_type_ent(&mapping, obj.type_mark()),
+                            &assoc.actual.pos,
+                            expr,
+                            diagnostics,
+                        )
+                        .and(Ok(()))?,
                     GpkgInterfaceEnt::Subprogram(target) => match expr {
                         Expression::Name(name) => {
                             let resolved =
@@ -547,10 +549,14 @@ impl<'a> AnalyzeContext<'a> {
         mapping: &FnvHashMap<EntityId, TypeEnt<'a>>,
         subtype: Subtype<'a>,
     ) -> Result<Subtype<'a>, String> {
-        let Subtype { type_mark } = subtype;
+        let Subtype {
+            type_mark,
+            constraint,
+        } = subtype;
 
         Ok(Subtype {
             type_mark: self.map_type_ent(mapping, type_mark),
+            constraint,
         })
     }
 }

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -482,11 +482,28 @@ pub enum StaticConstraint {
     Range(i64, i64, Direction),
 }
 
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum StaticValue {
+    /// The value is not static, e.g. a variable or signal
     NonStatic,
+    /// The case in unimplemented. This is to be treated as if there was no error.
+    /// This case should vanish when every possibility is explored.
     Unimplemented,
+    /// The static value is to be ignored (and also not returned) as a more severe error was found but was already reported. E.g.:
+    /// `constant x: bit_vector(2 downto 0) := "10F0";`
+    /// The length of the string literal is four, which does not match the length on the left.
+    /// However, there is the illegal character 'F' in the string literal which will be reported.
+    HasOtherError,
+    /// The value is an integer type.
     Integer(i64),
+    /// The value is a real type.
+    Real(f64),
+    /// The value is a character type.
+    Character(u8),
+    /// The value is a string type. This may also come from a bit-string literal
     String(Latin1String),
+    /// The value is null
+    Null,
+    /// The static value is a constraint.
     Constraint(StaticConstraint),
 }

--- a/vhdl_lang/src/analysis/static_expression.rs
+++ b/vhdl_lang/src/analysis/static_expression.rs
@@ -1,5 +1,5 @@
 use crate::analysis::static_expression::BitStringConversionError::EmptySignedExpansion;
-use crate::ast::{BaseSpecifier, BitString};
+use crate::ast::{BaseSpecifier, BitString, Direction};
 use crate::Latin1String;
 use itertools::Itertools;
 use std::cmp::Ordering;
@@ -475,4 +475,18 @@ mod test_mod {
             )
         }
     }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub enum StaticConstraint {
+    Range(i64, i64, Direction),
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum StaticValue {
+    NonStatic,
+    Unimplemented,
+    Integer(i64),
+    String(Latin1String),
+    Constraint(StaticConstraint),
 }

--- a/vhdl_lang/src/analysis/tests/mod.rs
+++ b/vhdl_lang/src/analysis/tests/mod.rs
@@ -20,6 +20,7 @@ mod resolves_design_units;
 mod resolves_names;
 mod resolves_type_mark;
 mod sensitivity_list;
+mod static_array_size;
 mod subprogram_arguments;
 mod typecheck_expression;
 mod util;

--- a/vhdl_lang/src/analysis/tests/static_array_size.rs
+++ b/vhdl_lang/src/analysis/tests/static_array_size.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[test]
+fn test_static_array_size() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.in_declarative_region(
+        "
+signal bad: bit_vector(2 downto 0) := \"1100\";
+constant good: bit_vector(2 downto 0) := \"100\";
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![Diagnostic::error(
+            code.s1("\"1100\""),
+            "Left hand side of expression has a size of 3 but the right hand side has a size of 4",
+        )],
+    );
+}

--- a/vhdl_lang/src/analysis/tests/static_array_size.rs
+++ b/vhdl_lang/src/analysis/tests/static_array_size.rs
@@ -7,6 +7,8 @@ fn test_static_array_size() {
         "
 signal bad: bit_vector(2 downto 0) := \"1100\";
 constant good: bit_vector(2 downto 0) := \"100\";
+constant WIDTH: natural := 5;
+constant bad2: bit_vector(WIDTH - 1 downto 0) := \"000\";
         ",
     );
 
@@ -16,6 +18,9 @@ constant good: bit_vector(2 downto 0) := \"100\";
         vec![Diagnostic::error(
             code.s1("\"1100\""),
             "Left hand side of expression has a size of 3 but the right hand side has a size of 4",
+        ), Diagnostic::error(
+            code.s1("\"---\""),
+            "Left hand side of expression has a size of 4 but the right hand side has a size of 3",
         )],
     );
 }


### PR DESCRIPTION
I want to enable support for static expression so that the following couple of examples will be recognized as errors:
```VHDL
constant x: bit_vector(2 down 0) := "0011"; -- Error: Left hand side of assignment has size 3 but right hand side has size 4
constant WIDTH: natural := 5;
constant y: bit_vector(WIDTH - 1 down 0) := "01" & "10"; -- Same as above
```

There are many more places where this is needed to recognize some more complex errors, some common examples include:
- Checking the bit-width for ports and generics in instantiated components
- Check full overlap for `case` statements
- Check the range for range constraint integers
- Check that something that expects a static value (i.e. constants) also get a static value

As this will probably be a fairly big change in the codebase I want to make sure the implementation makes sense from the very beginning. My idea is as follows:
- When analyzing expressions, return the static value of that expression. 
  - When the expression is not static, return the special case `StaticValue::NonStatic`.
  -  If there is another error, return `StaticValue::HasOtherError`. 
  - As this might be a longer process, return `StaticValue::Unimplemented` to retain the status where this implementation doesn't change anything
- Assignments, case statements and others can then be analyzed using the obtained static value.

Any comments on this approach? Do you think this will work or do you have something else in mind? I'm happy to discuss further approaches.