### PR TITLE
Feat: Enable type attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vhdl_lang"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "assert_matches",
  "clap",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "vhdl_ls"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vhdl_lang"
-version = "0.65.0"
+version = "0.64.0"
 dependencies = [
  "assert_matches",
  "clap",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "vhdl_ls"
-version = "0.65.0"
+version = "0.64.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -1454,6 +1454,24 @@ mod test {
     }
 
     #[test]
+    fn type_attributes_cannot_be_used_as_an_expression() {
+        let test = TestSetup::new();
+        test.declarative_part("variable x : integer;");
+        let code = test.snippet("x'subtype");
+
+        let mut diagnostics = Vec::new();
+        assert_eq!(test.expr_type(&code, &mut diagnostics), None);
+
+        check_diagnostics(
+            diagnostics,
+            vec![Diagnostic::error(
+                code.s1("x'subtype"),
+                "integer type 'INTEGER' cannot be used in an expression",
+            )],
+        );
+    }
+
+    #[test]
     fn binary_expression_missing_names() {
         let test = TestSetup::new();
 

--- a/vhdl_lang/src/analysis/formal_region.rs
+++ b/vhdl_lang/src/analysis/formal_region.rs
@@ -266,6 +266,8 @@ impl<'a> std::ops::Deref for GpkgInterfaceEnt<'a> {
             GpkgInterfaceEnt::Type(typ) => typ.deref(),
             GpkgInterfaceEnt::Constant(obj) => obj.deref(),
             GpkgInterfaceEnt::Subprogram(subp) => subp.deref(),
+            // `ent` is of type `&&AnyEnt`. `deref()` returns `&AnyEnt` which is what we want
+            #[allow(suspicious_double_ref_op)]
             GpkgInterfaceEnt::Package(ent) => ent.deref(),
         }
     }

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -326,9 +326,11 @@ impl<'a> ResolvedName<'a> {
     }
 }
 
-/// Represents the result when resolving a result.
-/// This can either be a value (in the future, this case might also hold the value
-/// of the static expression of the attribute) or a type itself.
+/// Represents the result when resolving an attribute.
+/// This can either be a value or a type.
+///
+/// in the future, the value case might also hold the value
+/// of the static expression of the attribute.
 ///
 /// Values are returned for attributes such as `'low`, `'high`, `'val(..)`, e.t.c.
 /// Types are returned for attributes such as `'base`, `'subtype`, `'element`

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -320,7 +320,7 @@ impl<'a> ResolvedName<'a> {
     /// Convenience function that returns `Some(name)` when self is an object name, else `None`
     fn as_object_name(&self) -> Option<ObjectName<'a>> {
         match self {
-            ResolvedName::ObjectName(oname) => Some(oname.clone()),
+            ResolvedName::ObjectName(oname) => Some(*oname),
             _ => None,
         }
     }
@@ -1811,7 +1811,6 @@ variable b: natural range 0 to a'subtype'high;
             Ok(ResolvedName::ObjectName(_))
         );
     }
-
 
     #[test]
     fn element_subtype_for_non_arrays() {

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -117,7 +117,7 @@ impl<'a> ObjectName<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResolvedName<'a> {
     Library(Symbol),
     Design(DesignEnt<'a>),


### PR DESCRIPTION
Closes #184 

Implementation details:
Introduces a new return type `AttrResolveResult` which is either a type (for attributes such as `'subtype`, `'element`) or a value (for most other attributes such as `'high`, `'low`, ...)

Based on this attribute the name can be resolved correctly and `a'subtype'high` will resolve to the correct type while `a'subtype` as an expression yields an error