### PR TITLE
Replace selected name with name

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -320,12 +320,12 @@ impl<'a> AnalyzeContext<'a> {
                             Ok(())
                         }
                         _ => {
-                            diagnostics.push(ent.kind_error(&entity_name.suffix_pos(), "entity"));
+                            diagnostics.push(ent.kind_error(entity_name.suffix_pos(), "entity"));
                             Ok(())
                         }
                     },
                     other => {
-                        diagnostics.push(other.kind_error(&entity_name.suffix_pos(), "entity"));
+                        diagnostics.push(other.kind_error(entity_name.suffix_pos(), "entity"));
                         Ok(())
                     }
                 };

--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -270,7 +270,7 @@ impl<'a> AnalyzeContext<'a> {
                 else {
                     return Ok(());
                 };
-                return match ent {
+                match ent {
                     ResolvedName::Design(ent) => match ent.kind() {
                         Design::Entity(_, ent_region) => {
                             if let Designator::Identifier(entity_ident) = ent.designator() {
@@ -328,7 +328,7 @@ impl<'a> AnalyzeContext<'a> {
                         diagnostics.push(other.kind_error(entity_name.suffix_pos(), "entity"));
                         Ok(())
                     }
-                };
+                }
             }
             InstantiatedUnit::Component(ref mut component_name) => {
                 let Some(resolved) = as_fatal(self.name_resolve(

--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -261,7 +261,7 @@ impl<'a> AnalyzeContext<'a> {
     ) -> FatalResult {
         match instance.unit {
             InstantiatedUnit::Entity(ref mut entity_name, ref mut architecture_name) => {
-                let Some(ent) = as_fatal(self.name_resolve(
+                let Some(resolved) = as_fatal(self.name_resolve(
                     scope,
                     &entity_name.pos,
                     &mut entity_name.item,
@@ -270,7 +270,7 @@ impl<'a> AnalyzeContext<'a> {
                 else {
                     return Ok(());
                 };
-                match ent {
+                match resolved {
                     ResolvedName::Design(ent) => match ent.kind() {
                         Design::Entity(_, ent_region) => {
                             if let Designator::Identifier(entity_ident) = ent.designator() {
@@ -320,7 +320,8 @@ impl<'a> AnalyzeContext<'a> {
                             Ok(())
                         }
                         _ => {
-                            diagnostics.push(ent.kind_error(entity_name.suffix_pos(), "entity"));
+                            diagnostics
+                                .push(resolved.kind_error(entity_name.suffix_pos(), "entity"));
                             Ok(())
                         }
                     },
@@ -376,7 +377,7 @@ impl<'a> AnalyzeContext<'a> {
                     )?;
                     Ok(())
                 } else {
-                    diagnostics.push(ent.kind_error(component_name.suffix_pos(), "component"));
+                    diagnostics.push(resolved.kind_error(component_name.suffix_pos(), "component"));
                     Ok(())
                 }
             }

--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -261,73 +261,74 @@ impl<'a> AnalyzeContext<'a> {
     ) -> FatalResult {
         match instance.unit {
             InstantiatedUnit::Entity(ref mut entity_name, ref mut architecture_name) => {
-                if let Some(entities) =
-                    as_fatal(self.resolve_selected_name(scope, entity_name, diagnostics))?
-                {
-                    let expected = "entity";
-                    let ent = match as_fatal(self.resolve_non_overloaded(
-                        entities,
-                        entity_name.suffix_pos(),
-                        expected,
-                        diagnostics,
-                    ))? {
-                        Some(ent) => ent,
-                        None => return Ok(()),
-                    };
-
-                    if let AnyEntKind::Design(Design::Entity(_, ent_region)) = ent.kind() {
-                        if let Designator::Identifier(entity_ident) = ent.designator() {
-                            if let Some(library_name) = ent.library_name() {
-                                if let Some(ref mut architecture_name) = architecture_name {
-                                    match self.get_architecture(
-                                        library_name,
-                                        &architecture_name.item.pos,
-                                        entity_ident,
-                                        &architecture_name.item.item,
-                                    ) {
-                                        Ok(arch) => {
-                                            architecture_name.set_unique_reference(&arch);
-                                        }
-                                        Err(err) => {
-                                            diagnostics.push(err.into_non_fatal()?);
+                let Some(ent) = as_fatal(self.name_resolve(
+                    scope,
+                    &entity_name.pos,
+                    &mut entity_name.item,
+                    diagnostics,
+                ))?
+                else {
+                    return Ok(());
+                };
+                return match ent {
+                    ResolvedName::Design(ent) => match ent.kind() {
+                        Design::Entity(_, ent_region) => {
+                            if let Designator::Identifier(entity_ident) = ent.designator() {
+                                if let Some(library_name) = ent.library_name() {
+                                    if let Some(ref mut architecture_name) = architecture_name {
+                                        match self.get_architecture(
+                                            library_name,
+                                            &architecture_name.item.pos,
+                                            entity_ident,
+                                            &architecture_name.item.item,
+                                        ) {
+                                            Ok(arch) => {
+                                                architecture_name.set_unique_reference(&arch);
+                                            }
+                                            Err(err) => {
+                                                diagnostics.push(err.into_non_fatal()?);
+                                            }
                                         }
                                     }
                                 }
                             }
+
+                            let (generic_region, port_region) = ent_region.to_entity_formal();
+
+                            self.check_association(
+                                &entity_name.pos,
+                                &generic_region,
+                                scope,
+                                instance
+                                    .generic_map
+                                    .as_mut()
+                                    .map(|it| it.list.items.as_mut_slice())
+                                    .unwrap_or(&mut []),
+                                diagnostics,
+                            )?;
+                            self.check_association(
+                                &entity_name.pos,
+                                &port_region,
+                                scope,
+                                instance
+                                    .port_map
+                                    .as_mut()
+                                    .map(|it| it.list.items.as_mut_slice())
+                                    .unwrap_or(&mut []),
+                                diagnostics,
+                            )?;
+                            Ok(())
                         }
-
-                        let (generic_region, port_region) = ent_region.to_entity_formal();
-
-                        self.check_association(
-                            &entity_name.pos,
-                            &generic_region,
-                            scope,
-                            instance
-                                .generic_map
-                                .as_mut()
-                                .map(|it| it.list.items.as_mut_slice())
-                                .unwrap_or(&mut []),
-                            diagnostics,
-                        )?;
-                        self.check_association(
-                            &entity_name.pos,
-                            &port_region,
-                            scope,
-                            instance
-                                .port_map
-                                .as_mut()
-                                .map(|it| it.list.items.as_mut_slice())
-                                .unwrap_or(&mut []),
-                            diagnostics,
-                        )?;
-                        Ok(())
-                    } else {
-                        diagnostics.push(ent.kind_error(entity_name.suffix_pos(), expected));
+                        _ => {
+                            diagnostics.push(ent.kind_error(&entity_name.suffix_pos(), "entity"));
+                            Ok(())
+                        }
+                    },
+                    other => {
+                        diagnostics.push(other.kind_error(&entity_name.suffix_pos(), "entity"));
                         Ok(())
                     }
-                } else {
-                    Ok(())
-                }
+                };
             }
             InstantiatedUnit::Component(ref mut component_name) => {
                 let Some(resolved) = as_fatal(self.name_resolve(

--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -850,7 +850,7 @@ impl<'a> AnalyzeContext<'a> {
                 self.arena.define(
                     &mut instance.ident,
                     parent,
-                    AnyEntKind::Design(Design::PackageInstance(package_region.clone())),
+                    AnyEntKind::Design(Design::PackageInstance(package_region)),
                 )
             }
         };

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -413,7 +413,9 @@ impl<'a> AnalyzeContext<'a> {
                         }
                     })
             },
-            _ => todo!()
+            _ => {
+                Err(AnalysisError::not_fatal_error(&ent_name, "Expected selected name"))
+            }
         };
         catch_analysis_err(res, diagnostics)
     }

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -362,7 +362,7 @@ impl<'a> AnalyzeContext<'a> {
         let res = match ent_name.item {
             // Entitities are implicitly defined for configurations
             // configuration cfg of ent
-            SelectedName::Designator(ref mut designator) => self.lookup_in_library(
+            Name::Designator(ref mut designator) => self.lookup_in_library(
                 self.work_library_name(),
                 &ent_name.pos,
                 &designator.item,
@@ -373,7 +373,7 @@ impl<'a> AnalyzeContext<'a> {
             ),
 
             // configuration cfg of lib.ent
-            SelectedName::Selected(ref mut prefix, ref mut designator) => {
+            Name::Selected(ref mut prefix, ref mut designator) => {
                 self.resolve_selected_name(scope, prefix, diagnostics)?
                     .into_non_overloaded()
                     .map_err(|ent|
@@ -412,7 +412,8 @@ impl<'a> AnalyzeContext<'a> {
                             ))
                         }
                     })
-            }
+            },
+            _ => todo!()
         };
         catch_analysis_err(res, diagnostics)
     }

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -618,7 +618,7 @@ impl<'a> AnalyzeContext<'a> {
     pub fn analyze_package_instance_name(
         &self,
         scope: &Scope<'a>,
-        package_name: &mut WithPos<SelectedName>,
+        package_name: &mut WithPos<Name>,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<&'a Region<'a>> {
         let decl = self.resolve_selected_name(scope, package_name, diagnostics)?;

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1609,11 +1609,11 @@ impl<'a> AnalyzeContext<'a> {
     pub fn resolve_selected_name(
         &self,
         scope: &Scope<'a>,
-        name: &mut WithPos<SelectedName>,
+        name: &mut WithPos<Name>,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<NamedEntities<'a>> {
         match name.item {
-            SelectedName::Selected(ref mut prefix, ref mut suffix) => {
+            Name::Selected(ref mut prefix, ref mut suffix) => {
                 let prefix_ent = self
                     .resolve_selected_name(scope, prefix, diagnostics)?
                     .into_non_overloaded();
@@ -1629,7 +1629,7 @@ impl<'a> AnalyzeContext<'a> {
                 diagnostics.error(&prefix.pos, "Invalid prefix for selected name");
                 Err(EvalError::Unknown)
             }
-            SelectedName::Designator(ref mut designator) => {
+            Name::Designator(ref mut designator) => {
                 match scope.lookup(&name.pos, designator.designator()) {
                     Ok(visible) => {
                         designator.set_reference(&visible);

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1641,7 +1641,10 @@ impl<'a> AnalyzeContext<'a> {
                     }
                 }
             }
-            _ => todo!(),
+            _ => {
+                diagnostics.error(&name, "Expected selected name");
+                Err(EvalError::Unknown)
+            }
         }
     }
 }

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1622,48 +1622,6 @@ impl<'a> AnalyzeContext<'a> {
             _ => Err(Diagnostic::invalid_selected_name_prefix(prefix, prefix_pos).into()),
         }
     }
-
-    pub fn resolve_selected_name(
-        &self,
-        scope: &Scope<'a>,
-        name: &mut WithPos<Name>,
-        diagnostics: &mut dyn DiagnosticHandler,
-    ) -> EvalResult<NamedEntities<'a>> {
-        match name.item {
-            Name::Selected(ref mut prefix, ref mut suffix) => {
-                let prefix_ent = self
-                    .resolve_selected_name(scope, prefix, diagnostics)?
-                    .into_non_overloaded();
-                if let Ok(prefix_ent) = prefix_ent {
-                    let visible = catch_analysis_err(
-                        self.lookup_selected(&prefix.pos, prefix_ent, suffix),
-                        diagnostics,
-                    )?;
-                    suffix.set_reference(&visible);
-                    return Ok(visible);
-                };
-
-                diagnostics.error(&prefix.pos, "Invalid prefix for selected name");
-                Err(EvalError::Unknown)
-            }
-            Name::Designator(ref mut designator) => {
-                match scope.lookup(&name.pos, designator.designator()) {
-                    Ok(visible) => {
-                        designator.set_reference(&visible);
-                        Ok(visible)
-                    }
-                    Err(err) => {
-                        diagnostics.push(err);
-                        Err(EvalError::Unknown)
-                    }
-                }
-            }
-            _ => {
-                diagnostics.error(&name, "Expected selected name");
-                Err(EvalError::Unknown)
-            }
-        }
-    }
 }
 
 fn plural(singular: &'static str, plural: &'static str, count: usize) -> &'static str {

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -269,6 +269,23 @@ impl<'a> ResolvedName<'a> {
         }
     }
 
+    pub fn decl_pos(&self) -> Option<&SrcPos> {
+        match self {
+            ResolvedName::Library(_) => None,
+            ResolvedName::Design(design) => design.decl_pos(),
+            ResolvedName::Type(typ) => typ.decl_pos(),
+            ResolvedName::Overloaded(_, names) => names.as_unique().and_then(|it| it.decl_pos()),
+            ResolvedName::ObjectName(name) => match name.base {
+                ObjectBase::Object(ent) => ent.decl_pos(),
+                ObjectBase::DeferredConstant(ent) | ObjectBase::ObjectAlias(_, ent) => {
+                    ent.decl_pos()
+                }
+                ObjectBase::ExternalName(_) => None,
+            },
+            ResolvedName::Expression(_) | ResolvedName::Final(_) => None,
+        }
+    }
+
     fn type_mark(&self) -> Option<TypeEnt<'a>> {
         match self {
             ResolvedName::Type(typ) => Some(*typ),

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1641,6 +1641,7 @@ impl<'a> AnalyzeContext<'a> {
                     }
                 }
             }
+            _ => todo!(),
         }
     }
 }

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -42,7 +42,7 @@ impl<'a> AnalyzeContext<'a> {
             package_ent,
             scope,
             &unit.ident.tree.pos,
-            package_region,
+            &package_region,
             generic_map,
             diagnostics,
         )

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -47,7 +47,7 @@ impl<'a> AnalyzeContext<'a> {
     pub fn resolve_type_mark_name(
         &self,
         scope: &Scope<'a>,
-        type_mark: &mut WithPos<SelectedName>,
+        type_mark: &mut WithPos<Name>,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<TypeEnt<'a>> {
         let entities = self.resolve_selected_name(scope, type_mark, diagnostics)?;

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -13,20 +13,6 @@ use crate::data::*;
 use crate::named_entity::*;
 
 impl<'a> AnalyzeContext<'a> {
-    pub fn resolve_non_overloaded(
-        &self,
-        named_entities: NamedEntities<'a>,
-        pos: &SrcPos,
-        expected: &str,
-        diagnostics: &mut dyn DiagnosticHandler,
-    ) -> EvalResult<EntRef<'a>> {
-        catch_diagnostic(
-            named_entities
-                .expect_non_overloaded(pos, || format!("Expected {expected}, got overloaded name")),
-            diagnostics,
-        )
-    }
-
     pub fn resolve_type_mark(
         &self,
         scope: &Scope<'a>,

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -13,23 +13,6 @@ use crate::data::*;
 use crate::named_entity::*;
 
 impl<'a> AnalyzeContext<'a> {
-    pub fn resolve_non_overloaded_with_kind(
-        &self,
-        named_entities: NamedEntities<'a>,
-        pos: &SrcPos,
-        kind_ok: &impl Fn(&AnyEntKind) -> bool,
-        expected: &str,
-        diagnostics: &mut dyn DiagnosticHandler,
-    ) -> EvalResult<EntRef<'a>> {
-        let ent = self.resolve_non_overloaded(named_entities, pos, expected, diagnostics)?;
-        if kind_ok(ent.actual_kind()) {
-            Ok(ent)
-        } else {
-            diagnostics.push(ent.kind_error(pos, expected));
-            Err(EvalError::Unknown)
-        }
-    }
-
     pub fn resolve_non_overloaded(
         &self,
         named_entities: NamedEntities<'a>,

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -293,6 +293,20 @@ impl<'a> AnyEnt<'a> {
     }
 }
 
+// TODO: duplication
+impl<'a> ResolvedName<'a> {
+    pub(super) fn kind_error(&self, pos: &SrcPos, expected: &str) -> Diagnostic {
+        let mut error = Diagnostic::error(
+            pos,
+            format!("Expected {}, got {}", expected, self.describe()),
+        );
+        if let Some(decl_pos) = self.decl_pos() {
+            error.add_related(decl_pos, "Defined here");
+        }
+        error
+    }
+}
+
 impl Diagnostic {
     pub(crate) fn type_mismatch(pos: &SrcPos, desc: &str, expected_type: TypeEnt) -> Diagnostic {
         Diagnostic::error(

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -249,22 +249,8 @@ impl Diagnostic {
     }
 }
 
-impl<'a> AnyEnt<'a> {
-    pub(super) fn kind_error(&self, pos: &SrcPos, expected: &str) -> Diagnostic {
-        let mut error = Diagnostic::error(
-            pos,
-            format!("Expected {}, got {}", expected, self.describe()),
-        );
-        if let Some(decl_pos) = self.decl_pos() {
-            error.add_related(decl_pos, "Defined here");
-        }
-        error
-    }
-}
-
-// TODO: duplication
 impl<'a> ResolvedName<'a> {
-    pub(super) fn kind_error(&self, pos: &SrcPos, expected: &str) -> Diagnostic {
+    pub(super) fn kind_error(&self, pos: impl AsRef<SrcPos>, expected: &str) -> Diagnostic {
         let mut error = Diagnostic::error(
             pos,
             format!("Expected {}, got {}", expected, self.describe()),

--- a/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
@@ -339,7 +339,14 @@ end package body;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![kind_error(&code, "bad", 2, 1, "type", "overloaded name")],
+        vec![kind_error(
+            &code,
+            "bad",
+            2,
+            1,
+            "type",
+            "function bad[return NATURAL]",
+        )],
     );
 }
 
@@ -382,7 +389,14 @@ end package;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![kind_error(&code, "bad", 2, 1, "type", "object alias 'bad'")],
+        vec![kind_error(
+            &code,
+            "bad",
+            2,
+            1,
+            "type",
+            "alias 'bad' of constant",
+        )],
     );
 }
 

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -195,8 +195,6 @@ pub enum Name {
     External(Box<ExternalName>),
 }
 
-pub type SelectedName = Name;
-
 /// LRM 9.3.4 Function calls
 #[derive(PartialEq, Debug, Clone)]
 pub struct CallOrIndexed {
@@ -364,15 +362,15 @@ pub struct RecordElementResolution {
 /// LRM 6.3 Subtype declarations
 #[derive(PartialEq, Debug, Clone)]
 pub enum ResolutionIndication {
-    FunctionName(WithPos<SelectedName>),
-    ArrayElement(WithPos<SelectedName>),
+    FunctionName(WithPos<Name>),
+    ArrayElement(WithPos<Name>),
     Record(Vec<RecordElementResolution>),
     Unresolved,
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct TypeMark {
-    pub name: WithPos<SelectedName>,
+    pub name: WithPos<Name>,
     pub attr: Option<TypeAttribute>,
 }
 
@@ -752,7 +750,7 @@ pub struct InterfaceObjectDeclaration {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum SubprogramDefault {
-    Name(WithPos<SelectedName>),
+    Name(WithPos<Name>),
     Box,
 }
 /// LRM 6.5.5 Interface package declaration
@@ -767,7 +765,7 @@ pub enum InterfacePackageGenericMapAspect {
 #[derive(PartialEq, Debug, Clone)]
 pub struct InterfacePackageDeclaration {
     pub ident: WithDecl<Ident>,
-    pub package_name: WithPos<SelectedName>,
+    pub package_name: WithPos<Name>,
     pub generic_map: InterfacePackageGenericMapAspect,
 }
 
@@ -1080,9 +1078,9 @@ pub struct ConcurrentSignalAssignment {
 /// 11.7 Component instantiation statements
 #[derive(PartialEq, Debug, Clone)]
 pub enum InstantiatedUnit {
-    Component(WithPos<SelectedName>),
-    Entity(WithPos<SelectedName>, Option<WithRef<Ident>>),
-    Configuration(WithPos<SelectedName>),
+    Component(WithPos<Name>),
+    Entity(WithPos<Name>, Option<WithRef<Ident>>),
+    Configuration(WithPos<Name>),
 }
 
 impl InstantiatedUnit {
@@ -1258,7 +1256,7 @@ pub struct ContextDeclaration {
 pub struct PackageInstantiation {
     pub context_clause: ContextClause,
     pub ident: WithDecl<Ident>,
-    pub package_name: WithPos<SelectedName>,
+    pub package_name: WithPos<Name>,
     pub generic_map: Option<MapAspect>,
 }
 
@@ -1273,8 +1271,8 @@ pub enum InstantiationList {
 /// LRM 7.3.2 Binding indication
 #[derive(PartialEq, Debug, Clone)]
 pub enum EntityAspect {
-    Entity(WithPos<SelectedName>, Option<Ident>),
-    Configuration(WithPos<SelectedName>),
+    Entity(WithPos<Name>, Option<Ident>),
+    Configuration(WithPos<Name>),
     Open,
 }
 
@@ -1290,7 +1288,7 @@ pub struct BindingIndication {
 #[derive(PartialEq, Debug, Clone)]
 pub struct ComponentSpecification {
     pub instantiation_list: InstantiationList,
-    pub component_name: WithPos<SelectedName>,
+    pub component_name: WithPos<Name>,
 }
 
 /// LRM 7.3.4 Verification unit binding indication
@@ -1345,7 +1343,7 @@ pub struct BlockConfiguration {
 pub struct ConfigurationDeclaration {
     pub context_clause: ContextClause,
     pub ident: WithDecl<Ident>,
-    pub entity_name: WithPos<SelectedName>,
+    pub entity_name: WithPos<Name>,
     pub decl: Vec<ConfigurationDeclarativeItem>,
     pub vunit_bind_inds: Vec<VUnitBindingIndication>,
     pub block_config: BlockConfiguration,

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -195,23 +195,7 @@ pub enum Name {
     External(Box<ExternalName>),
 }
 
-/// LRM 8. Names
-/// A subset of a full name allowing only selected name
-#[derive(PartialEq, Debug, Clone)]
-pub enum SelectedName {
-    Designator(WithRef<Designator>),
-    Selected(Box<WithPos<SelectedName>>, WithPos<WithRef<Designator>>),
-}
-
-impl SelectedName {
-    /// Returns the reference that this name selects
-    pub fn reference(&self) -> Option<EntityId> {
-        match &self {
-            SelectedName::Designator(desi) => desi.reference.get(),
-            SelectedName::Selected(_, desi) => desi.item.reference.get(),
-        }
-    }
-}
+pub type SelectedName = Name;
 
 /// LRM 9.3.4 Function calls
 #[derive(PartialEq, Debug, Clone)]
@@ -1105,9 +1089,9 @@ impl InstantiatedUnit {
     /// Returns a reference to the unit that this instantiation declares
     pub fn entity_reference(&self) -> Option<EntityId> {
         match &self {
-            InstantiatedUnit::Entity(name, _) => name.item.reference(),
-            InstantiatedUnit::Configuration(name) => name.item.reference(),
-            InstantiatedUnit::Component(name) => name.item.reference(),
+            InstantiatedUnit::Entity(name, _) => name.item.get_suffix_reference(),
+            InstantiatedUnit::Configuration(name) => name.item.get_suffix_reference(),
+            InstantiatedUnit::Component(name) => name.item.get_suffix_reference(),
         }
     }
 }

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -229,15 +229,6 @@ impl Display for Name {
     }
 }
 
-impl Display for SelectedName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self {
-            SelectedName::Selected(ref prefix, ref des) => write!(f, "{}.{}", prefix, &des),
-            SelectedName::Designator(ref des) => write!(f, "{}", &des),
-        }
-    }
-}
-
 impl Display for CallOrIndexed {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.name)?;

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -1187,12 +1187,12 @@ mod tests {
 
     #[test]
     fn test_selected_name_single() {
-        assert_format("foo", Code::selected_name);
+        assert_format("foo", Code::name);
     }
 
     #[test]
     fn test_selected_name_multiple() {
-        assert_format("foo.bar.baz", Code::selected_name);
+        assert_format("foo.bar.baz", Code::name);
     }
 
     #[test]

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -566,22 +566,6 @@ impl Search for WithPos<WithRef<Designator>> {
     }
 }
 
-impl Search for WithPos<SelectedName> {
-    fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
-        return_if_finished!(searcher.search_with_pos(ctx, &self.pos));
-        match self.item {
-            SelectedName::Selected(ref prefix, ref designator) => {
-                return_if_found!(prefix.search(ctx, searcher));
-                return_if_found!(designator.search(ctx, searcher));
-                NotFound
-            }
-            SelectedName::Designator(ref designator) => searcher
-                .search_designator_ref(ctx, &self.pos, designator)
-                .or_not_found(),
-        }
-    }
-}
-
 fn search_pos_name(
     pos: &SrcPos,
     name: &Name,

--- a/vhdl_lang/src/ast/util.rs
+++ b/vhdl_lang/src/ast/util.rs
@@ -9,33 +9,6 @@ use super::*;
 use crate::data::*;
 use crate::named_entity::{Concurrent, Sequential};
 
-impl From<WithPos<SelectedName>> for WithPos<Name> {
-    fn from(selected_name: WithPos<SelectedName>) -> WithPos<Name> {
-        match selected_name.item {
-            SelectedName::Designator(designator) => {
-                WithPos::from(Name::Designator(designator), selected_name.pos)
-            }
-
-            SelectedName::Selected(prefix, suffix) => {
-                let prefix: WithPos<SelectedName> = *prefix;
-                WithPos::from(
-                    Name::Selected(Box::new(prefix.into()), suffix),
-                    selected_name.pos,
-                )
-            }
-        }
-    }
-}
-
-impl WithPos<SelectedName> {
-    pub fn suffix_pos(&self) -> &SrcPos {
-        match self.item {
-            SelectedName::Designator(..) => &self.pos,
-            SelectedName::Selected(_, ref suffix) => &suffix.pos,
-        }
-    }
-}
-
 impl WithPos<Name> {
     pub fn suffix_pos(&self) -> &SrcPos {
         match self.item {

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -186,7 +186,7 @@ impl<'a> Searcher for AutocompletionSearcher<'a> {
             FoundDeclaration::PackageInstance(inst) => {
                 if let Some(map) = &inst.generic_map {
                     if self.load_completions_for_map_aspect(
-                        inst.package_name.item.reference(),
+                        inst.package_name.item.get_suffix_reference(),
                         map,
                         ctx,
                         MapAspectKind::Generic,

--- a/vhdl_lang/src/named_entity/region.rs
+++ b/vhdl_lang/src/named_entity/region.rs
@@ -40,7 +40,7 @@ impl<'a> Region<'a> {
         self
     }
 
-    pub(crate) fn to_entity_formal(&self) -> (FormalRegion, FormalRegion) {
+    pub(crate) fn to_entity_formal(&self) -> (FormalRegion<'a>, FormalRegion<'a>) {
         // @TODO separate generics and ports
         let mut generics = Vec::with_capacity(self.entities.len());
         let mut ports = Vec::with_capacity(self.entities.len());

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -1264,7 +1264,7 @@ with x(0) + 1 select
         let code = Code::new("inst: component lib.foo.bar;");
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").selected_name()),
+            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").name()),
             generic_map: None,
             port_map: None,
             semicolon: code.s1(";").token(),
@@ -1285,7 +1285,7 @@ with x(0) + 1 select
         let code = Code::new("inst: configuration lib.foo.bar;");
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Configuration(code.s1("lib.foo.bar").selected_name()),
+            unit: InstantiatedUnit::Configuration(code.s1("lib.foo.bar").name()),
             generic_map: None,
             port_map: None,
             semicolon: code.s1(";").token(),
@@ -1306,7 +1306,7 @@ with x(0) + 1 select
         let code = Code::new("inst: entity lib.foo.bar;");
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Entity(code.s1("lib.foo.bar").selected_name(), None),
+            unit: InstantiatedUnit::Entity(code.s1("lib.foo.bar").name(), None),
             generic_map: None,
             port_map: None,
             semicolon: code.s1(";").token(),
@@ -1328,7 +1328,7 @@ with x(0) + 1 select
 
         let inst = InstantiationStatement {
             unit: InstantiatedUnit::Entity(
-                code.s1("lib.foo.bar").selected_name(),
+                code.s1("lib.foo.bar").name(),
                 Some(WithRef::new(code.s1("arch").ident())),
             ),
             generic_map: None,
@@ -1360,7 +1360,7 @@ inst: component lib.foo.bar
         );
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").selected_name()),
+            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").name()),
             generic_map: Some(
                 code.s1("generic map (
    const => 1
@@ -1397,7 +1397,7 @@ inst: lib.foo.bar
         );
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").selected_name()),
+            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").name()),
             generic_map: None,
             port_map: Some(
                 code.s1("port map (
@@ -1429,7 +1429,7 @@ inst: lib.foo.bar
         );
 
         let inst = InstantiationStatement {
-            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").selected_name()),
+            unit: InstantiatedUnit::Component(code.s1("lib.foo.bar").name()),
             generic_map: Some(
                 code.s1("generic map (
    const => 1

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -11,9 +11,7 @@ use super::expression::parse_aggregate;
 use super::expression::{parse_choices, parse_expression};
 use super::interface_declaration::{parse_generic_interface_list, parse_port_interface_list};
 use super::names::parse_name;
-use super::names::{
-    expression_to_ident, into_selected_name, parse_association_list, parse_selected_name,
-};
+use super::names::{expression_to_ident, parse_association_list, parse_selected_name};
 use super::range::parse_discrete_range;
 use super::sequential_statement::{
     parse_assert_statement, parse_labeled_sequential_statements, parse_selection,
@@ -638,7 +636,8 @@ pub fn parse_concurrent_statement(
                 let token = stream.peek_expect()?;
                 match token.kind {
                     Generic|Port => {
-                        let unit = InstantiatedUnit::Component(into_selected_name(name)?);
+                        name.expect_selected()?;
+                        let unit = InstantiatedUnit::Component(name);
                         ConcurrentStatement::Instance(parse_instantiation_statement(stream, unit, diagnostics)?)
                     }
                     _ => {

--- a/vhdl_lang/src/syntax/configuration.rs
+++ b/vhdl_lang/src/syntax/configuration.rs
@@ -378,7 +378,7 @@ end;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -407,7 +407,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -437,7 +437,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![
                     ConfigurationDeclarativeItem::Use(code.s1("use lib.foo.bar;").use_clause()),
                     ConfigurationDeclarativeItem::Use(code.s1("use lib2.foo.bar;").use_clause())
@@ -471,7 +471,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![ConfigurationDeclarativeItem::Use(
                     code.s1("use lib.foo.bar;").use_clause()
                 ),],
@@ -504,7 +504,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -537,7 +537,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -581,7 +581,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -592,7 +592,7 @@ end configuration cfg;
                             instantiation_list: InstantiationList::Labels(vec![code
                                 .s1("inst")
                                 .ident()]),
-                            component_name: code.s1("lib.pkg.comp").selected_name()
+                            component_name: code.s1("lib.pkg.comp").name()
                         },
                         bind_ind: None,
                         vunit_bind_inds: Vec::new(),
@@ -630,7 +630,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -641,11 +641,11 @@ end configuration cfg;
                             instantiation_list: InstantiationList::Labels(vec![code
                                 .s1("inst")
                                 .ident()]),
-                            component_name: code.s1("lib.pkg.comp").selected_name()
+                            component_name: code.s1("lib.pkg.comp").name()
                         },
                         bind_ind: Some(BindingIndication {
                             entity_aspect: Some(EntityAspect::Entity(
-                                code.s1("work.bar").selected_name(),
+                                code.s1("work.bar").name(),
                                 None
                             )),
                             generic_map: None,
@@ -685,7 +685,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -696,11 +696,11 @@ end configuration cfg;
                             instantiation_list: InstantiationList::Labels(vec![code
                                 .s1("inst")
                                 .ident()]),
-                            component_name: code.s1("lib.pkg.comp").selected_name()
+                            component_name: code.s1("lib.pkg.comp").name()
                         },
                         bind_ind: Some(BindingIndication {
                             entity_aspect: Some(EntityAspect::Entity(
-                                code.s1("lib.use_name").selected_name(),
+                                code.s1("lib.use_name").name(),
                                 None
                             )),
                             generic_map: None,
@@ -739,7 +739,7 @@ end configuration cfg;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("cfg").decl_ident(),
-                entity_name: code.s1("entity_name").selected_name(),
+                entity_name: code.s1("entity_name").name(),
                 decl: vec![],
                 vunit_bind_inds: Vec::new(),
                 block_config: BlockConfiguration {
@@ -751,7 +751,7 @@ end configuration cfg;
                                 instantiation_list: InstantiationList::Labels(vec![code
                                     .s1("inst")
                                     .ident()]),
-                                component_name: code.s1("lib.pkg.comp").selected_name()
+                                component_name: code.s1("lib.pkg.comp").name()
                             },
                             bind_ind: None,
                             vunit_bind_inds: Vec::new(),
@@ -764,7 +764,7 @@ end configuration cfg;
                                     code.s1("inst2").ident(),
                                     code.s1("inst3").ident()
                                 ]),
-                                component_name: code.s1("lib2.pkg.comp").selected_name()
+                                component_name: code.s1("lib2.pkg.comp").name()
                             },
                             bind_ind: None,
                             vunit_bind_inds: Vec::new(),
@@ -773,7 +773,7 @@ end configuration cfg;
                         ConfigurationItem::Component(ComponentConfiguration {
                             spec: ComponentSpecification {
                                 instantiation_list: InstantiationList::All,
-                                component_name: code.s1("lib3.pkg.comp").selected_name()
+                                component_name: code.s1("lib3.pkg.comp").name()
                             },
                             bind_ind: None,
                             vunit_bind_inds: Vec::new(),
@@ -782,7 +782,7 @@ end configuration cfg;
                         ConfigurationItem::Component(ComponentConfiguration {
                             spec: ComponentSpecification {
                                 instantiation_list: InstantiationList::Others,
-                                component_name: code.s1("lib4.pkg.comp").selected_name()
+                                component_name: code.s1("lib4.pkg.comp").name()
                             },
                             bind_ind: None,
                             vunit_bind_inds: Vec::new(),
@@ -800,7 +800,7 @@ end configuration cfg;
         let code = Code::new("entity lib.foo.name");
         assert_eq!(
             code.with_stream(parse_entity_aspect),
-            EntityAspect::Entity(code.s1("lib.foo.name").selected_name(), None)
+            EntityAspect::Entity(code.s1("lib.foo.name").name(), None)
         );
     }
 
@@ -810,7 +810,7 @@ end configuration cfg;
         assert_eq!(
             code.with_stream(parse_entity_aspect),
             EntityAspect::Entity(
-                code.s1("lib.foo.name").selected_name(),
+                code.s1("lib.foo.name").name(),
                 Some(code.s1("arch").ident())
             )
         );
@@ -821,7 +821,7 @@ end configuration cfg;
         let code = Code::new("configuration lib.foo.name");
         assert_eq!(
             code.with_stream(parse_entity_aspect),
-            EntityAspect::Configuration(code.s1("lib.foo.name").selected_name())
+            EntityAspect::Configuration(code.s1("lib.foo.name").name())
         );
     }
 
@@ -841,11 +841,11 @@ end configuration cfg;
                 span: code.token_span(),
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,
-                    component_name: code.s1("lib.pkg.comp").selected_name(),
+                    component_name: code.s1("lib.pkg.comp").name(),
                 },
                 bind_ind: BindingIndication {
                     entity_aspect: Some(EntityAspect::Entity(
-                        code.s1("work.foo").selected_name(),
+                        code.s1("work.foo").name(),
                         Some(code.s1("rtl").ident())
                     )),
                     generic_map: None,
@@ -866,11 +866,11 @@ end configuration cfg;
                 span: code.token_span(),
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,
-                    component_name: code.s1("lib.pkg.comp").selected_name(),
+                    component_name: code.s1("lib.pkg.comp").name(),
                 },
                 bind_ind: BindingIndication {
                     entity_aspect: Some(EntityAspect::Entity(
-                        code.s1("work.foo").selected_name(),
+                        code.s1("work.foo").name(),
                         Some(code.s1("rtl").ident())
                     )),
                     generic_map: None,
@@ -893,11 +893,11 @@ end configuration cfg;
                 span: code.token_span(),
                 spec: ComponentSpecification {
                     instantiation_list: InstantiationList::All,
-                    component_name: code.s1("lib.pkg.comp").selected_name(),
+                    component_name: code.s1("lib.pkg.comp").name(),
                 },
                 bind_ind: BindingIndication {
                     entity_aspect: Some(EntityAspect::Entity(
-                        code.s1("work.foo").selected_name(),
+                        code.s1("work.foo").name(),
                         Some(code.s1("rtl").ident())
                     )),
                     generic_map: None,

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -179,7 +179,7 @@ package ident is new lib.foo.bar;
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("ident").decl_ident(),
-                package_name: code.s1("lib.foo.bar").selected_name(),
+                package_name: code.s1("lib.foo.bar").name(),
                 generic_map: None
             }
         );
@@ -201,7 +201,7 @@ package ident is new lib.foo.bar
                 span: code.token_span(),
                 context_clause: ContextClause::default(),
                 ident: code.s1("ident").decl_ident(),
-                package_name: code.s1("lib.foo.bar").selected_name(),
+                package_name: code.s1("lib.foo.bar").name(),
                 generic_map: Some(
                     code.s1("generic map (
     foo => bar

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -308,10 +308,10 @@ pub fn name_to_type_mark(name: WithPos<Name>) -> ParseResult<WithPos<TypeMark>> 
     Ok(type_mark)
 }
 
-fn name_to_selected_name(name: Name) -> Option<SelectedName> {
+fn name_to_selected_name(name: Name) -> Option<Name> {
     match name {
-        Name::Designator(d) => Some(SelectedName::Designator(d)),
-        Name::Selected(p, d) => Some(SelectedName::Selected(
+        Name::Designator(d) => Some(Name::Designator(d)),
+        Name::Selected(p, d) => Some(Name::Selected(
             Box::new(p.try_map_into(name_to_selected_name)?),
             d,
         )),

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -841,7 +841,7 @@ bar : natural)",
             InterfaceDeclaration::Subprogram(
                 code.s1("function foo return bar")
                     .subprogram_specification(),
-                Some(SubprogramDefault::Name(code.s1("lib.name").selected_name()))
+                Some(SubprogramDefault::Name(code.s1("lib.name").name()))
             )
         );
 
@@ -867,7 +867,7 @@ package foo is new lib.pkg
             code.with_stream(parse_generic),
             InterfaceDeclaration::Package(InterfacePackageDeclaration {
                 ident: code.s1("foo").decl_ident(),
-                package_name: code.s1("lib.pkg").selected_name(),
+                package_name: code.s1("lib.pkg").name(),
                 generic_map: InterfacePackageGenericMapAspect::Map(
                     code.s1("(foo => bar)").association_list()
                 )
@@ -886,7 +886,7 @@ package foo is new lib.pkg
             code.with_stream(parse_generic),
             InterfaceDeclaration::Package(InterfacePackageDeclaration {
                 ident: code.s1("foo").decl_ident(),
-                package_name: code.s1("lib.pkg").selected_name(),
+                package_name: code.s1("lib.pkg").name(),
                 generic_map: InterfacePackageGenericMapAspect::Box
             })
         );
@@ -903,7 +903,7 @@ package foo is new lib.pkg
             code.with_stream(parse_generic),
             InterfaceDeclaration::Package(InterfacePackageDeclaration {
                 ident: code.s1("foo").decl_ident(),
-                package_name: code.s1("lib.pkg").selected_name(),
+                package_name: code.s1("lib.pkg").name(),
                 generic_map: InterfacePackageGenericMapAspect::Default
             })
         );

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -807,7 +807,7 @@ mod tests {
     #[test]
     fn test_type_mark_without_subtype() {
         let code = Code::new("prefix");
-        let name = code.s1("prefix").selected_name();
+        let name = code.s1("prefix").name();
 
         assert_eq!(
             code.with_stream(parse_type_mark),
@@ -827,7 +827,7 @@ mod tests {
             WithPos {
                 pos: code.pos(),
                 item: TypeMark {
-                    name: code.s1("prefix").selected_name(),
+                    name: code.s1("prefix").name(),
                     attr: Some(TypeAttribute::Subtype)
                 },
             }
@@ -843,7 +843,7 @@ mod tests {
             WithPos {
                 pos: code.pos(),
                 item: TypeMark {
-                    name: code.s1("prefix").selected_name(),
+                    name: code.s1("prefix").name(),
                     attr: Some(TypeAttribute::Element)
                 },
             }

--- a/vhdl_lang/src/syntax/subtype_indication.rs
+++ b/vhdl_lang/src/syntax/subtype_indication.rs
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_subtype_indication),
             SubtypeIndication {
-                resolution: ResolutionIndication::FunctionName(code.s1("resolve").selected_name()),
+                resolution: ResolutionIndication::FunctionName(code.s1("resolve").name()),
                 type_mark: code.s1("std_logic").type_mark(),
                 constraint: None
             }
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_subtype_indication),
             SubtypeIndication {
-                resolution: ResolutionIndication::ArrayElement(code.s1("resolve").selected_name()),
+                resolution: ResolutionIndication::ArrayElement(code.s1("resolve").name()),
                 type_mark: code.s1("integer_vector").type_mark(),
                 constraint: None
             }
@@ -265,7 +265,7 @@ mod tests {
         let elem_resolution = RecordElementResolution {
             ident: code.s1("elem").ident(),
             resolution: Box::new(ResolutionIndication::FunctionName(
-                code.s1("resolve").selected_name(),
+                code.s1("resolve").name(),
             )),
         };
 
@@ -287,21 +287,21 @@ mod tests {
         let elem1_resolution = RecordElementResolution {
             ident: code.s1("elem1").ident(),
             resolution: Box::new(ResolutionIndication::ArrayElement(
-                code.s1("resolve1").selected_name(),
+                code.s1("resolve1").name(),
             )),
         };
 
         let elem2_resolution = RecordElementResolution {
             ident: code.s1("elem2").ident(),
             resolution: Box::new(ResolutionIndication::FunctionName(
-                code.s1("resolve2").selected_name(),
+                code.s1("resolve2").name(),
             )),
         };
 
         let sub_elem_resolution = RecordElementResolution {
             ident: code.s1("sub_elem").ident(),
             resolution: Box::new(ResolutionIndication::FunctionName(
-                code.s1("sub_resolve").selected_name(),
+                code.s1("sub_resolve").name(),
             )),
         };
 
@@ -330,9 +330,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_subtype_indication),
             SubtypeIndication {
-                resolution: ResolutionIndication::FunctionName(
-                    code.s1("lib.foo.resolve").selected_name()
-                ),
+                resolution: ResolutionIndication::FunctionName(code.s1("lib.foo.resolve").name()),
                 type_mark: code.s1("std_logic").type_mark(),
                 constraint: None
             }

--- a/vhdl_lang/src/syntax/subtype_indication.rs
+++ b/vhdl_lang/src/syntax/subtype_indication.rs
@@ -139,7 +139,7 @@ pub fn parse_element_resolution_indication(
     Ok(peek_token!(
         stream, token,
         Dot | RightPar => {
-            let selected_name = first_ident.map_into(|sym| SelectedName::Designator(Designator::Identifier(sym).into_ref()));
+            let selected_name = first_ident.map_into(|sym| Name::Designator(Designator::Identifier(sym).into_ref()));
             stream.expect_kind(RightPar)?;
             ResolutionIndication::ArrayElement(selected_name)
         },

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -17,9 +17,7 @@ use super::design_unit::{
 };
 use super::expression::{parse_aggregate, parse_choices, parse_expression};
 use super::interface_declaration::{parse_generic, parse_parameter, parse_port};
-use super::names::{
-    parse_association_list, parse_designator, parse_name, parse_selected_name, parse_type_mark,
-};
+use super::names::{parse_association_list, parse_designator, parse_name, parse_type_mark};
 use super::object_declaration::{parse_file_declaration, parse_object_declaration};
 use super::range::{parse_discrete_range, parse_range};
 use super::separated_list::{parse_ident_list, parse_name_list};
@@ -502,10 +500,6 @@ impl Code {
 
     pub fn ident_list(&self) -> SeparatedList<WithRef<Ident>> {
         self.parse_ok_no_diagnostics(parse_ident_list)
-    }
-
-    pub fn selected_name(&self) -> WithPos<Name> {
-        self.parse_ok(parse_selected_name)
     }
 
     pub fn type_mark(&self) -> WithPos<TypeMark> {

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -504,7 +504,7 @@ impl Code {
         self.parse_ok_no_diagnostics(parse_ident_list)
     }
 
-    pub fn selected_name(&self) -> WithPos<SelectedName> {
+    pub fn selected_name(&self) -> WithPos<Name> {
         self.parse_ok(parse_selected_name)
     }
 


### PR DESCRIPTION
Closes #147 

This removes the `SelectedName` enum. Analysis now only considers "regular" names. When only selected names are allowed in the specification, the parser still only considers selected names, but returns a regular name.
This simplifies the analyzer and removes duplication.

This has no measurable performance impact (tested using `cargo bench`)