### PR TITLE
 Return \n to end of line in case it's deleted

### DIFF
--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -115,9 +115,8 @@ impl Contents {
             }
         }
 
-        // New line should always be at the end of line, in case
-        // it's deleted by accident somehow, return it back.
-        if merged_content.chars().last().unwrap_or('\0') != '\n' {
+        let last_line_index = self.lines.len() - 1;
+        if (end.line as usize) < last_line_index && merged_content.chars().last().unwrap_or('\0') != '\n' {
             merged_content.push('\n');
         }
 

--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -543,6 +543,17 @@ mod tests {
     }
 
     #[test]
+    fn change_past_end_of_line() {
+        let mut contents = new("hello\nworld");
+        assert_eq!(flatten(&contents), "hello\nworld");
+        contents.change(&Range::new(Position::new(0, 3), Position::new(0, 7)), "");
+        assert_eq!(flatten(&contents), "hel\nworld");
+        assert_eq!(contents.num_lines(), 2);
+        assert_eq!(contents.get_line(0).unwrap().to_string(), "hel\n");
+        assert_eq!(contents.get_line(1).unwrap().to_string(), "world");
+    }
+
+    #[test]
     fn change_to_more_lines() {
         let mut contents = new("hello\nworld");
         assert_eq!(flatten(&contents), "hello\nworld");

--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -116,7 +116,9 @@ impl Contents {
         }
 
         let last_line_index = self.lines.len() - 1;
-        if (end.line as usize) < last_line_index && merged_content.chars().last().unwrap_or('\0') != '\n' {
+        if (end.line as usize) < last_line_index
+            && merged_content.chars().last().unwrap_or('\0') != '\n'
+        {
             merged_content.push('\n');
         }
 

--- a/vhdl_lang/src/data/contents.rs
+++ b/vhdl_lang/src/data/contents.rs
@@ -115,6 +115,12 @@ impl Contents {
             }
         }
 
+        // New line should always be at the end of line, in case
+        // it's deleted by accident somehow, return it back.
+        if merged_content.chars().last().unwrap_or('\0') != '\n' {
+            merged_content.push('\n');
+        }
+
         let end_line = std::cmp::min(self.lines.len().saturating_sub(1), end_line);
         self.lines
             .splice(start_line..=end_line, split_lines(&merged_content))


### PR DESCRIPTION
Hello, it's been quite some time. I am _reopening_ (creating a new one instead since it seems I don't have permission to reopen PRs here) #197.

One possible way to resolve https://github.com/VHDL-LS/rust_hdl/issues/193.

lsp-mode in emacs sometimes tries to edit something past end of line if other conditions are met. Specifically, the template system coming with vhdl-mode seems to trigger this behavior. This removes \n from one of the lines, making rust_hdl contents and actual file contents different.

I have added a unit test to go past the end of line. It indeed fails without the lines I added, and works with them. I also found a bug in my code thanks to running the unit tests. The last line had \n added as well, although it shouldn't. I added a condition for that.

If you know of a better way to handle this, let me know, I could try to implement that instead. I am not very knowledgeable of rust_hdl codebase, so there might be some obvious oversights.