### PR TITLE
Refactor: Vector of AssociationElements to MapAspect

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -86,13 +86,13 @@ impl<'a> AnalyzeContext<'a> {
                     self.analyze_interface_list(&nested, parent, list, diagnostics)?;
                 }
                 if let Some(ref mut list) = block.header.generic_map {
-                    self.analyze_assoc_elems(scope, list, diagnostics)?;
+                    self.analyze_assoc_elems(scope, &mut list.list.items[..], diagnostics)?;
                 }
                 if let Some(ref mut list) = block.header.port_clause {
                     self.analyze_interface_list(&nested, parent, list, diagnostics)?;
                 }
                 if let Some(ref mut list) = block.header.port_map {
-                    self.analyze_assoc_elems(scope, list, diagnostics)?;
+                    self.analyze_assoc_elems(scope, &mut list.list.items[..], diagnostics)?;
                 }
 
                 self.define_labels_for_concurrent_part(
@@ -288,14 +288,22 @@ impl<'a> AnalyzeContext<'a> {
                                     &entity_name.pos,
                                     &generic_region,
                                     scope,
-                                    &mut instance.generic_map,
+                                    instance
+                                        .generic_map
+                                        .as_mut()
+                                        .map(|it| it.list.items.as_mut_slice())
+                                        .unwrap_or(&mut []),
                                     diagnostics,
                                 )?;
                                 self.analyze_assoc_elems_with_formal_region(
                                     &entity_name.pos,
                                     &port_region,
                                     scope,
-                                    &mut instance.port_map,
+                                    instance
+                                        .port_map
+                                        .as_mut()
+                                        .map(|it| it.list.items.as_mut_slice())
+                                        .unwrap_or(&mut []),
                                     diagnostics,
                                 )?;
                                 Ok(())
@@ -326,14 +334,22 @@ impl<'a> AnalyzeContext<'a> {
                                     &component_name.pos,
                                     &generic_region,
                                     scope,
-                                    &mut instance.generic_map,
+                                    instance
+                                        .generic_map
+                                        .as_mut()
+                                        .map(|it| it.list.items.as_mut_slice())
+                                        .unwrap_or(&mut []),
                                     diagnostics,
                                 )?;
                                 self.analyze_assoc_elems_with_formal_region(
                                     &component_name.pos,
                                     &port_region,
                                     scope,
-                                    &mut instance.port_map,
+                                    instance
+                                        .port_map
+                                        .as_mut()
+                                        .map(|it| it.list.items.as_mut_slice())
+                                        .unwrap_or(&mut []),
                                     diagnostics,
                                 )?;
                                 Ok(())
@@ -366,12 +382,24 @@ impl<'a> AnalyzeContext<'a> {
                     err.add_to(diagnostics)?;
                 }
 
-                self.analyze_assoc_elems(scope, &mut instance.generic_map, diagnostics)?;
-                self.analyze_assoc_elems(scope, &mut instance.port_map, diagnostics)?;
+                self.analyze_map_aspect(scope, &mut instance.generic_map, diagnostics)?;
+                self.analyze_map_aspect(scope, &mut instance.port_map, diagnostics)?;
             }
         };
 
         Ok(())
