### PR TITLE
feat: search standard libs in `../share/`

### DIFF
--- a/vhdl_lang/src/config.rs
+++ b/vhdl_lang/src/config.rs
@@ -205,6 +205,7 @@ impl Config {
             "../vhdl_libraries",
             "../../vhdl_libraries",
             "/usr/lib/rust_hdl/vhdl_libraries",
+            "../share/vhdl_libraries"
         ];
 
         for dir in search_paths.into_iter() {


### PR DESCRIPTION
Quick fix to support local installations, first and foremost [Mason](https://github.com/williamboman/mason.nvim)
There's a relevant issue open on their registry repo: https://github.com/mason-org/mason-registry/issues/3615

I added `../share/vhdl_libraries` for now, but I can also imagine adding an environment variable as well, if that'd be useful.