### PR TITLE
Disallow Interface lists to be empty

### DIFF
--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -369,12 +369,19 @@ end entity myent;
 
     #[test]
     fn parse_entity_generic_clause() {
-        let (code, design_file) = parse_ok(
+        let (code, design_file, diagnostics) = parse_str(
             "
 entity myent is
   generic ();
 end entity;
 ",
+        );
+        check_diagnostics(
+            diagnostics,
+            vec![Diagnostic::error(
+                code.s1("()"),
+                "Interface list must not be empty",
+            )],
         );
         assert_eq!(
             to_single_entity(design_file),
@@ -419,12 +426,19 @@ end entity;
 
     #[test]
     fn parse_entity_port_clause() {
-        let (code, design_file) = parse_ok(
+        let (code, design_file, diagnostics) = parse_str(
             "
 entity myent is
   port ();
 end entity;
 ",
+        );
+        check_diagnostics(
+            diagnostics,
+            vec![Diagnostic::error(
+                code.s1("()"),
+                "Interface list must not be empty",
+            )],
         );
         assert_eq!(
             to_single_entity(design_file),

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -408,6 +408,12 @@ fn _parse_name(stream: &TokenStream) -> ParseResult<WithPos<Name>> {
             }
             LeftPar => {
                 stream.skip();
+                if let Some(right_par) = stream.pop_if_kind(RightPar) {
+                    return Err(Diagnostic::error(
+                        token.pos.combine(stream.get_pos(right_par)),
+                        "Association list cannot be empty",
+                    ));
+                }
                 let assoc = parse_association_element(stream)?;
                 expect_token!(
                     stream,
@@ -1189,6 +1195,19 @@ mod tests {
         );
         assert!(list.0.tokens.is_empty());
         assert!(list.0.items.is_empty());
+    }
+
+    #[test]
+    fn empty_association_list_in_name_diagnostic() {
+        let code = Code::new("foo()");
+        let res = code.parse(parse_name);
+        assert_eq!(
+            res,
+            Err(Diagnostic::error(
+                code.s1("()"),
+                "Association list cannot be empty"
+            ))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Small PR. Improve the quality of error messages and disallow interface lists to be empty.

According to the reference manual:
```
interface_list ::= interface_element { ; interface_element }
```
so an interface list must hold at least one element. Therefore declarations of the following form:
```vhdl
function foo() return bar;
```
are illegal in VHDL. This PR adds an appropriate error message.
Also improves the error message of function calls such as 
```
foo()
```
Previously, the error message was `expected {expression}`, now it's `Association list cannot be empty`