### PR TITLE
Fix: Allow components with the same name in different blocks

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -96,7 +96,7 @@ impl<'a> AnalyzeContext<'a> {
                 }
 
                 self.define_labels_for_concurrent_part(
-                    scope,
+                    &nested,
                     parent,
                     &mut block.statements,
                     diagnostics,

--- a/vhdl_lang/src/analysis/formal_region.rs
+++ b/vhdl_lang/src/analysis/formal_region.rs
@@ -266,6 +266,8 @@ impl<'a> std::ops::Deref for GpkgInterfaceEnt<'a> {
             GpkgInterfaceEnt::Type(typ) => typ.deref(),
             GpkgInterfaceEnt::Constant(obj) => obj.deref(),
             GpkgInterfaceEnt::Subprogram(subp) => subp.deref(),
+            // `ent` is of type `&&AnyEnt`. `deref()` returns `&AnyEnt` which is what we want
+            #[allow(suspicious_double_ref_op)]
             GpkgInterfaceEnt::Package(ent) => ent.deref(),
         }
     }

--- a/vhdl_lang/src/analysis/tests/homographs.rs
+++ b/vhdl_lang/src/analysis/tests/homographs.rs
@@ -25,6 +25,36 @@ end package;
 }
 
 #[test]
+fn allow_homographs_in_separate_blocks() {
+    let mut builder = LibraryBuilder::new();
+    builder.code(
+        "libname",
+        "
+entity A is
+end A;
+
+architecture arch of A is
+    component Z is end component;
+begin
+
+    First : block
+    begin
+        Z_inst : Z;
+    end block;
+
+    Second : block
+    begin
+        Z_inst : Z;
+    end block;
+end arch;
+",
+    );
+
+    let diagnostics = builder.analyze();
+    check_no_diagnostics(&diagnostics);
+}
+
+#[test]
 fn forbid_homographs() {
     let mut builder = LibraryBuilder::new();
     let code = builder.code(


### PR DESCRIPTION
Closes #182 

Implementation detail:
The labels were still defined in the old scope (i.e. `define_labels_for_concurrent_part` was called with the non-nested scope)