### PR TITLE
Check the interface mode of a subprograms interface list

### DIFF
--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -42,7 +42,8 @@ pub use region::{AsUnique, NamedEntities, OverloadedName, Region, SetReference};
 
 mod formal_region;
 pub use formal_region::{
-    FormalRegion, GpkgInterfaceEnt, GpkgRegion, InterfaceEnt, RecordElement, RecordRegion,
+    FormalRegion, GpkgInterfaceEnt, GpkgRegion, InterfaceClass, InterfaceEnt, RecordElement,
+    RecordRegion,
 };
 
 pub enum AnyEntKind<'a> {


### PR DESCRIPTION
In VHDL, when a subprogram is declared with a parameter list that is not `constant` (i.e., the implicit default), the actual part must be a name denoting that subprogram. So, for example, a procedure `proc` that is defined as follows:
```vhdl
procedure proc(signal foo: foo_type; variable bar: bar_type);
```

can only be called using
```vhdl
proc(actual_foo, actual_bar);
```

where `actual_foo` denotes a signal and `actual_bar` denotes a variable or shared variable. This PR adds checks for this behaviour.

Relevant LRM section: 4.2.2.1