### PR TITLE
Refactor: More EvalResults and less AnalysisResults

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -264,16 +264,14 @@ impl<'a> AnalyzeContext<'a> {
                     as_fatal(self.resolve_selected_name(scope, entity_name, diagnostics))?
                 {
                     let expected = "entity";
-                    let ent = match self.resolve_non_overloaded(
+                    let ent = match as_fatal(self.resolve_non_overloaded(
                         entities,
                         entity_name.suffix_pos(),
                         expected,
-                    ) {
-                        Ok(ent) => ent,
-                        Err(err) => {
-                            err.add_to(diagnostics)?;
-                            return Ok(());
-                        }
+                        diagnostics,
+                    ))? {
+                        Some(ent) => ent,
+                        None => return Ok(()),
                     };
 
                     if let AnyEntKind::Design(Design::Entity(_, ent_region)) = ent.kind() {
@@ -337,14 +335,14 @@ impl<'a> AnalyzeContext<'a> {
                     return Ok(());
                 };
                 let expected = "component";
-                let ent = match self.resolve_non_overloaded(
+                let ent = match as_fatal(self.resolve_non_overloaded(
                     entities,
                     component_name.suffix_pos(),
                     expected,
-                ) {
-                    Ok(ent) => ent,
-                    Err(err) => {
-                        err.add_to(diagnostics)?;
+                    diagnostics,
+                ))? {
+                    Some(ent) => ent,
+                    None => {
                         return Ok(());
                     }
                 };
@@ -389,15 +387,15 @@ impl<'a> AnalyzeContext<'a> {
                 else {
                     return Ok(());
                 };
-                let _ = match self.resolve_non_overloaded_with_kind(
+                let _ = match as_fatal(self.resolve_non_overloaded_with_kind(
                     entities,
                     config_name.suffix_pos(),
                     &is_configuration,
                     "configuration",
-                ) {
-                    Ok(ent) => ent,
-                    Err(err) => {
-                        err.add_to(diagnostics)?;
+                    diagnostics,
+                ))? {
+                    Some(ent) => ent,
+                    None => {
                         return Ok(());
                     }
                 };

--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -260,116 +260,123 @@ impl<'a> AnalyzeContext<'a> {
     ) -> FatalResult {
         match instance.unit {
             InstantiatedUnit::Entity(ref mut entity_name, ref mut architecture_name) => {
-                if let Err(err) =
-                    self.resolve_selected_name(scope, entity_name)
-                        .and_then(|entities| {
-                            let expected = "entity";
-                            let ent = self.resolve_non_overloaded(
-                                entities,
-                                entity_name.suffix_pos(),
-                                expected,
-                            )?;
+                if let Some(entities) =
+                    as_fatal(self.resolve_selected_name(scope, entity_name, diagnostics))?
+                {
+                    let expected = "entity";
+                    let ent = match self.resolve_non_overloaded(
+                        entities,
+                        entity_name.suffix_pos(),
+                        expected,
+                    ) {
+                        Ok(ent) => ent,
+                        Err(err) => {
+                            err.add_to(diagnostics)?;
+                            return Ok(());
+                        }
+                    };
 
-                            if let AnyEntKind::Design(Design::Entity(_, ent_region)) = ent.kind() {
-                                if let Designator::Identifier(entity_ident) = ent.designator() {
-                                    if let Some(library_name) = ent.library_name() {
-                                        if let Some(ref mut architecture_name) = architecture_name {
-                                            match self.get_architecture(
-                                                library_name,
-                                                &architecture_name.item.pos,
-                                                entity_ident,
-                                                &architecture_name.item.item,
-                                            ) {
-                                                Ok(arch) => {
-                                                    architecture_name.set_unique_reference(&arch);
-                                                }
-                                                Err(err) => {
-                                                    diagnostics.push(err.into_non_fatal()?);
-                                                }
-                                            }
+                    if let AnyEntKind::Design(Design::Entity(_, ent_region)) = ent.kind() {
+                        if let Designator::Identifier(entity_ident) = ent.designator() {
+                            if let Some(library_name) = ent.library_name() {
+                                if let Some(ref mut architecture_name) = architecture_name {
+                                    match self.get_architecture(
+                                        library_name,
+                                        &architecture_name.item.pos,
+                                        entity_ident,
+                                        &architecture_name.item.item,
+                                    ) {
+                                        Ok(arch) => {
+                                            architecture_name.set_unique_reference(&arch);
+                                        }
+                                        Err(err) => {
+                                            diagnostics.push(err.into_non_fatal()?);
                                         }
                                     }
                                 }
-
-                                let (generic_region, port_region) = ent_region.to_entity_formal();
-
-                                self.check_association(
-                                    &entity_name.pos,
-                                    &generic_region,
-                                    scope,
-                                    instance
-                                        .generic_map
-                                        .as_mut()
-                                        .map(|it| it.list.items.as_mut_slice())
-                                        .unwrap_or(&mut []),
-                                    diagnostics,
-                                )?;
-                                self.check_association(
-                                    &entity_name.pos,
-                                    &port_region,
-                                    scope,
-                                    instance
-                                        .port_map
-                                        .as_mut()
-                                        .map(|it| it.list.items.as_mut_slice())
-                                        .unwrap_or(&mut []),
-                                    diagnostics,
-                                )?;
-                                Ok(())
-                            } else {
-                                Err(AnalysisError::NotFatal(
-                                    ent.kind_error(entity_name.suffix_pos(), expected),
-                                ))
                             }
-                        })
-                {
-                    err.add_to(diagnostics)?;
+                        }
+
+                        let (generic_region, port_region) = ent_region.to_entity_formal();
+
+                        self.check_association(
+                            &entity_name.pos,
+                            &generic_region,
+                            scope,
+                            instance
+                                .generic_map
+                                .as_mut()
+                                .map(|it| it.list.items.as_mut_slice())
+                                .unwrap_or(&mut []),
+                            diagnostics,
+                        )?;
+                        self.check_association(
+                            &entity_name.pos,
+                            &port_region,
+                            scope,
+                            instance
+                                .port_map
+                                .as_mut()
+                                .map(|it| it.list.items.as_mut_slice())
+                                .unwrap_or(&mut []),
+                            diagnostics,
+                        )?;
+                        Ok(())
+                    } else {
+                        diagnostics.push(ent.kind_error(entity_name.suffix_pos(), expected));
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
                 }
             }
             InstantiatedUnit::Component(ref mut component_name) => {
-                if let Err(err) =
-                    self.resolve_selected_name(scope, component_name)
-                        .and_then(|entities| {
-                            let expected = "component";
-                            let ent = self.resolve_non_overloaded(
-                                entities,
-                                component_name.suffix_pos(),
-                                expected,
-                            )?;
+                let Some(entities) =
+                    as_fatal(self.resolve_selected_name(scope, component_name, diagnostics))?
+                else {
+                    return Ok(());
+                };
+                let expected = "component";
+                let ent = match self.resolve_non_overloaded(
+                    entities,
+                    component_name.suffix_pos(),
+                    expected,
+                ) {
+                    Ok(ent) => ent,
+                    Err(err) => {
+                        err.add_to(diagnostics)?;
+                        return Ok(());
+                    }
+                };
 
-                            if let AnyEntKind::Component(ent_region) = ent.kind() {
-                                let (generic_region, port_region) = ent_region.to_entity_formal();
-                                self.check_association(
-                                    &component_name.pos,
-                                    &generic_region,
-                                    scope,
-                                    instance
-                                        .generic_map
-                                        .as_mut()
-                                        .map(|it| it.list.items.as_mut_slice())
-                                        .unwrap_or(&mut []),
-                                    diagnostics,
-                                )?;
-                                self.check_association(
-                                    &component_name.pos,
-                                    &port_region,
-                                    scope,
-                                    instance
-                                        .port_map
-                                        .as_mut()
-                                        .map(|it| it.list.items.as_mut_slice())
-                                        .unwrap_or(&mut []),
-                                    diagnostics,
-                                )?;
-                                Ok(())
-                            } else {
-                                Err(AnalysisError::NotFatal(
-                                    ent.kind_error(component_name.suffix_pos(), expected),
-                                ))
-                            }
-                        })
-                {
-                    err.add_to(diagnostics)?;
+                if let AnyEntKind::Component(ent_region) = ent.kind() {
+                    let (generic_region, port_region) = ent_region.to_entity_formal();
+                    self.check_association(
+                        &component_name.pos,
+                        &generic_region,
+                        scope,
+                        instance
+                            .generic_map
+                            .as_mut()
+                            .map(|it| it.list.items.as_mut_slice())
+                            .unwrap_or(&mut []),
+                        diagnostics,
+                    )?;
+                    self.check_association(
+                        &component_name.pos,
+                        &port_region,
+                        scope,
+                        instance
+                            .port_map
+                            .as_mut()
+                            .map(|it| it.list.items.as_mut_slice())
+                            .unwrap_or(&mut []),
+                        diagnostics,
+                    )?;
+                    Ok(())
+                } else {
+                    diagnostics.push(ent.kind_error(component_name.suffix_pos(), expected));
+                    Ok(())
                 }
             }
             InstantiatedUnit::Configuration(ref mut config_name) => {
@@ -377,26 +384,28 @@ impl<'a> AnalyzeContext<'a> {
                     matches!(kind, AnyEntKind::Design(Design::Configuration))
                 }
 
-                if let Err(err) =
-                    self.resolve_selected_name(scope, config_name)
-                        .and_then(|entities| {
-                            self.resolve_non_overloaded_with_kind(
-                                entities,
-                                config_name.suffix_pos(),
-                                &is_configuration,
-                                "configuration",
-                            )
-                        })
-                {
-                    err.add_to(diagnostics)?;
-                }
+                let Some(entities) =
+                    as_fatal(self.resolve_selected_name(scope, config_name, diagnostics))?
+                else {
+                    return Ok(());
+                };
+                let _ = match self.resolve_non_overloaded_with_kind(
+                    entities,
+                    config_name.suffix_pos(),
+                    &is_configuration,
+                    "configuration",
+                ) {
+                    Ok(ent) => ent,
+                    Err(err) => {
+                        err.add_to(diagnostics)?;
+                        return Ok(());
+                    }
+                };
 
                 self.analyze_map_aspect(scope, &mut instance.generic_map, diagnostics)?;
-                self.analyze_map_aspect(scope, &mut instance.port_map, diagnostics)?;
+                self.analyze_map_aspect(scope, &mut instance.port_map, diagnostics)
             }
-        };
-
-        Ok(())
+        }
     }
 
     pub fn analyze_map_aspect(

--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -841,8 +841,9 @@ impl<'a> AnalyzeContext<'a> {
                 ent.into()
             }
             InterfaceDeclaration::Package(ref mut instance) => {
-                let package_region = catch_analysis_err(
-                    self.analyze_package_instance_name(scope, &mut instance.package_name),
+                let package_region = self.analyze_package_instance_name(
+                    scope,
+                    &mut instance.package_name,
                     diagnostics,
                 )?;
 

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -619,17 +619,20 @@ impl<'a> AnalyzeContext<'a> {
         &self,
         scope: &Scope<'a>,
         package_name: &mut WithPos<SelectedName>,
-    ) -> AnalysisResult<&'a Region<'a>> {
-        let decl = self.resolve_selected_name(scope, package_name)?;
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> EvalResult<&'a Region<'a>> {
+        let decl =
+            catch_analysis_err(self.resolve_selected_name(scope, package_name), diagnostics)?;
 
         if let AnyEntKind::Design(Design::UninstPackage(_, ref package_region)) = decl.first_kind()
         {
             Ok(package_region)
         } else {
-            Err(AnalysisError::not_fatal_error(
+            diagnostics.error(
                 &package_name.pos,
                 format!("'{package_name}' is not an uninstantiated generic package"),
-            ))
+            );
+            Err(EvalError::Unknown)
         }
     }
 }

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -573,8 +573,8 @@ impl<'a> AnalyzeContext<'a> {
     ) -> EvalResult<TypeEnt<'a>> {
         let QualifiedExpression { type_mark, expr } = qexpr;
 
-        match self.resolve_type_mark(scope, type_mark) {
-            Ok(target_type) => {
+        match as_fatal(self.resolve_type_mark(scope, type_mark, diagnostics))? {
+            Some(target_type) => {
                 self.expr_pos_with_ttyp(
                     scope,
                     target_type,
@@ -584,9 +584,8 @@ impl<'a> AnalyzeContext<'a> {
                 )?;
                 Ok(target_type)
             }
-            Err(e) => {
+            None => {
                 self.expr_unknown_ttyp(scope, expr, diagnostics)?;
-                e.add_to(diagnostics)?;
                 Err(EvalError::Unknown)
             }
         }

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -482,15 +482,9 @@ impl<'a> AnalyzeContext<'a> {
                     let typ = self.analyze_qualified_expression(scope, qexpr, diagnostics)?;
                     Ok(ExpressionType::Unambiguous(typ))
                 }
-                Allocator::Subtype(ref mut subtype) => {
-                    match self.resolve_subtype_indication(scope, subtype, diagnostics) {
-                        Ok(typ) => Ok(ExpressionType::Unambiguous(typ.type_mark())),
-                        Err(err) => {
-                            diagnostics.push(err.into_non_fatal()?);
-                            Err(EvalError::Unknown)
-                        }
-                    }
-                }
+                Allocator::Subtype(ref mut subtype) => self
+                    .resolve_subtype_indication(scope, subtype, diagnostics)
+                    .map(|typ| ExpressionType::Unambiguous(typ.type_mark())),
             },
             Expression::Literal(ref mut literal) => match literal {
                 Literal::Physical(PhysicalLiteral { ref mut unit, .. }) => {

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1068,10 +1068,7 @@ impl<'a> AnalyzeContext<'a> {
             }
             SplitName::External(ename) => {
                 let ExternalName { subtype, class, .. } = ename;
-                let subtype = catch_analysis_err(
-                    self.resolve_subtype_indication(scope, subtype, diagnostics),
-                    diagnostics,
-                )?;
+                let subtype = self.resolve_subtype_indication(scope, subtype, diagnostics)?;
                 return Ok(ResolvedName::ObjectName(ObjectName {
                     base: ObjectBase::ExternalName(*class),
                     type_mark: Some(subtype.type_mark().to_owned()),

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -36,22 +36,17 @@ impl<'a> AnalyzeContext<'a> {
             ..
         } = unit;
 
-        match self.analyze_package_instance_name(scope, package_name) {
-            Ok(package_region) => self
-                .generic_instance(
-                    package_ent,
-                    scope,
-                    &unit.ident.tree.pos,
-                    package_region,
-                    generic_map,
-                    diagnostics,
-                )
-                .map(|(region, _)| region),
-            Err(err) => {
-                diagnostics.push(err.into_non_fatal()?);
-                Err(EvalError::Unknown)
-            }
-        }
+        let package_region =
+            self.analyze_package_instance_name(scope, package_name, diagnostics)?;
+        self.generic_instance(
+            package_ent,
+            scope,
+            &unit.ident.tree.pos,
+            package_region,
+            generic_map,
+            diagnostics,
+        )
+        .map(|(region, _)| region)
     }
 
     pub fn generic_map(

--- a/vhdl_lang/src/analysis/range.rs
+++ b/vhdl_lang/src/analysis/range.rs
@@ -236,14 +236,9 @@ impl<'a> AnalyzeContext<'a> {
     ) -> EvalResult<BaseType<'a>> {
         let typ = match drange {
             DiscreteRange::Discrete(ref mut type_mark, ref mut range) => {
-                let typ = match self.resolve_type_mark(scope, type_mark) {
-                    Ok(typ) => typ.base(),
-                    Err(err) => {
-                        err.add_to(diagnostics)?;
-                        return Err(EvalError::Unknown);
-                    }
-                };
-
+                let typ = self
+                    .resolve_type_mark(scope, type_mark, diagnostics)?
+                    .base();
                 if let Some(ref mut range) = range {
                     self.range_with_ttyp(scope, typ.into(), range, diagnostics)?;
                 }
@@ -353,9 +348,7 @@ impl<'a> AnalyzeContext<'a> {
     ) -> FatalResult {
         match drange {
             DiscreteRange::Discrete(ref mut type_mark, ref mut range) => {
-                if let Err(err) = self.resolve_type_mark(scope, type_mark) {
-                    err.add_to(diagnostics)?;
-                }
+                let _ = as_fatal(self.resolve_type_mark(scope, type_mark, diagnostics))?;
                 if let Some(ref mut range) = range {
                     self.range_with_ttyp(scope, target_type, range, diagnostics)?;
                 }

--- a/vhdl_lang/src/analysis/subprogram.rs
+++ b/vhdl_lang/src/analysis/subprogram.rs
@@ -22,14 +22,11 @@ impl<'a> AnalyzeContext<'a> {
     ) -> FatalResult<Region<'a>> {
         let mut region = Region::default();
         for decl in header.generic_list.iter_mut() {
-            match self.analyze_interface_declaration(scope, parent, decl, diagnostics) {
-                Ok(ent) => {
-                    region.add(ent, diagnostics);
-                    scope.add(ent, diagnostics);
-                }
-                Err(err) => {
-                    err.add_to(diagnostics)?;
-                }
+            if let Some(ent) =
+                as_fatal(self.analyze_interface_declaration(scope, parent, decl, diagnostics))?
+            {
+                region.add(ent, diagnostics);
+                scope.add(ent, diagnostics);
             }
         }
         self.analyze_map_aspect(scope, &mut header.map_aspect, diagnostics)?;

--- a/vhdl_lang/src/analysis/types.rs
+++ b/vhdl_lang/src/analysis/types.rs
@@ -16,7 +16,7 @@ impl<'a> AnalyzeContext<'a> {
         scope: &Scope<'a>,
         subtype_indication: &mut SubtypeIndication,
         diagnostics: &mut dyn DiagnosticHandler,
-    ) -> AnalysisResult<Subtype<'a>> {
+    ) -> EvalResult<Subtype<'a>> {
         // @TODO more
         let SubtypeIndication {
             type_mark,
@@ -24,7 +24,7 @@ impl<'a> AnalyzeContext<'a> {
             ..
         } = subtype_indication;
 
-        let base_type = self.resolve_type_mark(scope, type_mark)?;
+        let base_type = catch_analysis_err(self.resolve_type_mark(scope, type_mark), diagnostics)?;
 
         if let Some(constraint) = constraint {
             self.analyze_subtype_constraint(
@@ -228,19 +228,14 @@ impl<'a> AnalyzeContext<'a> {
                 for elem_decl in element_decls.iter_mut() {
                     let subtype =
                         self.resolve_subtype_indication(scope, &mut elem_decl.subtype, diagnostics);
-                    match subtype {
-                        Ok(subtype) => {
-                            let elem = self.arena.define(
-                                &mut elem_decl.ident,
-                                type_ent.into(),
-                                AnyEntKind::ElementDeclaration(subtype),
-                            );
-                            region.add(elem, diagnostics);
-                            elems.add(elem);
-                        }
-                        Err(err) => {
-                            err.add_to(diagnostics)?;
-                        }
+                    if let Some(subtype) = as_fatal(subtype)? {
+                        let elem = self.arena.define(
+                            &mut elem_decl.ident,
+                            type_ent.into(),
+                            AnyEntKind::ElementDeclaration(subtype),
+                        );
+                        region.add(elem, diagnostics);
+                        elems.add(elem);
                     }
                 }
                 region.close(diagnostics);
@@ -262,27 +257,24 @@ impl<'a> AnalyzeContext<'a> {
             TypeDefinition::Access(ref mut subtype_indication) => {
                 let subtype =
                     self.resolve_subtype_indication(scope, subtype_indication, diagnostics);
-                match subtype {
-                    Ok(subtype) => {
-                        let type_ent = TypeEnt::define_with_opt_id(
-                            self.arena,
-                            overwrite_id,
-                            &mut type_decl.ident,
-                            parent,
-                            None,
-                            Type::Access(subtype),
-                        );
+                if let Some(subtype) = as_fatal(subtype)? {
+                    let type_ent = TypeEnt::define_with_opt_id(
+                        self.arena,
+                        overwrite_id,
+                        &mut type_decl.ident,
+                        parent,
+                        None,
+                        Type::Access(subtype),
+                    );
 
-                        scope.add(type_ent.into(), diagnostics);
+                    scope.add(type_ent.into(), diagnostics);
 
-                        for ent in self.access_implicits(type_ent) {
-                            unsafe {
-                                self.arena.add_implicit(type_ent.id(), ent);
-                            }
-                            scope.add(ent, diagnostics);
+                    for ent in self.access_implicits(type_ent) {
+                        unsafe {
+                            self.arena.add_implicit(type_ent.id(), ent);
                         }
+                        scope.add(ent, diagnostics);
                     }
-                    Err(err) => err.add_to(diagnostics)?,
                 }
             }
             TypeDefinition::Array(ref mut array_indexes, ref mut subtype_indication) => {
@@ -295,14 +287,14 @@ impl<'a> AnalyzeContext<'a> {
                     ))?);
                 }
 
-                let elem_type =
-                    match self.resolve_subtype_indication(scope, subtype_indication, diagnostics) {
-                        Ok(subtype) => subtype.type_mark().to_owned(),
-                        Err(err) => {
-                            err.add_to(diagnostics)?;
-                            return Ok(());
-                        }
-                    };
+                let elem_type = match as_fatal(self.resolve_subtype_indication(
+                    scope,
+                    subtype_indication,
+                    diagnostics,
+                ))? {
+                    Some(subtype) => subtype.type_mark().to_owned(),
+                    None => return Ok(()),
+                };
 
                 let is_1d = indexes.len() == 1;
                 let array_ent = TypeEnt::define_with_opt_id(
@@ -325,21 +317,20 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             TypeDefinition::Subtype(ref mut subtype_indication) => {
-                match self.resolve_subtype_indication(scope, subtype_indication, diagnostics) {
-                    Ok(subtype) => {
-                        let type_ent = TypeEnt::define_with_opt_id(
-                            self.arena,
-                            overwrite_id,
-                            &mut type_decl.ident,
-                            parent,
-                            None,
-                            Type::Subtype(subtype),
-                        );
-                        scope.add(type_ent.into(), diagnostics);
-                    }
-                    Err(err) => {
-                        err.add_to(diagnostics)?;
-                    }
+                if let Some(subtype) = as_fatal(self.resolve_subtype_indication(
+                    scope,
+                    subtype_indication,
+                    diagnostics,
+                ))? {
+                    let type_ent = TypeEnt::define_with_opt_id(
+                        self.arena,
+                        overwrite_id,
+                        &mut type_decl.ident,
+                        parent,
+                        None,
+                        Type::Subtype(subtype),
+                    );
+                    scope.add(type_ent.into(), diagnostics);
                 }
             }
             TypeDefinition::Physical(ref mut physical) => {
@@ -618,9 +609,7 @@ impl<'a> AnalyzeContext<'a> {
         subtype_indication: &mut SubtypeIndication,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalResult {
-        if let Err(err) = self.resolve_subtype_indication(scope, subtype_indication, diagnostics) {
-            err.add_to(diagnostics)?;
-        }
-        Ok(())
+        as_fatal(self.resolve_subtype_indication(scope, subtype_indication, diagnostics))
+            .map(|_| ())
     }
 }


### PR DESCRIPTION
Towards #147
Also simplifies  some functions because the error handling is now more consistent

When a `TypeMark` can be parsed as a name (or a derivative of a name), the relevant functions now return an `EvalResult` instead of an `AnalysisResult`.