### PR TITLE
Entity Completion

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -110,6 +110,7 @@ impl<'a> AnalyzeContext<'a> {
                     decl,
                     statements,
                     end_label_pos: _,
+                    ..
                 } = process;
                 if let Some(sensitivity_list) = sensitivity_list {
                     match sensitivity_list {
@@ -130,6 +131,7 @@ impl<'a> AnalyzeContext<'a> {
                     discrete_range,
                     body,
                     end_label_pos: _,
+                    ..
                 } = gen;
                 let typ = as_fatal(self.drange_type(scope, discrete_range, diagnostics))?;
                 let nested = scope.nested();
@@ -163,6 +165,7 @@ impl<'a> AnalyzeContext<'a> {
                             ref mut alternatives,
                         },
                     end_label_pos: _,
+                    ..
                 } = gen;
 
                 let ctyp = as_fatal(self.expr_unambiguous_type(scope, expression, diagnostics))?;

--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -253,6 +253,10 @@ impl Library {
         self.id
     }
 
+    pub(crate) fn units(&self) -> impl Iterator<Item = &LockedUnit> {
+        self.units.values()
+    }
+
     pub(crate) fn primary_units(&self) -> impl Iterator<Item = &LockedUnit> {
         self.units.iter().filter_map(|(key, value)| match key {
             UnitKey::Primary(_) => Some(value),

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -1016,6 +1016,7 @@ pub struct LabeledSequentialStatement {
 }
 
 /// LRM 11.2 Block statement
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct BlockStatement {
     pub guard_condition: Option<WithPos<Expression>>,
@@ -1041,6 +1042,7 @@ pub enum SensitivityList {
 }
 
 /// LRM 11.3 Process statement
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct ProcessStatement {
     pub postponed: bool,
@@ -1113,12 +1115,12 @@ impl MapAspect {
 }
 
 /// 11.7 Component instantiation statements
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct InstantiationStatement {
     pub unit: InstantiatedUnit,
     pub generic_map: Option<MapAspect>,
     pub port_map: Option<MapAspect>,
-    pub semicolon: TokenId,
 }
 
 impl InstantiationStatement {
@@ -1138,6 +1140,7 @@ pub struct GenerateBody {
 }
 
 /// 11.8 Generate statements
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct ForGenerateStatement {
     pub index_name: WithDecl<Ident>,
@@ -1147,11 +1150,14 @@ pub struct ForGenerateStatement {
 }
 
 /// 11.8 Generate statements
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct IfGenerateStatement {
     pub conds: Conditionals<GenerateBody>,
     pub end_label_pos: Option<SrcPos>,
 }
+
+#[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct CaseGenerateStatement {
     pub sels: Selection<GenerateBody>,
@@ -1369,6 +1375,7 @@ pub struct ArchitectureBody {
     pub context_clause: ContextClause,
     pub ident: WithDecl<Ident>,
     pub entity_name: WithRef<Ident>,
+    pub begin_token: TokenId,
     pub decl: Vec<Declaration>,
     pub statements: Vec<LabeledConcurrentStatement>,
     pub end_ident_pos: Option<SrcPos>,
@@ -1431,6 +1438,12 @@ pub type ContextClause = Vec<ContextItem>;
 pub enum AnyDesignUnit {
     Primary(AnyPrimaryUnit),
     Secondary(AnySecondaryUnit),
+}
+
+impl AnyDesignUnit {
+    pub fn is_entity(&self) -> bool {
+        matches!(self, AnyDesignUnit::Primary(AnyPrimaryUnit::Entity(_)))
+    }
 }
 
 #[derive(PartialEq, Debug, Clone, Default)]

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -11,6 +11,7 @@ use crate::named_entity::{EntRef, HasEntityId, Reference, Related};
 use crate::syntax::{HasTokenSpan, TokenAccess};
 
 #[must_use]
+#[derive(PartialEq)]
 pub enum SearchResult {
     Found,
     NotFound,
@@ -486,6 +487,7 @@ impl Search for LabeledConcurrentStatement {
                     decl,
                     statements,
                     end_label_pos: _,
+                    ..
                 } = process;
                 return_if_found!(sensitivity_list.search(ctx, searcher));
                 return_if_found!(decl.search(ctx, searcher));
@@ -503,6 +505,7 @@ impl Search for LabeledConcurrentStatement {
                     discrete_range,
                     body,
                     end_label_pos: _,
+                    ..
                 } = gen;
                 return_if_found!(discrete_range.search(ctx, searcher));
                 return_if_found!(body.search(ctx, searcher));
@@ -524,6 +527,7 @@ impl Search for LabeledConcurrentStatement {
                 let ConcurrentProcedureCall {
                     postponed: _postponed,
                     call,
+                    ..
                 } = pcall;
                 return_if_finished!(searcher.search_with_pos(ctx, &call.pos));
                 return_if_found!(call.item.search(ctx, searcher));

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2023, Olof Kraigher olof.kraigher@gmail.com
+
 use crate::analysis::DesignRoot;
 use crate::ast::search::{Found, FoundDeclaration, NotFinished, NotFound, SearchState, Searcher};
 use crate::ast::{

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -336,21 +336,14 @@ impl<'a> Searcher for RegionSearcher<'a> {
         match decl {
             FoundDeclaration::Architecture(body) => {
                 for statement in &body.statements {
-                    let span = match &statement.statement.item {
-                        ConcurrentStatement::ProcedureCall(_) => None,
-                        ConcurrentStatement::Block(blk) => Some(blk.get_span(ctx)),
-                        ConcurrentStatement::Process(proc) => Some(proc.get_span(ctx)),
-                        ConcurrentStatement::Assert(_) => None,
-                        ConcurrentStatement::Assignment(_) => None,
-                        ConcurrentStatement::Instance(instance) => Some(instance.get_span(ctx)),
-                        ConcurrentStatement::ForGenerate(for_gen) => Some(for_gen.get_span(ctx)),
-                        ConcurrentStatement::IfGenerate(if_gen) => Some(if_gen.get_span(ctx)),
-                        ConcurrentStatement::CaseGenerate(case_gen) => Some(case_gen.get_span(ctx)),
-                    };
-                    if let Some(span) = span {
-                        if span.contains(self.cursor) {
-                            return Finished(NotFound);
-                        }
+                    let pos = &statement.statement.pos;
+
+                    if pos.start() > self.cursor {
+                        break;
+                    }
+
+                    if pos.contains(self.cursor) {
+                        return Finished(NotFound);
                     }
                 }
                 if ctx

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -375,7 +375,7 @@ impl DesignRoot {
         self.libraries()
             .flat_map(|lib| lib.primary_units())
             .filter(|unit| unit.unit.get().map(|it| it.is_entity()).unwrap_or(false))
-            .filter_map(|unit| unit.unit.get().and_then(|it| it.data().ent_id()))
+            .filter_map(|unit| unit.unit.get().and_then(|it| it.ent_id()))
     }
 }
 

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -338,6 +338,7 @@ impl<'a> Searcher for RegionSearcher<'a> {
                 for statement in &body.statements {
                     let pos = &statement.statement.pos;
 
+                    // Early exit. The cursor is below the current statement.
                     if pos.start() > self.cursor {
                         break;
                     }

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -41,6 +41,7 @@ pub enum CompletionItem<'a> {
     ///     port map (
     ///         -- ...
     ///     );
+    /// ```
     EntityInstantiation(EntRef<'a>),
 }
 
@@ -325,15 +326,15 @@ fn list_available_declarations<'a>(
 
 /// General-purpose Completion Searcher
 /// when no more accurate searcher is available.
-struct RegionSearcher<'a> {
+struct CompletionSearcher<'a> {
     root: &'a DesignRoot,
     cursor: Position,
     completions: Vec<CompletionItem<'a>>,
 }
 
-impl<'a> RegionSearcher<'a> {
-    pub fn new(cursor: Position, design_root: &'a DesignRoot) -> RegionSearcher<'a> {
-        RegionSearcher {
+impl<'a> CompletionSearcher<'a> {
+    pub fn new(cursor: Position, design_root: &'a DesignRoot) -> CompletionSearcher<'a> {
+        CompletionSearcher {
             root: design_root,
             cursor,
             completions: Vec::new(),
@@ -341,7 +342,7 @@ impl<'a> RegionSearcher<'a> {
     }
 }
 
-impl<'a> Searcher for RegionSearcher<'a> {
+impl<'a> Searcher for CompletionSearcher<'a> {
     fn search_decl(&mut self, ctx: &dyn TokenAccess, decl: FoundDeclaration) -> SearchState {
         match decl {
             FoundDeclaration::Architecture(body) => {
@@ -448,7 +449,7 @@ pub fn list_completion_options<'a>(
             searcher.completions
         }
         _ => {
-            let mut searcher = RegionSearcher::new(cursor, root);
+            let mut searcher = CompletionSearcher::new(cursor, root);
             let _ = root.search_source(source, &mut searcher);
             searcher.completions
         }

--- a/vhdl_lang/src/data/source.rs
+++ b/vhdl_lang/src/data/source.rs
@@ -553,6 +553,10 @@ impl SrcPos {
     pub fn contains(&self, pos: Position) -> bool {
         self.range.contains(pos)
     }
+
+    pub fn end_pos(&self) -> SrcPos {
+        SrcPos::new(self.source.clone(), Range::new(self.end(), self.end()))
+    }
 }
 
 /// Denotes an item with an associated source file.

--- a/vhdl_lang/src/lib.rs
+++ b/vhdl_lang/src/lib.rs
@@ -30,8 +30,8 @@ pub use crate::data::{
 
 pub use crate::analysis::EntHierarchy;
 pub use crate::named_entity::{
-    AnyEnt, AnyEntKind, Concurrent, Design, EntRef, EntityId, HasEntityId, Object, Overloaded,
-    Reference, Related, Sequential, Type,
+    AnyEnt, AnyEntKind, Concurrent, Design, EntRef, EntityId, HasEntityId, InterfaceEnt, Object,
+    Overloaded, Reference, Related, Sequential, Type,
 };
 
 pub use crate::project::{Project, SourceFile};

--- a/vhdl_lang/src/named_entity/region.rs
+++ b/vhdl_lang/src/named_entity/region.rs
@@ -8,7 +8,6 @@ use super::*;
 use crate::ast::*;
 use crate::named_entity::overloaded::SubprogramKey;
 use fnv::FnvHashMap;
-use itertools::Itertools;
 use std::collections::hash_map::Entry;
 
 #[derive(Clone)]
@@ -214,30 +213,6 @@ impl<'a> Region<'a> {
                 }
             })
             .filter(|ent| ent.is_explicit())
-    }
-
-    pub fn ports(&self) -> impl Iterator<Item = InterfaceEnt> + '_ {
-        self.entities
-            .values()
-            .filter_map(|ent| match ent {
-                NamedEntities::Single(ent) => {
-                    InterfaceEnt::from_any(ent).filter(|&ent| ent.is_signal())
-                }
-                _ => None,
-            })
-            .sorted_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start))
-    }
-
-    pub fn generics(&self) -> impl Iterator<Item = InterfaceEnt> + '_ {
-        self.entities
-            .values()
-            .filter_map(|ent| match ent {
-                NamedEntities::Single(ent) => {
-                    InterfaceEnt::from_any(ent).filter(|&ent| !ent.is_signal())
-                }
-                _ => None,
-            })
-            .sorted_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start))
     }
 }
 

--- a/vhdl_lang/src/named_entity/region.rs
+++ b/vhdl_lang/src/named_entity/region.rs
@@ -8,6 +8,7 @@ use super::*;
 use crate::ast::*;
 use crate::named_entity::overloaded::SubprogramKey;
 use fnv::FnvHashMap;
+use itertools::Itertools;
 use std::collections::hash_map::Entry;
 
 #[derive(Clone)]
@@ -41,6 +42,14 @@ impl<'a> Region<'a> {
     }
 
     pub(crate) fn to_entity_formal(&self) -> (FormalRegion<'a>, FormalRegion<'a>) {
+        let (ports, generics) = self.ports_and_generics();
+        (
+            FormalRegion::new_with(InterfaceType::Generic, generics),
+            FormalRegion::new_with(InterfaceType::Port, ports),
+        )
+    }
+
+    pub fn ports_and_generics(&self) -> (Vec<InterfaceEnt<'a>>, Vec<InterfaceEnt<'a>>) {
         // @TODO separate generics and ports
         let mut generics = Vec::with_capacity(self.entities.len());
         let mut ports = Vec::with_capacity(self.entities.len());
@@ -59,10 +68,7 @@ impl<'a> Region<'a> {
         // Sorting by source file position gives declaration order
         generics.sort_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start));
         ports.sort_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start));
-        (
-            FormalRegion::new_with(InterfaceType::Generic, generics),
-            FormalRegion::new_with(InterfaceType::Port, ports),
-        )
+        (ports, generics)
     }
 
     pub(crate) fn to_package_generic(&self) -> (GpkgRegion<'a>, Vec<EntRef<'a>>) {
@@ -208,6 +214,30 @@ impl<'a> Region<'a> {
                 }
             })
             .filter(|ent| ent.is_explicit())
+    }
+
+    pub fn ports(&self) -> impl Iterator<Item = InterfaceEnt> + '_ {
+        self.entities
+            .values()
+            .filter_map(|ent| match ent {
+                NamedEntities::Single(ent) => {
+                    InterfaceEnt::from_any(ent).filter(|&ent| ent.is_signal())
+                }
+                _ => None,
+            })
+            .sorted_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start))
+    }
+
+    pub fn generics(&self) -> impl Iterator<Item = InterfaceEnt> + '_ {
+        self.entities
+            .values()
+            .filter_map(|ent| match ent {
+                NamedEntities::Single(ent) => {
+                    InterfaceEnt::from_any(ent).filter(|&ent| !ent.is_signal())
+                }
+                _ => None,
+            })
+            .sorted_by_key(|ent| ent.decl_pos().map(|pos| pos.range().start))
     }
 }
 

--- a/vhdl_lang/src/named_entity/visibility.rs
+++ b/vhdl_lang/src/named_entity/visibility.rs
@@ -48,10 +48,6 @@ pub struct Visibility<'a> {
 }
 
 impl<'a> Visibility<'a> {
-    pub fn entities(&self) -> impl Iterator<Item = &EntityId> {
-        self.visible.values().flat_map(|map| map.keys())
-    }
-
     pub fn make_all_potentially_visible(
         &mut self,
         visible_pos: Option<&SrcPos>,

--- a/vhdl_lang/src/named_entity/visibility.rs
+++ b/vhdl_lang/src/named_entity/visibility.rs
@@ -59,6 +59,10 @@ impl<'a> Visibility<'a> {
         });
     }
 
+    pub fn visible(&self) -> impl Iterator<Item = EntRef<'a>> + '_ {
+        self.visible.values().flatten().map(|entry| entry.1.entity)
+    }
+
     pub fn add_context_visibility(
         &mut self,
         visible_pos: Option<&SrcPos>,

--- a/vhdl_lang/src/named_entity/visibility.rs
+++ b/vhdl_lang/src/named_entity/visibility.rs
@@ -48,6 +48,10 @@ pub struct Visibility<'a> {
 }
 
 impl<'a> Visibility<'a> {
+    pub fn entities(&self) -> impl Iterator<Item = &EntityId> {
+        self.visible.values().flat_map(|map| map.keys())
+    }
+
     pub fn make_all_potentially_visible(
         &mut self,
         visible_pos: Option<&SrcPos>,

--- a/vhdl_lang/src/syntax/concurrent_statement.rs
+++ b/vhdl_lang/src/syntax/concurrent_statement.rs
@@ -679,9 +679,18 @@ pub fn parse_labeled_concurrent_statements(
             End | Elsif | Else | When => {
                 break Ok(statements);
             }
-            _ => {
-                statements.push(parse_labeled_concurrent_statement(stream, diagnostics)?);
-            }
+            _ => match parse_labeled_concurrent_statement(stream, diagnostics) {
+                Ok(stmt) => {
+                    statements.push(stmt);
+                }
+                Err(diagnostic) => {
+                    diagnostics.push(diagnostic);
+                    stream.skip_until(|kind| {
+                        matches!(kind, SemiColon | End | Process | Block | Assert)
+                    })?;
+                    stream.pop_if_kind(SemiColon);
+                }
+            },
         }
     }
 }

--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -284,6 +284,7 @@ pub fn parse_design_file(
 mod tests {
     use super::*;
     use itertools::Itertools;
+    use vhdl_lang::TokenId;
 
     use crate::data::Diagnostic;
     use crate::syntax::test::{check_diagnostics, check_no_diagnostics, Code};
@@ -618,12 +619,14 @@ end;
         ident: WithDecl<Ident>,
         entity_name: Ident,
         span: TokenSpan,
+        begin_token: TokenId,
         end_ident_pos: Option<SrcPos>,
     ) -> AnyDesignUnit {
         AnyDesignUnit::Secondary(AnySecondaryUnit::Architecture(ArchitectureBody {
             span,
             context_clause: ContextClause::default(),
             ident,
+            begin_token,
             entity_name: entity_name.into_ref(),
             decl: Vec::new(),
             statements: vec![],
@@ -648,6 +651,7 @@ end architecture;
                     WithDecl::new(code.s1("arch_name").ident()),
                     code.s1("myent").ident(),
                     code.token_span(),
+                    code.s1("begin").token(),
                     None,
                 )
             )]
@@ -671,6 +675,7 @@ end architecture arch_name;
                     WithDecl::new(code.s1("arch_name").ident()),
                     code.s1("myent").ident(),
                     code.token_span(),
+                    code.s1("begin").token(),
                     Some(code.s("arch_name", 2).pos()),
                 )
             )]
@@ -694,6 +699,7 @@ end;
                     WithDecl::new(code.s1("arch_name").ident()),
                     code.s1("myent").ident(),
                     code.token_span(),
+                    code.s1("begin").token(),
                     None,
                 )
             )]

--- a/vhdl_lang/src/syntax/design_unit.rs
+++ b/vhdl_lang/src/syntax/design_unit.rs
@@ -68,7 +68,7 @@ pub fn parse_architecture_body(
     stream.expect_kind(Is)?;
 
     let decl = parse_declarative_part(stream, diagnostics)?;
-    stream.expect_kind(Begin)?;
+    let begin_token = stream.expect_kind(Begin)?;
 
     let statements = parse_labeled_concurrent_statements(stream, diagnostics)?;
     stream.expect_kind(End)?;
@@ -81,6 +81,7 @@ pub fn parse_architecture_body(
         span: TokenSpan::new(start_token, end_token),
         context_clause: ContextClause::default(),
         end_ident_pos: check_end_identifier_mismatch(&ident.tree, end_ident, diagnostics),
+        begin_token,
         ident,
         entity_name: entity_name.into_ref(),
         decl,

--- a/vhdl_lang/src/syntax/tokens/tokenizer.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenizer.rs
@@ -538,6 +538,10 @@ pub trait HasTokenSpan {
 
     fn get_token_slice<'a>(&self, tokens: &'a dyn TokenAccess) -> &'a [Token];
     fn get_pos(&self, tokens: &dyn TokenAccess) -> SrcPos;
+
+    fn get_span(&self, ctx: &dyn TokenAccess) -> SrcPos {
+        ctx.get_span(self.get_start_token(), self.get_end_token())
+    }
 }
 
 /// Holds token information about an AST element.

--- a/vhdl_lang/src/syntax/tokens/tokenizer.rs
+++ b/vhdl_lang/src/syntax/tokens/tokenizer.rs
@@ -467,7 +467,7 @@ pub struct Token {
 /// A TokenId represents a unique value that is used to access a token.
 /// A token ID cannot be created directly by the user. Instead, the value must be taken
 /// from the AST.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Ord, PartialOrd)]
 pub struct TokenId(usize);
 
 /// The TokenId represents an index into an array of tokens.
@@ -568,6 +568,20 @@ impl TokenSpan {
         TokenSpan {
             start_token: self.start_token.apply_offset(offset),
             end_token: self.end_token.apply_offset(offset),
+        }
+    }
+
+    /// Skips the stream to the token given by the offset
+    #[cfg(test)]
+    pub fn skip_to(&self, offset: TokenId) -> TokenSpan {
+        let new_token = TokenId(self.start_token.0 + offset.0);
+        debug_assert!(
+            new_token <= self.end_token,
+            "[TokenSpan::skip_to] skipping past end of the span"
+        );
+        TokenSpan {
+            start_token: new_token,
+            end_token: self.end_token,
         }
     }
 }

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -15,8 +15,9 @@ use crate::rpc_channel::SharedRpcChannel;
 use std::io;
 use std::path::{Path, PathBuf};
 use vhdl_lang::{
-    kind_str, AnyEntKind, Concurrent, Config, Diagnostic, EntHierarchy, EntRef, EntityId, Message,
-    MessageHandler, Object, Overloaded, Project, Severity, Source, SrcPos, Type,
+    kind_str, AnyEntKind, Concurrent, Config, Design, Diagnostic, EntHierarchy, EntRef, EntityId,
+    InterfaceEnt, Message, MessageHandler, Object, Overloaded, Project, Severity, Source, SrcPos,
+    Type,
 };
 
 #[derive(Default, Clone)]
@@ -294,6 +295,52 @@ impl VHDLServer {
                 kind: Some(CompletionItemKind::KEYWORD),
                 ..Default::default()
             },
+            vhdl_lang::CompletionItem::EntityInstantiation(ent) => {
+                let region = match ent.kind() {
+                    AnyEntKind::Design(Design::Entity(_, region)) => region,
+                    _ => return entity_to_completion_item(ent),
+                };
+                let template = if self.client_supports_snippets() {
+                    let mut line = format!(
+                        "${{1:{}_inst}}: entity {}.{}",
+                        ent.designator, "work", ent.designator
+                    );
+                    let (ports, generics) = region.ports_and_generics();
+                    let mut idx = 2;
+                    let mut interface_ent = |elements: Vec<InterfaceEnt>, purpose: &str| {
+                        line += &*format!("\n {} map(\n", purpose);
+                        for (i, generic) in elements.iter().enumerate() {
+                            line += &*format!(
+                                "    {} => ${{{}:{}}}",
+                                generic.designator, idx, generic.designator
+                            );
+                            idx += 1;
+                            if i != elements.len() - 1 {
+                                line += ","
+                            }
+                            line += "\n";
+                        }
+                        line += ")";
+                    };
+                    if !generics.is_empty() {
+                        interface_ent(generics, "generic");
+                    }
+                    if !ports.is_empty() {
+                        interface_ent(ports, "port");
+                    }
+                    line += ";";
+                    line
+                } else {
+                    format!("{}", ent.designator)
+                };
+                CompletionItem {
+                    label: format!("{} instantiation", ent.designator),
+                    insert_text: Some(template),
+                    insert_text_format: Some(InsertTextFormat::SNIPPET),
+                    kind: Some(CompletionItemKind::MODULE),
+                    ..Default::default()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Towards #164 

Unsure whether this closes 164, but this is a big steps towards it. This PR implements entity completion. What's still missing is

- showing components for instantiation
- ~enabling completing components and entities from other libraries (currently, everything is completed using the `work` library)~
- ~Limiting the scope. Currently, all visible entities are brought into scope~

There are also some other changes here (like adding the `TokenSpan` attributes to some statements) that I implemented but no longer need. However, these changes are beneficial anyway so I kept them. Hope this doesn't blow up the PR too much.

In theory, this PR is ready for review but I'll still keep it as draft since I want to add a couple of tests and comments.
Happy to receive feedback from anyone concerning the concrete form of completion.