+    }
+
+    pub fn analyze_map_aspect(
+        &self,
+        scope: &Scope<'a>,
+        map: &mut Option<MapAspect>,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> FatalResult {
+        let Some(aspect) = map else {
+            return Ok(());
+        };
+        self.analyze_assoc_elems(scope, aspect.list.items.as_mut_slice(), diagnostics)
     }
 
     pub fn sensitivity_list_check(

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -479,7 +479,7 @@ impl<'a> AnalyzeContext<'a> {
                 ContextItem::Library(LibraryClause {
                     ref mut name_list, ..
                 }) => {
-                    for library_name in name_list.items_mut() {
+                    for library_name in name_list.items.iter_mut() {
                         if self.work_sym == library_name.item.item {
                             library_name.set_unique_reference(self.work_library());
                             diagnostics.push(Diagnostic::hint(
@@ -503,7 +503,7 @@ impl<'a> AnalyzeContext<'a> {
                 ContextItem::Context(ContextReference {
                     ref mut name_list, ..
                 }) => {
-                    for name in name_list.items_mut() {
+                    for name in name_list.items.iter_mut() {
                         match name.item {
                             Name::Selected(..) => {}
                             _ => {
@@ -560,7 +560,7 @@ impl<'a> AnalyzeContext<'a> {
         use_clause: &mut UseClause,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalResult {
-        for name in use_clause.name_list.items_mut() {
+        for name in use_clause.name_list.items.iter_mut() {
             match name.item {
                 Name::Selected(..) => {}
                 Name::SelectedAll(..) => {}

--- a/vhdl_lang/src/analysis/named_entity.rs
+++ b/vhdl_lang/src/analysis/named_entity.rs
@@ -411,8 +411,9 @@ impl<'a> AnyEnt<'a> {
     #[allow(clippy::mut_from_ref)]
     unsafe fn unsafe_ref_mut(&self) -> &mut Self {
         // NOTE: Use read_volatile to prevent compiler to optimization away assignment to the returned reference
-        let mut_self: *mut AnyEnt = std::ptr::read_volatile(&self) as *const AnyEnt as *mut AnyEnt;
-        &mut *mut_self
+        let const_ptr = std::ptr::read_volatile(&self) as *const Self;
+        let mut_ptr = const_ptr as *mut Self;
+        &mut *mut_ptr
     }
 
     // Used to update the kind of pre-declared symbols that are visible before they have been fully analyzed

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -225,7 +225,12 @@ impl<'a> AnalyzeContext<'a> {
                 let (generics, other) = package_region.to_package_generic();
 
                 let mapping = if let Some(generic_map) = generic_map {
-                    self.package_generic_map(&nested, generics, generic_map, diagnostics)?
+                    self.package_generic_map(
+                        &nested,
+                        generics,
+                        generic_map.list.items.as_mut_slice(),
+                        diagnostics,
+                    )?
                 } else {
                     FnvHashMap::default()
                 };

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -21,11 +21,10 @@ pub mod search;
 pub use self::display::*;
 pub(crate) use self::util::*;
 pub(crate) use any_design_unit::*;
-use std::iter;
 
 use crate::analysis::EntityId;
 use crate::data::*;
-use crate::syntax::{Token, TokenId};
+use crate::syntax::{Token, TokenAccess, TokenId};
 
 /// LRM 15.8 Bit string literals
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
@@ -697,7 +696,7 @@ pub enum SubprogramDefault {
 /// LRM 6.5.5 Interface package declaration
 #[derive(PartialEq, Debug, Clone)]
 pub enum InterfacePackageGenericMapAspect {
-    Map(Vec<AssociationElement>),
+    Map(SeparatedList<AssociationElement>),
     Box,
     Default,
 }
@@ -969,9 +968,9 @@ pub struct BlockStatement {
 #[derive(PartialEq, Debug, Clone)]
 pub struct BlockHeader {
     pub generic_clause: Option<Vec<InterfaceDeclaration>>,
-    pub generic_map: Option<Vec<AssociationElement>>,
+    pub generic_map: Option<MapAspect>,
     pub port_clause: Option<Vec<InterfaceDeclaration>>,
-    pub port_map: Option<Vec<AssociationElement>>,
+    pub port_map: Option<MapAspect>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -1022,12 +1021,32 @@ pub enum InstantiatedUnit {
     Configuration(WithPos<SelectedName>),
 }
 
+#[derive(PartialEq, Debug, Clone)]
+pub struct MapAspect {
+    pub start: TokenId, // `generic` or `map`
+    pub list: SeparatedList<AssociationElement>,
+    pub closing_paren: TokenId,
+}
+
+impl MapAspect {
+    /// Returns an iterator over the formal elements of this map
+    pub fn formals(&self) -> impl Iterator<Item = &Designator> {
+        self.list.formals()
+    }
+
+    /// Returns the span that this aspect encompasses
+    pub fn span(&self, ctx: &dyn TokenAccess) -> SrcPos {
+        ctx.get_span(self.start, self.closing_paren)
+    }
+}
+
 /// 11.7 Component instantiation statements
 #[derive(PartialEq, Debug, Clone)]
 pub struct InstantiationStatement {
     pub unit: InstantiatedUnit,
-    pub generic_map: Vec<AssociationElement>,
-    pub port_map: Vec<AssociationElement>,
+    pub generic_map: Option<MapAspect>,
+    pub port_map: Option<MapAspect>,
+    pub semicolon: TokenId,
 }
 
 /// 11.8 Generate statements
@@ -1092,22 +1111,25 @@ pub struct LibraryClause {
 /// Represents a token-separated list of some generic type `T`
 #[derive(PartialEq, Debug, Clone)]
 pub struct SeparatedList<T> {
-    pub first: T,
-    pub remainder: Vec<(TokenId, T)>,
+    pub items: Vec<T>,
+    pub tokens: Vec<TokenId>,
+}
+
+impl SeparatedList<AssociationElement> {
+    /// Returns an iterator over the formal elements of this list
+    pub fn formals(&self) -> impl Iterator<Item = &Designator> {
+        self.items.iter().filter_map(|el| match &el.formal {
+            None => None,
+            Some(name) => match &name.item {
+                Name::Designator(desi) => Some(&desi.item),
+                _ => None,
+            },
+        })
+    }
 }
 
 pub type IdentList = SeparatedList<WithRef<Ident>>;
 pub type NameList = SeparatedList<WithPos<Name>>;
-
-impl<T> SeparatedList<T> {
-    pub fn items(&self) -> impl Iterator<Item = &T> {
-        iter::once(&self.first).chain(self.remainder.iter().map(|it| &it.1))
-    }
-
-    pub fn items_mut(&mut self) -> impl Iterator<Item = &mut T> {
-        iter::once(&mut self.first).chain(self.remainder.iter_mut().map(|it| &mut it.1))
-    }
-}
 
 /// LRM 12.4. Use clauses
 #[derive(PartialEq, Debug, Clone)]
@@ -1147,7 +1169,7 @@ pub struct PackageInstantiation {
     pub context_clause: ContextClause,
     pub ident: WithDecl<Ident>,
     pub package_name: WithPos<SelectedName>,
-    pub generic_map: Option<Vec<AssociationElement>>,
+    pub generic_map: Option<MapAspect>,
 }
 
 /// LRM 7.3 Configuration specification
@@ -1170,8 +1192,8 @@ pub enum EntityAspect {
 #[derive(PartialEq, Debug, Clone)]
 pub struct BindingIndication {
     pub entity_aspect: Option<EntityAspect>,
-    pub generic_map: Option<Vec<AssociationElement>>,
-    pub port_map: Option<Vec<AssociationElement>>,
+    pub generic_map: Option<MapAspect>,
+    pub port_map: Option<MapAspect>,
 }
 
 /// LRM 7.3 Configuration specification

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -916,7 +916,7 @@ impl Display for InterfacePackageDeclaration {
         match &self.generic_map {
             InterfacePackageGenericMapAspect::Map(assoc_list) => {
                 let mut first = true;
-                for assoc in assoc_list {
+                for assoc in &assoc_list.items {
                     if first {
                         write!(f, "\n    {assoc}")?;
                     } else {
@@ -1020,7 +1020,7 @@ impl Display for PackageInstantiation {
         write!(f, "package {} is new {}", self.ident, self.package_name)?;
         if let Some(assoc_list) = &self.generic_map {
             let mut first = true;
-            for assoc in assoc_list {
+            for assoc in &assoc_list.list.items {
                 if first {
                     write!(f, "\n  generic map (\n    {assoc}")?;
                 } else {

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -277,7 +277,7 @@ impl Search for WithPos<Target> {
 
 impl<T: Search> Search for SeparatedList<T> {
     fn search(&mut self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
-        for item in self.items_mut() {
+        for item in self.items.iter_mut() {
             return_if_found!(item.search(ctx, searcher));
         }
         NotFound
@@ -1199,7 +1199,7 @@ impl Search for FunctionSpecification {
 
 impl Search for LibraryClause {
     fn search(&mut self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
-        for name in self.name_list.items_mut() {
+        for name in self.name_list.items.iter_mut() {
             return_if_found!(searcher
                 .search_pos_with_ref(ctx, &name.item.pos, &mut name.reference)
                 .or_not_found());
@@ -1340,6 +1340,12 @@ impl Search for CaseStatement {
         return_if_found!(expression.search(ctx, searcher));
         return_if_found!(search_alternatives(alternatives, false, searcher, ctx));
         NotFound
+    }
+}
+
+impl Search for MapAspect {
+    fn search(&mut self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
+        self.list.search(ctx, searcher)
     }
 }
 

--- a/vhdl_lang/src/syntax/context.rs
+++ b/vhdl_lang/src/syntax/context.rs
@@ -90,14 +90,13 @@ pub fn parse_context(
         }))
     } else {
         // Context reference
-        let mut name_list = Vec::new();
+        let mut items = vec![name];
+        let mut tokens = Vec::new();
         while let Some(comma) = stream.pop_if_kind(Comma) {
-            name_list.push((comma, parse_name(stream)?));
+            items.push(parse_name(stream)?);
+            tokens.push(comma);
         }
-        let name_list = SeparatedList {
-            first: name,
-            remainder: name_list,
-        };
+        let name_list = SeparatedList { items, tokens };
         let semi_token = stream.expect_kind(SemiColon)?;
         Ok(DeclarationOrReference::Reference(ContextReference {
             context_token,

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -10,13 +10,14 @@ use super::common::ParseResult;
 use super::component_declaration::parse_component_declaration;
 use super::configuration::parse_configuration_specification;
 use super::context::parse_use_clause;
-use super::names::{parse_association_list, parse_selected_name};
+use super::names::parse_selected_name;
 use super::object_declaration::{parse_file_declaration, parse_object_declaration};
 use super::subprogram::parse_subprogram;
 use super::tokens::{Kind::*, *};
 use super::type_declaration::parse_type_declaration;
 use crate::ast::{ContextClause, Declaration, PackageInstantiation};
 use crate::data::DiagnosticHandler;
+use crate::syntax::concurrent_statement::parse_map_aspect;
 
 pub fn parse_package_instantiation(stream: &TokenStream) -> ParseResult<PackageInstantiation> {
     stream.expect_kind(Package)?;
@@ -24,17 +25,9 @@ pub fn parse_package_instantiation(stream: &TokenStream) -> ParseResult<PackageI
     stream.expect_kind(Is)?;
     stream.expect_kind(New)?;
     let package_name = parse_selected_name(stream)?;
+    let generic_map = parse_map_aspect(stream, Generic)?;
+    stream.expect_kind(SemiColon)?;
 
-    let generic_map = expect_token!(
-        stream,
-        token,
-        Generic => {
-            stream.expect_kind(Map)?;
-            let association_list = parse_association_list(stream)?;
-            stream.expect_kind(SemiColon)?;
-            Some(association_list)
-        },
-        SemiColon => None);
     Ok(PackageInstantiation {
         context_clause: ContextClause::default(),
         ident: ident.into(),
@@ -204,10 +197,10 @@ package ident is new lib.foo.bar
                 ident: code.s1("ident").decl_ident(),
                 package_name: code.s1("lib.foo.bar").selected_name(),
                 generic_map: Some(
-                    code.s1("(
+                    code.s1("generic map (
     foo => bar
   )")
-                        .association_list()
+                        .generic_map_aspect()
                 )
             }
         );

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -1056,7 +1056,7 @@ mod tests {
                 pos: code.s1("2").pos(),
             };
 
-            let range = DiscreteRange::Range(Range::Range(RangeConstraint {
+            let range = DiscreteRange::Range(ast::Range::Range(RangeConstraint {
                 direction: *direction,
                 left_expr: Box::new(one_expr),
                 right_expr: Box::new(zero_expr),

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -200,7 +200,10 @@ fn parse_interface_package(stream: &TokenStream) -> ParseResult<InterfacePackage
                 stream.expect_kind(RightPar)?;
                 InterfacePackageGenericMapAspect::Default
             }
-            _ => InterfacePackageGenericMapAspect::Map(parse_association_list_no_leftpar(stream)?),
+            _ => {
+                let (list, _) = parse_association_list_no_leftpar(stream)?;
+                InterfacePackageGenericMapAspect::Map(list)
+            }
         }
     };
 

--- a/vhdl_lang/src/syntax/range.rs
+++ b/vhdl_lang/src/syntax/range.rs
@@ -127,7 +127,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_range),
             WithPos::new(
-                Range::Range(RangeConstraint {
+                ast::Range::Range(RangeConstraint {
                     direction: Direction::Ascending,
                     left_expr: Box::new(code.s1("foo.bar").expr()),
                     right_expr: Box::new(code.s1("1").expr())
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_range),
             WithPos::new(
-                Range::Attribute(Box::new(code.s1("foo.bar'range").attribute_name())),
+                ast::Range::Attribute(Box::new(code.s1("foo.bar'range").attribute_name())),
                 code.pos()
             )
         );
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_range),
             WithPos::new(
-                Range::Attribute(Box::new(code.s1("foo.bar'reverse_range").attribute_name())),
+                ast::Range::Attribute(Box::new(code.s1("foo.bar'reverse_range").attribute_name())),
                 code.pos()
             )
         );
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_range),
             WithPos::new(
-                Range::Range(RangeConstraint {
+                ast::Range::Range(RangeConstraint {
                     direction: Direction::Descending,
                     left_expr: Box::new(code.s1("foo.bar'length").expr()),
                     right_expr: Box::new(code.s1("0").expr())
@@ -182,7 +182,7 @@ mod tests {
         let code = Code::new("foo.bar to 1");
         assert_eq!(
             code.with_stream(parse_discrete_range),
-            DiscreteRange::Range(Range::Range(RangeConstraint {
+            DiscreteRange::Range(ast::Range::Range(RangeConstraint {
                 direction: Direction::Ascending,
                 left_expr: Box::new(code.s1("foo.bar").expr()),
                 right_expr: Box::new(code.s1("1").expr())
@@ -195,7 +195,7 @@ mod tests {
         let code = Code::new("foo.bar'range");
         assert_eq!(
             code.with_stream(parse_discrete_range),
-            DiscreteRange::Range(Range::Attribute(Box::new(
+            DiscreteRange::Range(ast::Range::Attribute(Box::new(
                 code.s1("foo.bar'range").attribute_name()
             )))
         );

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -29,6 +29,7 @@ use crate::ast;
 use crate::ast::*;
 use crate::data::Range;
 use crate::data::*;
+use crate::syntax::concurrent_statement::parse_map_aspect;
 use crate::syntax::context::{parse_context, DeclarationOrReference};
 use crate::syntax::{TokenAccess, TokenId};
 use std::collections::hash_map::DefaultHasher;
@@ -102,6 +103,15 @@ impl CodeBuilder {
 
     pub fn symbol(&self, name: &str) -> Symbol {
         self.symbols.symtab().insert_utf8(name)
+    }
+}
+
+impl<T> SeparatedList<T> {
+    pub fn single(item: T) -> SeparatedList<T> {
+        SeparatedList {
+            items: vec![item],
+            tokens: vec![],
+        }
     }
 }
 
@@ -503,8 +513,18 @@ impl Code {
         self.parse_ok_no_diagnostics(parse_labeled_concurrent_statement)
     }
 
-    pub fn association_list(&self) -> Vec<AssociationElement> {
-        self.parse_ok(parse_association_list)
+    pub fn association_list(&self) -> SeparatedList<AssociationElement> {
+        self.parse_ok(parse_association_list).0
+    }
+
+    pub fn port_map_aspect(&self) -> MapAspect {
+        self.parse_ok(|stream| parse_map_aspect(stream, Kind::Port))
+            .expect("Expecting port map aspect")
+    }
+
+    pub fn generic_map_aspect(&self) -> MapAspect {
+        self.parse_ok(|stream| parse_map_aspect(stream, Kind::Generic))
+            .expect("Expecting generic map aspect")
     }
 
     pub fn waveform(&self) -> Waveform {


### PR DESCRIPTION
Relates to #201 

Refactor the following:
- `Vec<AssociationElement>` to `SeparatedList<AssociationElement>`
- Some cases of `Vec<AssociationElement>` to `MapAspect`

Both changes are performed to record the position of the tokens in an easier way.