### PR TITLE
extend goto/implementation to find architectures of entities

### DIFF
--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -469,7 +469,7 @@ impl DesignRoot {
                                     ent.designator(),
                                     Designator::Identifier(comp_ident) if comp_ident == ident
                                 )
-                            },
+                            }
                             // Find all architectures which implement the entity
                             AnyEntKind::Design(Design::Architecture(ent_of_arch)) => {
                                 ent_of_arch.id == ent_id

--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -461,6 +461,7 @@ impl DesignRoot {
                     }
                     // Find components and architectures to entity
                     AnyEntKind::Design(Design::Entity(..)) => {
+                        let ent_id = ent.id;
                         let mut searcher = FindAllEnt::new(self, |ent| match ent.kind() {
                             // Find all components with same name as entity in the library
                             AnyEntKind::Component(_) => {
@@ -470,11 +471,8 @@ impl DesignRoot {
                                 )
                             },
                             // Find all architectures which implement the entity
-                            AnyEntKind::Design(Design::Architecture(a)) => {
-                                matches!(
-                                    a.designator(),
-                                    Designator::Identifier(ent_ident) if ent_ident == ident
-                                )
+                            AnyEntKind::Design(Design::Architecture(ent_of_arch)) => {
+                                ent_of_arch.id == ent_id
                             }
                             _ => false,
                         });

--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -459,14 +459,24 @@ impl DesignRoot {
                             return vec![design.into()];
                         }
                     }
-                    // Find all components with same name as entity in the library
+                    // Find components and architectures to entity
                     AnyEntKind::Design(Design::Entity(..)) => {
-                        let mut searcher = FindAllEnt::new(self, |ent| {
-                            matches!(ent.kind(), AnyEntKind::Component(_))
-                                && matches!(
+                        let mut searcher = FindAllEnt::new(self, |ent| match ent.kind() {
+                            // Find all components with same name as entity in the library
+                            AnyEntKind::Component(_) => {
+                                matches!(
                                     ent.designator(),
                                     Designator::Identifier(comp_ident) if comp_ident == ident
                                 )
+                            },
+                            // Find all architectures which implement the entity
+                            AnyEntKind::Design(Design::Architecture(a)) => {
+                                matches!(
+                                    a.designator(),
+                                    Designator::Identifier(ent_ident) if ent_ident == ident
+                                )
+                            }
+                            _ => false,
                         });
 
                         let _ = self.search_library(library_name, &mut searcher);

--- a/vhdl_lang/src/analysis/tests/hierarchy.rs
+++ b/vhdl_lang/src/analysis/tests/hierarchy.rs
@@ -309,11 +309,14 @@ end architecture;
     let ent = root
         .search_reference(code.source(), code.s1("ent0").start())
         .unwrap();
+    let arch = root
+        .search_reference(code.source(), code.s1("a ").start())
+        .unwrap();
     let comp = root
         .search_reference(code.source(), code.sa("component ", "ent0").start())
         .unwrap();
 
-    assert_eq!(root.find_implementation(ent), vec![comp]);
+    assert_eq!(root.find_implementation(ent), vec![arch, comp]);
     assert_eq!(root.find_implementation(comp), vec![ent]);
 }
 


### PR DESCRIPTION
Hi, I've extended the find_implementation function to also search for architectures which implement an entity.