### PR TITLE
Extend TOML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ lib1.files = [
   'tb_ent.vhd'
 ]
 
+# Wildcards are supported
+lib3.files = [
+  'test/*.vhd',
+  'src/*.vhd',
+  'src/*/*.vhd',
+]
+
 # Libraries can be marked as third-party to disable some analysis warnings
 UNISIM.files = [
   'C:\Xilinx\Vivado\2023.1\data\vhdl\src\unisims\unisim_VCOMP.vhd',

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ lib1.files = [
   'pkg1.vhd',
   'tb_ent.vhd'
 ]
+
+# Libraries can be marked as third-party to disable some analysis warnings
+UNISIM.files = [
+  'C:\Xilinx\Vivado\2023.1\data\vhdl\src\unisims\unisim_VCOMP.vhd',
+]
+UNISIM.is_third_party = true
 ```
 
 ## As an LSP-client developer how should I integrate VHDL-LS?

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ lib3.files = [
   'src/*/*.vhd',
 ]
 
-# Libraries can be marked as third-party to disable some analysis warnings
+# Libraries can be marked as third-party to disable some analysis warnings, such as unused declarations
 UNISIM.files = [
   'C:\Xilinx\Vivado\2023.1\data\vhdl\src\unisims\unisim_VCOMP.vhd',
 ]


### PR DESCRIPTION
Add examples for wildcards/glob patterns and `is_third_party` setting in TOML file.

I think it's good to aid discoverability for these features, especially as common libraries like UVVM have many unused signals.

I can make the examples more generic if you prefer, but this one may also help some people understand how to support Xilinx libraries.