### PR TITLE
Improve diagnostics for map aspects

### DIFF
--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -1144,7 +1144,7 @@ pub struct SeparatedList<T> {
     pub tokens: Vec<TokenId>,
 }
 
-impl <T> Default for SeparatedList<T> {
+impl<T> Default for SeparatedList<T> {
     fn default() -> Self {
         SeparatedList {
             items: Vec::default(),

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -1144,6 +1144,15 @@ pub struct SeparatedList<T> {
     pub tokens: Vec<TokenId>,
 }
 
+impl <T> Default for SeparatedList<T> {
+    fn default() -> Self {
+        SeparatedList {
+            items: Vec::default(),
+            tokens: Vec::default(),
+        }
+    }
+}
+
 impl SeparatedList<AssociationElement> {
     /// Returns an iterator over the formal elements of this list
     pub fn formals(&self) -> impl Iterator<Item = &Designator> {

--- a/vhdl_lang/src/syntax/configuration.rs
+++ b/vhdl_lang/src/syntax/configuration.rs
@@ -40,7 +40,7 @@ fn parse_entity_aspect(stream: &TokenStream) -> ParseResult<EntityAspect> {
 fn parse_binding_indication_known_entity_aspect(
     entity_aspect: Option<EntityAspect>,
     stream: &TokenStream,
-    diagnostics: &mut dyn DiagnosticHandler
+    diagnostics: &mut dyn DiagnosticHandler,
 ) -> ParseResult<BindingIndication> {
     let (generic_map, port_map) = parse_generic_and_port_map(stream, diagnostics)?;
 
@@ -53,7 +53,10 @@ fn parse_binding_indication_known_entity_aspect(
 }
 
 /// LRM 7.3.2
-fn parse_binding_indication(stream: &TokenStream, diagnostics: &mut dyn DiagnosticHandler) -> ParseResult<BindingIndication> {
+fn parse_binding_indication(
+    stream: &TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler,
+) -> ParseResult<BindingIndication> {
     let entity_aspect = if stream.skip_if_kind(Use) {
         Some(parse_entity_aspect(stream)?)
     } else {
@@ -285,7 +288,10 @@ pub fn parse_configuration_declaration(
                     break parse_vunit_binding_indication_list_known_keyword(stream)?;
                 }
 
-                decl.push(ConfigurationDeclarativeItem::Use(parse_use_clause(stream)?));
+                decl.push(ConfigurationDeclarativeItem::Use(parse_use_clause(
+                    stream,
+                    diagnostics,
+                )?));
             }
             _ => break Vec::new(),
         }
@@ -313,7 +319,7 @@ pub fn parse_configuration_declaration(
 /// LRM 7.3 Configuration Specification
 pub fn parse_configuration_specification(
     stream: &TokenStream,
-    diagnsotics: &mut dyn DiagnosticHandler
+    diagnsotics: &mut dyn DiagnosticHandler,
 ) -> ParseResult<ConfigurationSpecification> {
     stream.expect_kind(For)?;
     match parse_component_specification_or_name(stream)? {

--- a/vhdl_lang/src/syntax/configuration.rs
+++ b/vhdl_lang/src/syntax/configuration.rs
@@ -40,8 +40,9 @@ fn parse_entity_aspect(stream: &TokenStream) -> ParseResult<EntityAspect> {
 fn parse_binding_indication_known_entity_aspect(
     entity_aspect: Option<EntityAspect>,
     stream: &TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler
 ) -> ParseResult<BindingIndication> {
-    let (generic_map, port_map) = parse_generic_and_port_map(stream)?;
+    let (generic_map, port_map) = parse_generic_and_port_map(stream, diagnostics)?;
 
     stream.expect_kind(SemiColon)?;
     Ok(BindingIndication {
@@ -52,13 +53,13 @@ fn parse_binding_indication_known_entity_aspect(
 }
 
 /// LRM 7.3.2
-fn parse_binding_indication(stream: &TokenStream) -> ParseResult<BindingIndication> {
+fn parse_binding_indication(stream: &TokenStream, diagnostics: &mut dyn DiagnosticHandler) -> ParseResult<BindingIndication> {
     let entity_aspect = if stream.skip_if_kind(Use) {
         Some(parse_entity_aspect(stream)?)
     } else {
         None
     };
-    parse_binding_indication_known_entity_aspect(entity_aspect, stream)
+    parse_binding_indication_known_entity_aspect(entity_aspect, stream, diagnostics)
 }
 
 fn parse_component_configuration_known_spec(
@@ -78,7 +79,7 @@ fn parse_component_configuration_known_spec(
                 (None, vunit_bind_inds)
             } else {
                 let aspect = parse_entity_aspect(stream)?;
-                let bind_ind = parse_binding_indication_known_entity_aspect(Some(aspect), stream)?;
+                let bind_ind = parse_binding_indication_known_entity_aspect(Some(aspect), stream, diagnostics)?;
 
                 if stream.skip_if_kind(Use) {
                     (Some(bind_ind), parse_vunit_binding_indication_list_known_keyword(stream)?)
@@ -312,11 +313,12 @@ pub fn parse_configuration_declaration(
 /// LRM 7.3 Configuration Specification
 pub fn parse_configuration_specification(
     stream: &TokenStream,
+    diagnsotics: &mut dyn DiagnosticHandler
 ) -> ParseResult<ConfigurationSpecification> {
     stream.expect_kind(For)?;
     match parse_component_specification_or_name(stream)? {
         ComponentSpecificationOrName::ComponentSpec(spec) => {
-            let bind_ind = parse_binding_indication(stream)?;
+            let bind_ind = parse_binding_indication(stream, diagnsotics)?;
             if stream.skip_if_kind(Use) {
                 let vunit_bind_inds = parse_vunit_binding_indication_list_known_keyword(stream)?;
                 stream.expect_kind(End)?;
@@ -814,7 +816,7 @@ end configuration cfg;
         let code = Code::new("for all : lib.pkg.comp use entity work.foo(rtl);");
 
         assert_eq!(
-            code.with_stream(parse_configuration_specification),
+            code.with_stream_no_diagnostics(parse_configuration_specification),
             ConfigurationSpecification {
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,
@@ -838,7 +840,7 @@ end configuration cfg;
         let code = Code::new("for all : lib.pkg.comp use entity work.foo(rtl); end for;");
 
         assert_eq!(
-            code.with_stream(parse_configuration_specification),
+            code.with_stream_no_diagnostics(parse_configuration_specification),
             ConfigurationSpecification {
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,
@@ -864,7 +866,7 @@ end configuration cfg;
         );
 
         assert_eq!(
-            code.with_stream(parse_configuration_specification),
+            code.with_stream_no_diagnostics(parse_configuration_specification),
             ConfigurationSpecification {
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,

--- a/vhdl_lang/src/syntax/context.rs
+++ b/vhdl_lang/src/syntax/context.rs
@@ -18,7 +18,7 @@ pub fn parse_library_clause(
     diagnsotics: &mut dyn DiagnosticHandler,
 ) -> ParseResult<LibraryClause> {
     let library_token = stream.expect_kind(Library)?;
-    let name_list = parse_ident_list(stream, diagnsotics, SemiColon)?;
+    let name_list = parse_ident_list(stream, diagnsotics)?;
     let semi_token = stream.expect_kind(SemiColon)?;
     Ok(LibraryClause {
         library_token,
@@ -34,7 +34,7 @@ pub fn parse_use_clause(
 ) -> ParseResult<UseClause> {
     let use_token = stream.expect_kind(Use)?;
 
-    let name_list = parse_name_list(stream, diagnsotics, SemiColon)?;
+    let name_list = parse_name_list(stream, diagnsotics)?;
     let semi_token = stream.expect_kind(SemiColon)?;
     Ok(UseClause {
         use_token,
@@ -55,7 +55,7 @@ pub fn parse_context_reference(
 ) -> ParseResult<ContextReference> {
     let context_token = stream.expect_kind(Context)?;
 
-    let name_list = parse_name_list(stream, diagnostics, SemiColon)?;
+    let name_list = parse_name_list(stream, diagnostics)?;
     let semi_token = stream.expect_kind(SemiColon)?;
     Ok(ContextReference {
         context_token,
@@ -129,7 +129,7 @@ mod tests {
             code.with_stream_no_diagnostics(parse_library_clause),
             LibraryClause {
                 library_token: code.s1("library").token(),
-                name_list: code.s1("foo").ident_list(SemiColon),
+                name_list: code.s1("foo").ident_list(),
                 semi_token: code.s1(";").token(),
             }
         )
@@ -142,7 +142,7 @@ mod tests {
             code.with_stream_no_diagnostics(parse_library_clause),
             LibraryClause {
                 library_token: code.s1("library").token(),
-                name_list: code.s1("foo, bar").ident_list(SemiColon),
+                name_list: code.s1("foo, bar").ident_list(),
                 semi_token: code.s1(";").token(),
             },
         )
@@ -155,7 +155,7 @@ mod tests {
             code.with_stream_no_diagnostics(parse_use_clause),
             UseClause {
                 use_token: code.s1("use").token(),
-                name_list: code.s1("lib.foo").name_list(SemiColon),
+                name_list: code.s1("lib.foo").name_list(),
                 semi_token: code.s1(";").token(),
             },
         )
@@ -168,7 +168,7 @@ mod tests {
             code.with_stream_no_diagnostics(parse_use_clause),
             UseClause {
                 use_token: code.s1("use").token(),
-                name_list: code.s1("foo.'a', lib.bar.all").name_list(SemiColon),
+                name_list: code.s1("foo.'a', lib.bar.all").name_list(),
                 semi_token: code.s1(";").token(),
             },
         )
@@ -181,7 +181,7 @@ mod tests {
             code.with_stream_no_diagnostics(parse_context),
             DeclarationOrReference::Reference(ContextReference {
                 context_token: code.s1("context").token(),
-                name_list: code.s1("lib.foo").name_list(SemiColon),
+                name_list: code.s1("lib.foo").name_list(),
                 semi_token: code.s1(";").token(),
             },)
         )
@@ -269,17 +269,17 @@ end context;
                 items: vec![
                     ContextItem::Library(LibraryClause {
                         library_token: code.s1("library").token(),
-                        name_list: code.s1("foo").ident_list(SemiColon),
+                        name_list: code.s1("foo").ident_list(),
                         semi_token: code.s(";", 1).token(),
                     }),
                     ContextItem::Use(UseClause {
                         use_token: code.s1("use").token(),
-                        name_list: code.s1("foo.bar").name_list(SemiColon),
+                        name_list: code.s1("foo.bar").name_list(),
                         semi_token: code.s(";", 2).token(),
                     }),
                     ContextItem::Context(ContextReference {
                         context_token: code.s("context", 2).token(),
-                        name_list: code.s1("foo.ctx").name_list(SemiColon),
+                        name_list: code.s1("foo.ctx").name_list(),
                         semi_token: code.s(";", 3).token(),
                     }),
                 ],

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -19,7 +19,10 @@ use crate::ast::{ContextClause, Declaration, PackageInstantiation};
 use crate::data::DiagnosticHandler;
 use crate::syntax::concurrent_statement::parse_map_aspect;
 
-pub fn parse_package_instantiation(stream: &TokenStream, diagnsotics: &mut dyn DiagnosticHandler) -> ParseResult<PackageInstantiation> {
+pub fn parse_package_instantiation(
+    stream: &TokenStream,
+    diagnsotics: &mut dyn DiagnosticHandler,
+) -> ParseResult<PackageInstantiation> {
     stream.expect_kind(Package)?;
     let ident = stream.expect_ident()?;
     stream.expect_kind(Is)?;
@@ -98,10 +101,10 @@ pub fn parse_declarative_part(
                     Component => parse_component_declaration(stream, diagnostics)
                         .map(Declaration::Component)?,
                     Impure | Pure | Function | Procedure => parse_subprogram(stream, diagnostics)?,
-                    Package => parse_package_instantiation(stream, diagnostics).map(Declaration::Package)?,
-                    For => {
-                        parse_configuration_specification(stream, diagnostics).map(Declaration::Configuration)?
-                    }
+                    Package => parse_package_instantiation(stream, diagnostics)
+                        .map(Declaration::Package)?,
+                    For => parse_configuration_specification(stream, diagnostics)
+                        .map(Declaration::Configuration)?,
                     _ => unreachable!(),
                 };
                 declarations.push(decl);
@@ -128,7 +131,7 @@ pub fn parse_declarative_part(
 
             Use | Alias => {
                 let decl: ParseResult<Declaration> = match token.kind {
-                    Use => parse_use_clause(stream).map(Declaration::Use),
+                    Use => parse_use_clause(stream, diagnostics).map(Declaration::Use),
                     Alias => parse_alias_declaration(stream).map(Declaration::Alias),
                     _ => unreachable!(),
                 };

--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -169,7 +169,7 @@ pub fn parse_design_file(
         try_init_token_kind!(
             token,
             Library => {
-                match parse_library_clause(stream) {
+                match parse_library_clause(stream, diagnostics) {
                     Ok(library) => {
                         context_clause.push(ContextItem::Library(library));
                     },
@@ -177,7 +177,7 @@ pub fn parse_design_file(
                 }
             },
             Use => {
-                match parse_use_clause(stream) {
+                match parse_use_clause(stream, diagnostics) {
                     Ok(use_clause) => {
                         context_clause.push(ContextItem::Use(use_clause));
                     },

--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -243,7 +243,7 @@ pub fn parse_design_file(
                         Err(diagnostic) => diagnostics.push(diagnostic),
                     };
                 } else if stream.next_kinds_are(&[Package, Identifier, Is, New]) {
-                    match parse_package_instantiation(stream) {
+                    match parse_package_instantiation(stream, diagnostics) {
                         Ok(mut inst) => {
                             let tokens = stream.slice_tokens();
                             inst.context_clause = take_context_clause(&mut context_clause);

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -177,7 +177,10 @@ fn parse_subprogram_default(stream: &TokenStream) -> ParseResult<Option<Subprogr
     }
 }
 
-fn parse_interface_package(stream: &TokenStream, diagnsotics: &mut dyn DiagnosticHandler) -> ParseResult<InterfacePackageDeclaration> {
+fn parse_interface_package(
+    stream: &TokenStream,
+    diagnsotics: &mut dyn DiagnosticHandler,
+) -> ParseResult<InterfacePackageDeclaration> {
     stream.expect_kind(Package)?;
     let ident = stream.expect_ident()?;
     stream.expect_kind(Is)?;

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -187,7 +187,7 @@ fn parse_interface_package(stream: &TokenStream, diagnsotics: &mut dyn Diagnosti
     stream.expect_kind(Map)?;
 
     let generic_map = {
-        stream.expect_kind(LeftPar)?;
+        let left_par = stream.expect_kind(LeftPar)?;
         let map_token = stream.peek_expect()?;
         match map_token.kind {
             BOX => {
@@ -201,7 +201,7 @@ fn parse_interface_package(stream: &TokenStream, diagnsotics: &mut dyn Diagnosti
                 InterfacePackageGenericMapAspect::Default
             }
             _ => {
-                let (list, _) = parse_association_list_no_leftpar(stream, diagnsotics)?;
+                let (list, _) = parse_association_list_no_leftpar(stream, left_par, diagnsotics)?;
                 InterfacePackageGenericMapAspect::Map(list)
             }
         }

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -177,7 +177,7 @@ fn parse_subprogram_default(stream: &TokenStream) -> ParseResult<Option<Subprogr
     }
 }
 
-fn parse_interface_package(stream: &TokenStream) -> ParseResult<InterfacePackageDeclaration> {
+fn parse_interface_package(stream: &TokenStream, diagnsotics: &mut dyn DiagnosticHandler) -> ParseResult<InterfacePackageDeclaration> {
     stream.expect_kind(Package)?;
     let ident = stream.expect_ident()?;
     stream.expect_kind(Is)?;
@@ -201,7 +201,7 @@ fn parse_interface_package(stream: &TokenStream) -> ParseResult<InterfacePackage
                 InterfacePackageGenericMapAspect::Default
             }
             _ => {
-                let (list, _) = parse_association_list_no_leftpar(stream)?;
+                let (list, _) = parse_association_list_no_leftpar(stream, diagnsotics)?;
                 InterfacePackageGenericMapAspect::Map(list)
             }
         }
@@ -237,7 +237,7 @@ fn parse_interface_declaration(
             Ok(vec![InterfaceDeclaration::Subprogram(decl, default)])
         },
         Package => {
-            Ok(vec![InterfaceDeclaration::Package (parse_interface_package(stream)?)])
+            Ok(vec![InterfaceDeclaration::Package (parse_interface_package(stream, diagnostics)?)])
         }
     )
 }

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -13,7 +13,7 @@ use super::tokens::{Kind::*, TokenAccess, TokenStream};
 use crate::ast;
 use crate::ast::*;
 use crate::data::{Diagnostic, DiagnosticHandler, WithPos};
-use crate::syntax::separated_list::parse_list_with_separator;
+use crate::syntax::separated_list::parse_list_with_separator_or_recover;
 use crate::syntax::TokenId;
 
 pub fn parse_designator(stream: &TokenStream) -> ParseResult<WithPos<Designator>> {
@@ -200,7 +200,13 @@ pub fn parse_association_list_no_leftpar(
         );
         return Ok((SeparatedList::default(), right_par));
     }
-    let list = parse_list_with_separator(stream, Comma, diagnostics, parse_association_element)?;
+    let list = parse_list_with_separator_or_recover(
+        stream,
+        Comma,
+        diagnostics,
+        parse_association_element,
+        Some(RightPar),
+    )?;
     let right_par = stream.expect_kind(RightPar)?;
     Ok((list, right_par))
 }

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -184,12 +184,13 @@ pub fn parse_association_list(
     stream: &TokenStream,
     diagnsotics: &mut dyn DiagnosticHandler
 ) -> ParseResult<(SeparatedList<AssociationElement>, TokenId)> {
-    stream.expect_kind(LeftPar)?;
-    parse_association_list_no_leftpar(stream, diagnsotics)
+    let left_par = stream.expect_kind(LeftPar)?;
+    parse_association_list_no_leftpar(stream, left_par,diagnsotics)
 }
 
 pub fn parse_association_list_no_leftpar(
     stream: &TokenStream,
+    left_par : TokenId,
     diagnostics: &mut dyn DiagnosticHandler
 ) -> ParseResult<(SeparatedList<AssociationElement>, TokenId)> {
     if let Some(right_par) = stream.pop_if_kind(RightPar) {

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -204,7 +204,6 @@ pub fn parse_association_list_no_leftpar(
         stream,
         Comma,
         diagnostics,
-        RightPar,
         parse_association_element,
     )?;
     let right_par = stream.expect_kind(RightPar)?;
@@ -1198,8 +1197,8 @@ mod tests {
         assert_eq!(
             diag,
             vec![Diagnostic::error(
-                code.s1(",").pos(),
-                "Trailing comma not allowed"
+                code.s1(")").pos(),
+                "Expected {expression}"
             )]
         );
         assert_eq!(list.0.items, vec![code.s1("a => b").association_element()]);

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -12,7 +12,7 @@ use super::subtype_indication::parse_subtype_indication;
 use super::tokens::{Kind::*, TokenAccess, TokenStream};
 use crate::ast;
 use crate::ast::*;
-use crate::data::{Diagnostic, WithPos};
+use crate::data::{Diagnostic, DiagnosticHandler, WithPos};
 use crate::syntax::separated_list::parse_list_with_separator;
 use crate::syntax::TokenId;
 
@@ -182,13 +182,15 @@ fn parse_association_element(stream: &TokenStream) -> ParseResult<AssociationEle
 
 pub fn parse_association_list(
     stream: &TokenStream,
+    diagnsotics: &mut dyn DiagnosticHandler
 ) -> ParseResult<(SeparatedList<AssociationElement>, TokenId)> {
     stream.expect_kind(LeftPar)?;
-    parse_association_list_no_leftpar(stream)
+    parse_association_list_no_leftpar(stream, diagnsotics)
 }
 
 pub fn parse_association_list_no_leftpar(
     stream: &TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler
 ) -> ParseResult<(SeparatedList<AssociationElement>, TokenId)> {
     if let Some(right_par) = stream.pop_if_kind(RightPar) {
         return Err(Diagnostic::error(
@@ -1022,7 +1024,7 @@ mod tests {
             actual: WithPos::new(ActualPart::Open, code.s("open", 2)),
         };
         assert_eq!(
-            code.with_stream(parse_association_list),
+            code.with_stream_no_diagnostics(parse_association_list),
             (
                 SeparatedList {
                     items: vec![elem1, elem2],

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -200,12 +200,7 @@ pub fn parse_association_list_no_leftpar(
         );
         return Ok((SeparatedList::default(), right_par));
     }
-    let list = parse_list_with_separator(
-        stream,
-        Comma,
-        diagnostics,
-        parse_association_element,
-    )?;
+    let list = parse_list_with_separator(stream, Comma, diagnostics, parse_association_element)?;
     let right_par = stream.expect_kind(RightPar)?;
     Ok((list, right_par))
 }

--- a/vhdl_lang/src/syntax/separated_list.rs
+++ b/vhdl_lang/src/syntax/separated_list.rs
@@ -10,7 +10,6 @@ use crate::syntax::common::ParseResult;
 use crate::syntax::names::parse_name;
 use crate::syntax::Kind::Comma;
 use crate::syntax::{kind_str, Kind, Recover, TokenAccess, TokenStream};
-use std::fmt::Debug;
 
 /// Skip extraneous tokens of kind `separator`.
 /// When there are any extra tokens of that kind, mark all the positions of these tokens as erroneous

--- a/vhdl_lang/src/syntax/separated_list.rs
+++ b/vhdl_lang/src/syntax/separated_list.rs
@@ -8,9 +8,29 @@ use crate::ast::{IdentList, NameList, SeparatedList, WithRef};
 use crate::data::{DiagnosticHandler, DiagnosticResult};
 use crate::syntax::common::ParseResult;
 use crate::syntax::names::parse_name;
-use crate::syntax::Kind::{Comma};
-use crate::syntax::{Kind, TokenStream};
+use crate::syntax::Kind::Comma;
+use crate::syntax::{kind_str, Kind, TokenAccess, TokenStream};
 use std::fmt::Debug;
+
+/// Skip extraneous tokens of kind `separator`.
+/// When there are any extra tokens of that kind, mark all the positions of these tokens as erroneous
+fn skip_extraneous_tokens(
+    stream: &TokenStream,
+    separator: Kind,
+    diagnostics: &mut dyn DiagnosticHandler,
+) {
+    if let Some(separator_tok) = stream.pop_if_kind(separator) {
+        let start_pos = stream.get_pos(separator_tok);
+        let mut end_pos = start_pos;
+        while let Some(separator_tok) = stream.pop_if_kind(separator) {
+            end_pos = stream.get_pos(separator_tok)
+        }
+        diagnostics.error(
+            start_pos.combine(end_pos),
+            format!("Extraneous '{}'", kind_str(separator)),
+        );
+    }
+}
 
 /// Parses a list of the form
 ///   `element { separator element }`
@@ -27,11 +47,12 @@ where
 {
     let mut items = vec![parse_fn(stream)?];
     let mut tokens = Vec::new();
-    while let Some(separator) = stream.pop_if_kind(separator) {
-        tokens.push(separator);
+    while let Some(separator_tok) = stream.pop_if_kind(separator) {
+        skip_extraneous_tokens(stream, separator, diagnostics);
+        tokens.push(separator_tok);
         match parse_fn(stream) {
             Ok(item) => items.push(item),
-            Err(err) => diagnostics.push(err)
+            Err(err) => diagnostics.push(err),
         }
     }
     Ok(SeparatedList { items, tokens })
@@ -41,24 +62,16 @@ pub fn parse_name_list(
     stream: &TokenStream,
     diagnostics: &mut dyn DiagnosticHandler,
 ) -> DiagnosticResult<NameList> {
-    parse_list_with_separator(
-        stream,
-        Comma,
-        diagnostics,
-        parse_name,
-    )
+    parse_list_with_separator(stream, Comma, diagnostics, parse_name)
 }
 
 pub fn parse_ident_list(
     stream: &TokenStream,
     diagnostics: &mut dyn DiagnosticHandler,
 ) -> DiagnosticResult<IdentList> {
-    parse_list_with_separator(
-        stream,
-        Comma,
-        diagnostics,
-        |stream| stream.expect_ident().map(WithRef::new),
-    )
+    parse_list_with_separator(stream, Comma, diagnostics, |stream| {
+        stream.expect_ident().map(WithRef::new)
+    })
 }
 
 #[cfg(test)]
@@ -66,6 +79,7 @@ mod test {
     use crate::ast::{IdentList, NameList};
     use crate::syntax::separated_list::{parse_ident_list, parse_name_list};
     use crate::syntax::test::Code;
+    use crate::Diagnostic;
     use assert_matches::assert_matches;
 
     #[test]
@@ -109,6 +123,48 @@ mod test {
                 items: vec![code.s1("work.foo").name(), code.s1("lib.bar.all").name()],
                 tokens: vec![code.s1(",").token()],
             }
+        )
+    }
+
+    #[test]
+    fn parse_extraneous_single_separators() {
+        let code = Code::new("a,,b,c");
+        let (res, diag) = code.with_stream_diagnostics(parse_ident_list);
+        assert_eq!(
+            res,
+            IdentList {
+                items: vec![
+                    code.s1("a").ident().into_ref(),
+                    code.s1("b").ident().into_ref(),
+                    code.s1("c").ident().into_ref()
+                ],
+                tokens: vec![code.s(",", 1).token(), code.s(",", 3).token()]
+            }
+        );
+        assert_eq!(
+            diag,
+            vec![Diagnostic::error(code.s(",", 2).pos(), "Extraneous ','")]
+        )
+    }
+
+    #[test]
+    fn parse_extraneous_multiple_separators() {
+        let code = Code::new("a,,,,b,c");
+        let (res, diag) = code.with_stream_diagnostics(parse_ident_list);
+        assert_eq!(
+            res,
+            IdentList {
+                items: vec![
+                    code.s1("a").ident().into_ref(),
+                    code.s1("b").ident().into_ref(),
+                    code.s1("c").ident().into_ref()
+                ],
+                tokens: vec![code.s(",", 1).token(), code.s(",", 5).token()]
+            }
+        );
+        assert_eq!(
+            diag,
+            vec![Diagnostic::error(code.s(",,,", 2).pos(), "Extraneous ','")]
         )
     }
 }

--- a/vhdl_lang/src/syntax/separated_list.rs
+++ b/vhdl_lang/src/syntax/separated_list.rs
@@ -5,19 +5,22 @@
 // Copyright (c) 2023, Olof Kraigher olof.kraigher@gmail.com
 
 use crate::ast::{IdentList, NameList, SeparatedList, WithRef};
-use crate::data::DiagnosticResult;
+use crate::data::{DiagnosticHandler, DiagnosticResult};
 use crate::syntax::common::ParseResult;
 use crate::syntax::names::parse_name;
-use crate::syntax::Kind::Comma;
-use crate::syntax::{Kind, TokenStream};
+use crate::syntax::Kind::{Comma};
+use crate::syntax::{Kind, TokenAccess, TokenStream};
+use std::fmt::Debug;
 
 /// Parses a list of the form
 ///   `element { separator element }`
 /// where `element` is an AST element and `separator` is a token of some `ast::Kind`.
 /// The returned list retains information of the whereabouts of the separator tokens.
-pub fn parse_list_with_separator<F, T>(
+pub fn parse_list_with_separator<F, T: Debug>(
     stream: &TokenStream,
     separator: Kind,
+    diagnostics: &mut dyn DiagnosticHandler,
+    final_token: Kind,
     parse_fn: F,
 ) -> DiagnosticResult<SeparatedList<T>>
 where
@@ -26,20 +29,42 @@ where
     let mut items = vec![parse_fn(stream)?];
     let mut tokens = Vec::new();
     while let Some(separator) = stream.pop_if_kind(separator) {
-        items.push(parse_fn(stream)?);
         tokens.push(separator);
+        if stream.next_kind_is(final_token) {
+            diagnostics.error(stream.get_pos(separator), "Trailing comma not allowed");
+            break
+        }
+        items.push(parse_fn(stream)?);
     }
     Ok(SeparatedList { items, tokens })
 }
 
-pub fn parse_name_list(stream: &TokenStream) -> DiagnosticResult<NameList> {
-    parse_list_with_separator(stream, Comma, parse_name)
+pub fn parse_name_list(
+    stream: &TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler,
+    final_token: Kind
+) -> DiagnosticResult<NameList> {
+    parse_list_with_separator(
+        stream,
+        Comma,
+        diagnostics,
+        final_token,
+        parse_name,
+    )
 }
 
-pub fn parse_ident_list(stream: &TokenStream) -> DiagnosticResult<IdentList> {
-    parse_list_with_separator(stream, Comma, |stream| {
-        stream.expect_ident().map(WithRef::new)
-    })
+pub fn parse_ident_list(
+    stream: &TokenStream,
+    diagnostics: &mut dyn DiagnosticHandler,
+    final_token: Kind
+) -> DiagnosticResult<IdentList> {
+    parse_list_with_separator(
+        stream,
+        Comma,
+        diagnostics,
+        final_token,
+        |stream| stream.expect_ident().map(WithRef::new),
+    )
 }
 
 #[cfg(test)]
@@ -48,18 +73,20 @@ mod test {
     use crate::syntax::separated_list::{parse_ident_list, parse_name_list};
     use crate::syntax::test::Code;
     use assert_matches::assert_matches;
+    use crate::syntax::Kind::SemiColon;
 
     #[test]
     pub fn test_error_on_empty_list() {
         let code = Code::new("");
-        assert_matches!(code.parse(parse_ident_list), Err(_))
+        let (res, diag) = code.with_partial_stream_diagnostics(|stream, diag| parse_ident_list(stream, diag, SemiColon));
+        assert_matches!(res, Err(_))
     }
 
     #[test]
     pub fn parse_single_element_list() {
         let code = Code::new("abc");
         assert_eq!(
-            code.parse_ok(parse_ident_list),
+            code.parse_ok_no_diagnostics(|stream, diag| parse_ident_list(stream, diag, SemiColon)),
             IdentList::single(code.s1("abc").ident().into_ref())
         )
     }
@@ -68,7 +95,7 @@ mod test {
     pub fn parse_list_with_multiple_elements() {
         let code = Code::new("abc, def, ghi");
         assert_eq!(
-            code.parse_ok(parse_ident_list),
+            code.parse_ok_no_diagnostics(|stream, diag| parse_ident_list(stream, diag, SemiColon)),
             IdentList {
                 items: vec![
                     code.s1("abc").ident().into_ref(),
@@ -84,7 +111,7 @@ mod test {
     fn parse_list_with_many_names() {
         let code = Code::new("work.foo, lib.bar.all");
         assert_eq!(
-            code.parse_ok(parse_name_list),
+            code.parse_ok_no_diagnostics(|stream, diag| parse_name_list(stream, diag, SemiColon)),
             NameList {
                 items: vec![code.s1("work.foo").name(), code.s1("lib.bar.all").name()],
                 tokens: vec![code.s1(",").token()],

--- a/vhdl_lang/src/syntax/separated_list.rs
+++ b/vhdl_lang/src/syntax/separated_list.rs
@@ -48,8 +48,8 @@ where
 }
 
 /// Same as `parse_list_with_separator`.
-/// However, when supplied with a `recover_token` will skip an element until either the separator
-/// or the recover token is met.
+/// However, when supplied with a `recover_token` will skip until either the separator
+/// or the recover token is found.
 pub fn parse_list_with_separator_or_recover<F, T>(
     stream: &TokenStream,
     separator: Kind,

--- a/vhdl_lang/src/syntax/separated_list.rs
+++ b/vhdl_lang/src/syntax/separated_list.rs
@@ -10,7 +10,6 @@ use crate::syntax::common::ParseResult;
 use crate::syntax::names::parse_name;
 use crate::syntax::Kind::Comma;
 use crate::syntax::{kind_str, Kind, TokenAccess, TokenStream};
-use std::fmt::Debug;
 
 /// Skip extraneous tokens of kind `separator`.
 /// When there are any extra tokens of that kind, mark all the positions of these tokens as erroneous
@@ -36,7 +35,7 @@ fn skip_extraneous_tokens(
 ///   `element { separator element }`
 /// where `element` is an AST element and `separator` is a token of some `ast::Kind`.
 /// The returned list retains information of the whereabouts of the separator tokens.
-pub fn parse_list_with_separator<F, T: Debug>(
+pub fn parse_list_with_separator<F, T>(
     stream: &TokenStream,
     separator: Kind,
     diagnostics: &mut dyn DiagnosticHandler,

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -514,16 +514,16 @@ impl Code {
     }
 
     pub fn association_list(&self) -> SeparatedList<AssociationElement> {
-        self.parse_ok(parse_association_list).0
+        self.parse_ok_no_diagnostics(parse_association_list).0
     }
 
     pub fn port_map_aspect(&self) -> MapAspect {
-        self.parse_ok(|stream| parse_map_aspect(stream, Kind::Port))
+        self.parse_ok_no_diagnostics(|stream, diagnsotics| parse_map_aspect(stream, Kind::Port, diagnsotics))
             .expect("Expecting port map aspect")
     }
 
     pub fn generic_map_aspect(&self) -> MapAspect {
-        self.parse_ok(|stream| parse_map_aspect(stream, Kind::Generic))
+        self.parse_ok_no_diagnostics(|stream, diagnostics| parse_map_aspect(stream, Kind::Generic, diagnostics))
             .expect("Expecting generic map aspect")
     }
 

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -414,12 +414,12 @@ impl Code {
         self.parse_ok(parse_name)
     }
 
-    pub fn name_list(&self, final_token: Kind) -> SeparatedList<WithPos<Name>> {
-        self.parse_ok_no_diagnostics(|stream, diag| parse_name_list(stream, diag, final_token))
+    pub fn name_list(&self) -> SeparatedList<WithPos<Name>> {
+        self.parse_ok_no_diagnostics(parse_name_list)
     }
 
-    pub fn ident_list(&self, final_token: Kind) -> SeparatedList<WithRef<Ident>> {
-        self.parse_ok_no_diagnostics(|stream, diag| parse_ident_list(stream, diag, final_token))
+    pub fn ident_list(&self) -> SeparatedList<WithRef<Ident>> {
+        self.parse_ok_no_diagnostics(parse_ident_list)
     }
 
     pub fn selected_name(&self) -> WithPos<SelectedName> {

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -31,6 +31,7 @@ use crate::data::Range;
 use crate::data::*;
 use crate::syntax::concurrent_statement::parse_map_aspect;
 use crate::syntax::context::{parse_context, DeclarationOrReference};
+use crate::syntax::names::parse_association_element;
 use crate::syntax::{TokenAccess, TokenId};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::hash_map::Entry;
@@ -413,12 +414,12 @@ impl Code {
         self.parse_ok(parse_name)
     }
 
-    pub fn name_list(&self) -> SeparatedList<WithPos<Name>> {
-        self.parse_ok(parse_name_list)
+    pub fn name_list(&self, final_token: Kind) -> SeparatedList<WithPos<Name>> {
+        self.parse_ok_no_diagnostics(|stream, diag| parse_name_list(stream, diag, final_token))
     }
 
-    pub fn ident_list(&self) -> SeparatedList<WithRef<Ident>> {
-        self.parse_ok(parse_ident_list)
+    pub fn ident_list(&self, final_token: Kind) -> SeparatedList<WithRef<Ident>> {
+        self.parse_ok_no_diagnostics(|stream, diag| parse_ident_list(stream, diag, final_token))
     }
 
     pub fn selected_name(&self) -> WithPos<SelectedName> {
@@ -518,13 +519,17 @@ impl Code {
     }
 
     pub fn port_map_aspect(&self) -> MapAspect {
-        self.parse_ok_no_diagnostics(|stream, diagnsotics| parse_map_aspect(stream, Kind::Port, diagnsotics))
-            .expect("Expecting port map aspect")
+        self.parse_ok_no_diagnostics(|stream, diagnsotics| {
+            parse_map_aspect(stream, Kind::Port, diagnsotics)
+        })
+        .expect("Expecting port map aspect")
     }
 
     pub fn generic_map_aspect(&self) -> MapAspect {
-        self.parse_ok_no_diagnostics(|stream, diagnostics| parse_map_aspect(stream, Kind::Generic, diagnostics))
-            .expect("Expecting generic map aspect")
+        self.parse_ok_no_diagnostics(|stream, diagnostics| {
+            parse_map_aspect(stream, Kind::Generic, diagnostics)
+        })
+        .expect("Expecting generic map aspect")
     }
 
     pub fn waveform(&self) -> Waveform {
@@ -548,11 +553,11 @@ impl Code {
     }
 
     pub fn use_clause(&self) -> UseClause {
-        self.parse_ok(parse_use_clause)
+        self.parse_ok_no_diagnostics(parse_use_clause)
     }
 
     pub fn library_clause(&self) -> LibraryClause {
-        self.parse_ok(parse_library_clause)
+        self.parse_ok_no_diagnostics(parse_library_clause)
     }
 
     pub fn context_declaration(&self) -> ContextDeclaration {
@@ -575,6 +580,10 @@ impl Code {
             Name::Attribute(attr) => *attr,
             name => panic!("Expected attribute got {name:?}"),
         }
+    }
+
+    pub fn association_element(&self) -> AssociationElement {
+        self.parse_ok(parse_association_element)
     }
 }
 

--- a/vhdl_lang/src/syntax/tokens/tokenstream.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenstream.rs
@@ -216,7 +216,10 @@ impl<'a> TokenStream<'a> {
         self.pop_if_kind(kind).is_some()
     }
 
-    pub fn skip_until(&self, cond: fn(Kind) -> bool) -> DiagnosticResult<()> {
+    pub fn skip_until<F>(&self, cond: F) -> DiagnosticResult<()>
+    where
+        F: Fn(Kind) -> bool,
+    {
         loop {
             let token = self.peek_expect()?;
             if cond(token.kind) {
@@ -287,23 +290,28 @@ impl<'a> TokenAccess for TokenStream<'a> {
 }
 
 pub trait Recover<T> {
-    fn or_recover_until(
+    fn or_recover_until<F>(
         self,
         stream: &TokenStream,
         msgs: &mut dyn DiagnosticHandler,
-        cond: fn(Kind) -> bool,
-    ) -> DiagnosticResult<T>;
+        cond: F,
+    ) -> DiagnosticResult<T>
+    where
+        F: Fn(Kind) -> bool;
 
     fn log(self, msgs: &mut dyn DiagnosticHandler);
 }
 
 impl<T: std::fmt::Debug> Recover<T> for DiagnosticResult<T> {
-    fn or_recover_until(
+    fn or_recover_until<F>(
         self,
         stream: &TokenStream,
         msgs: &mut dyn DiagnosticHandler,
-        cond: fn(Kind) -> bool,
-    ) -> DiagnosticResult<T> {
+        cond: F,
+    ) -> DiagnosticResult<T>
+    where
+        F: Fn(Kind) -> bool,
+    {
         if self.is_ok() {
             return self;
         }


### PR DESCRIPTION
Improve the following diagnostics for map aspects:

- Empty association list (generic map or port map): Now "Association list cannot be empty"
- Trailing comma: Same error message but parsing goes on
- Extraneous commas (i.e. `port map (a => a,, b => b)`): Now "extraneous comma"

This also enables better completions as the parser can parse more semantically incorrect code.