### PR TITLE
Shutdown the server on `shutdown` request using `connection.handle_shutdown`.

### DIFF
--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -86,7 +86,18 @@ impl ConnectionRpcChannel {
         while let Ok(message) = self.connection.receiver.recv() {
             trace!("Received message: {:?}", message);
             match message {
-                lsp_server::Message::Request(request) => self.handle_request(&mut server, request),
+                lsp_server::Message::Request(request) => {
+                    match self.connection.handle_shutdown(&request) {
+                        Ok(shutdown) => {
+                            if shutdown {
+                                server.shutdown_server();
+                            } else {
+                                self.handle_request(&mut server, request)
+                            }
+                        }
+                        Err(err) => panic!("{err:?}"),
+                    }
+                }
                 lsp_server::Message::Notification(notification) => {
                     self.handle_notification(&mut server, notification);
                 }
@@ -191,14 +202,6 @@ impl ConnectionRpcChannel {
             Ok((id, params)) => {
                 let result = server.text_document_references(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
-                return;
-            }
-            Err(request) => request,
-        };
-        let request = match extract::<request::Shutdown>(request) {
-            Ok((id, _params)) => {
-                server.shutdown_server();
-                self.send_response(lsp_server::Response::new_ok(id, ()));
                 return;
             }
             Err(request) => request,


### PR DESCRIPTION
I noticed in an example in rust-analyzer repository: https://github.com/rust-lang/rust-analyzer/blob/master/lib/lsp-server/examples/goto_def.rs#L86C31-L86C46 that there is a handle_shutdown method that does a little more than what vhdl_ls currently did. Using this method also fixes #194 thanks to not actually deserializing the request - so it kind of works around the problem, so probably not the best solution.

It looks like the parameters of the shutdown request that are sent are: `{}`, this gets parsed into Map instead of unit - `()`.