### PR TITLE
Refactor: Move completion to its own module

### DIFF
--- a/vhdl_lang/src/analysis.rs
+++ b/vhdl_lang/src/analysis.rs
@@ -26,11 +26,8 @@ mod standard;
 mod static_expression;
 mod target;
 
-mod completion;
-
 #[cfg(test)]
 pub(crate) mod tests;
 pub(crate) use root::{Library, LockedUnit};
 
 pub use self::root::{DesignRoot, EntHierarchy};
-pub use completion::CompletionItem;

--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -1142,6 +1142,11 @@ impl DesignRoot {
     pub fn get_ent(&self, id: EntityId) -> &AnyEnt {
         self.arenas.get(id)
     }
+
+    /// Returns a reference to the symbols that were used to analyze and parse the design root.
+    pub fn symbols(&self) -> &Symbols {
+        self.symbols.as_ref()
+    }
 }
 
 fn get_all_affected(

--- a/vhdl_lang/src/lib.rs
+++ b/vhdl_lang/src/lib.rs
@@ -23,13 +23,14 @@ mod named_entity;
 mod project;
 mod syntax;
 
+mod completion;
+
 pub use crate::config::Config;
 pub use crate::data::{
     Diagnostic, Latin1String, Message, MessageHandler, MessagePrinter, MessageType,
     NullDiagnostics, NullMessages, Position, Range, Severity, Source, SrcPos,
 };
 
-pub use crate::analysis::CompletionItem;
 pub use crate::analysis::EntHierarchy;
 pub use crate::named_entity::{
     AnyEnt, AnyEntKind, Concurrent, Design, EntRef, EntityId, HasEntityId, Object, Overloaded,
@@ -40,3 +41,5 @@ pub use crate::project::{Project, SourceFile};
 pub use crate::syntax::{
     kind_str, HasTokenSpan, ParserResult, Token, TokenAccess, TokenId, TokenSpan, VHDLParser,
 };
+
+pub use completion::{list_completion_options, CompletionItem};

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
-use crate::analysis::{CompletionItem, DesignRoot};
+use crate::analysis::DesignRoot;
 use crate::ast::DesignFile;
+use crate::completion::{list_completion_options, CompletionItem};
 use crate::config::Config;
 use crate::lint::dead_code::UnusedDeclarationsLinter;
 use crate::named_entity::{AnyEnt, EntRef};
@@ -318,7 +319,7 @@ impl Project {
         source: &Source,
         cursor: Position,
     ) -> Vec<CompletionItem> {
-        self.root.list_completion_options(source, cursor)
+        list_completion_options(&self.root, source, cursor)
     }
 }
 


### PR DESCRIPTION
As discussed in the chat, `completion` was moved out of the `analysis` mod and is now its own module.