### PR TITLE
Return \n to end of line in case it's deleted

### DIFF
--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -115,6 +115,12 @@ impl Contents {
             }
         }
 
+        // New line should always be at the end of line, in case
+        // it's deleted by accident somehow, return it back.
+        if merged_content.chars().last().unwrap_or('\0') != '\n' {
+            merged_content.push('\n');
+        }
+
         let end_line = std::cmp::min(self.lines.len().saturating_sub(1), end_line);
         self.lines
             .splice(


### PR DESCRIPTION
One possible way to resolve #193.

It looks to me like LSP really does delete \n at the end of the line in the did change document event, if that's true, this seems to me like a plausible solution.

It's possible I am overlooking something, in that case this may be just a hot fix ignoring the actual cause.