### PR TITLE
Change the error message when the error is something other than NotFound

### DIFF
--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -1113,6 +1113,10 @@ mod tests {
         );
     }
 
+    fn expect_erroneous_config(mock: &RpcMock) {
+        mock.expect_error_contains("Error loading vhdl_ls.toml");
+    }
+
     /// Create RpcMock and VHDLServer
     fn setup_server() -> (Rc<RpcMock>, VHDLServer) {
         let mock = Rc::new(RpcMock::new());
@@ -1312,7 +1316,7 @@ lib.files = [
 ",
         );
 
-        expect_missing_config_messages(&mock);
+        expect_erroneous_config(&mock);
         initialize_server(&mut server, root_uri);
     }
 

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -13,6 +13,7 @@ use vhdl_lang::ast::{Designator, ObjectClass};
 
 use crate::rpc_channel::SharedRpcChannel;
 use std::io;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use vhdl_lang::{
     kind_str, AnyEntKind, Concurrent, Config, Design, Diagnostic, EntHierarchy, EntRef, EntityId,
@@ -96,12 +97,16 @@ impl VHDLServer {
                 config.append(&root_config, &mut self.message_filter());
             }
             Err(ref err) => {
-                self.message(Message::error(format!(
-                    "Library mapping is unknown due to missing vhdl_ls.toml config file in the workspace root path: {err}"
-                )));
-                self.message(Message::warning(
-                    "Without library mapping semantic analysis might be incorrect",
-                ));
+                if matches!(err.kind(), ErrorKind::NotFound) {
+                    self.message(Message::error(format!(
+                        "Library mapping is unknown due to missing vhdl_ls.toml config file in the workspace root path: {err}"
+                    )));
+                    self.message(Message::warning(
+                        "Without library mapping semantic analysis might be incorrect",
+                    ));
+                } else {
+                    self.message(Message::error(format!("Error loading vhdl_ls.toml: {err}")));
+                }
             }
         };
 


### PR DESCRIPTION
At the moment, when there is an error with the `vhdl_ls.toml` config file (e.g., the file is bad formatted or there is the `work` library name present), the language server will show something like "Library mapping is unknown due to missing vhdl_ls.toml config file ...".
This error message makes it seem like there is no `vhdl_ls.toml` file present eve though there is. I hope to add a better description of when something is wrong with the file which is not related to the file being missing with this PR.