### PR TITLE
Remove analysis result

### DIFF
--- a/vhdl_lang/src/analysis/analyze.rs
+++ b/vhdl_lang/src/analysis/analyze.rs
@@ -64,20 +64,6 @@ pub fn catch_diagnostic<T>(
     }
 }
 
-pub fn catch_analysis_err<T>(
-    res: AnalysisResult<T>,
-    diagnostics: &mut dyn DiagnosticHandler,
-) -> EvalResult<T> {
-    match res {
-        Ok(val) => Ok(val),
-        Err(AnalysisError::Fatal(err)) => Err(EvalError::Circular(err)),
-        Err(AnalysisError::NotFatal(diag)) => {
-            diagnostics.push(diag);
-            Err(EvalError::Unknown)
-        }
-    }
-}
-
 /// Pushes the diagnostic to the provided handler and returns
 /// with an `EvalError::Unknown` result.
 ///

--- a/vhdl_lang/src/analysis/analyze.rs
+++ b/vhdl_lang/src/analysis/analyze.rs
@@ -40,7 +40,6 @@ impl CircularDependencyError {
     }
 }
 
-pub type AnalysisResult<T> = Result<T, AnalysisError>;
 pub type FatalResult<T = ()> = Result<T, CircularDependencyError>;
 
 pub fn as_fatal<T>(res: EvalResult<T>) -> FatalResult<Option<T>> {
@@ -118,15 +117,6 @@ impl<T> IntoEvalResult<T> for Result<T, Diagnostic> {
             Err(diagnostic) => {
                 bail!(diagnostics, diagnostic);
             }
-        }
-    }
-}
-
-impl AnalysisError {
-    pub fn into_non_fatal(self) -> FatalResult<Diagnostic> {
-        match self {
-            AnalysisError::Fatal(err) => Err(err),
-            AnalysisError::NotFatal(diag) => Ok(diag),
         }
     }
 }

--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -278,18 +278,14 @@ impl<'a> AnalyzeContext<'a> {
                             if let Designator::Identifier(entity_ident) = ent.designator() {
                                 if let Some(library_name) = ent.library_name() {
                                     if let Some(ref mut architecture_name) = architecture_name {
-                                        match self.get_architecture(
+                                        if let Some(arch) = as_fatal(self.get_architecture(
+                                            diagnostics,
                                             library_name,
                                             &architecture_name.item.pos,
                                             entity_ident,
                                             &architecture_name.item.item,
-                                        ) {
-                                            Ok(arch) => {
-                                                architecture_name.set_unique_reference(&arch);
-                                            }
-                                            Err(err) => {
-                                                diagnostics.push(err.into_non_fatal()?);
-                                            }
+                                        ))? {
+                                            architecture_name.set_unique_reference(&arch);
                                         }
                                     }
                                 }

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -632,7 +632,7 @@ impl<'a> AnalyzeContext<'a> {
         Ok(())
     }
 
-    /// Returns a reference to the the uninstantiated package
+    /// Returns a reference to the uninstantiated package
     pub fn analyze_package_instance_name(
         &self,
         scope: &Scope<'a>,

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -223,16 +223,14 @@ impl<'a> AnalyzeContext<'a> {
         unit: &mut ArchitectureBody,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalResult {
-        let primary = match self.lookup_in_library(
+        let Some(primary) = as_fatal(self.lookup_in_library(
+            diagnostics,
             self.work_library_name(),
             &unit.entity_name.item.pos,
             &Designator::Identifier(unit.entity_name.item.item.clone()),
-        ) {
-            Ok(primary) => primary,
-            Err(err) => {
-                diagnostics.push(err.into_non_fatal()?);
-                return Ok(());
-            }
+        ))?
+        else {
+            return Ok(());
         };
         unit.entity_name.set_unique_reference(primary.into());
         self.check_secondary_before_primary(&primary, unit.pos(), diagnostics);
@@ -278,16 +276,14 @@ impl<'a> AnalyzeContext<'a> {
         unit: &mut PackageBody,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalResult {
-        let primary = match self.lookup_in_library(
+        let Some(primary) = as_fatal(self.lookup_in_library(
+            diagnostics,
             self.work_library_name(),
             &unit.ident.tree.pos,
             &Designator::Identifier(unit.ident.tree.item.clone()),
-        ) {
-            Ok(primary) => primary,
-            Err(err) => {
-                diagnostics.push(err.into_non_fatal()?);
-                return Ok(());
-            }
+        ))?
+        else {
+            return Ok(());
         };
 
         let (visibility, region) = match primary.kind() {
@@ -363,14 +359,17 @@ impl<'a> AnalyzeContext<'a> {
         match ent_name.item {
             // Entitities are implicitly defined for configurations
             // configuration cfg of ent
-            Name::Designator(ref mut designator) => Ok(catch_analysis_err(
-                self.lookup_in_library(self.work_library_name(), &ent_name.pos, &designator.item)
-                    .map(|design| {
-                        designator.reference.set_unique_reference(design.into());
-                        design
-                    }),
-                diagnostics,
-            )?),
+            Name::Designator(ref mut designator) => Ok(self
+                .lookup_in_library(
+                    diagnostics,
+                    self.work_library_name(),
+                    &ent_name.pos,
+                    &designator.item,
+                )
+                .map(|design| {
+                    designator.reference.set_unique_reference(design.into());
+                    design
+                })?),
 
             // configuration cfg of lib.ent
             Name::Selected(ref mut prefix, ref mut designator) => {
@@ -383,13 +382,11 @@ impl<'a> AnalyzeContext<'a> {
                                 format!("Configuration must be within the same library '{}' as the corresponding entity", self.work_library_name()));
                             Err(EvalError::Unknown)
                         } else {
-                            let primary_ent = catch_analysis_err(
-                                self.lookup_in_library(
-                                    library_name,
-                                    &designator.pos,
-                                    &designator.item.item,
-                                ),
+                            let primary_ent = self.lookup_in_library(
                                 diagnostics,
+                                library_name,
+                                &designator.pos,
+                                &designator.item.item,
                             )?;
                             designator
                                 .item
@@ -425,40 +422,52 @@ impl<'a> AnalyzeContext<'a> {
 
     fn resolve_context_item_prefix(
         &self,
+        diagnostics: &mut dyn DiagnosticHandler,
         scope: &Scope<'a>,
         prefix: &mut WithPos<Name>,
-    ) -> AnalysisResult<EntRef<'a>> {
-        match self.resolve_context_item_name(scope, prefix)? {
-            UsedNames::Single(visible) => visible.into_non_overloaded().map_err(|_| {
-                AnalysisError::not_fatal_error(&prefix, "Invalid prefix of a selected name")
-            }),
-            UsedNames::AllWithin(..) => Err(AnalysisError::not_fatal_error(
-                &prefix,
-                "'.all' may not be the prefix of a selected name",
-            )),
+    ) -> EvalResult<EntRef<'a>> {
+        match self.resolve_context_item_name(diagnostics, scope, prefix)? {
+            UsedNames::Single(visible) => match visible.into_non_overloaded() {
+                Ok(ent_ref) => Ok(ent_ref),
+                Err(_) => {
+                    bail!(
+                        diagnostics,
+                        Diagnostic::error(&prefix, "Invalid prefix of a selected name")
+                    );
+                }
+            },
+            UsedNames::AllWithin(..) => {
+                bail!(
+                    diagnostics,
+                    Diagnostic::error(&prefix, "'.all' may not be the prefix of a selected name",)
+                );
+            }
         }
     }
 
     fn resolve_context_item_name(
         &self,
+        diagnostics: &mut dyn DiagnosticHandler,
         scope: &Scope<'a>,
         name: &mut WithPos<Name>,
-    ) -> AnalysisResult<UsedNames<'a>> {
+    ) -> EvalResult<UsedNames<'a>> {
         match &mut name.item {
             Name::Selected(ref mut prefix, ref mut suffix) => {
-                let prefix_ent = self.resolve_context_item_prefix(scope, prefix)?;
+                let prefix_ent = self.resolve_context_item_prefix(diagnostics, scope, prefix)?;
 
-                let visible = self.lookup_selected(&prefix.pos, prefix_ent, suffix)?;
+                let visible = self.lookup_selected(diagnostics, &prefix.pos, prefix_ent, suffix)?;
                 suffix.set_reference(&visible);
                 Ok(UsedNames::Single(visible))
             }
 
             Name::SelectedAll(prefix) => {
-                let prefix_ent = self.resolve_context_item_prefix(scope, prefix)?;
+                let prefix_ent = self.resolve_context_item_prefix(diagnostics, scope, prefix)?;
                 Ok(UsedNames::AllWithin(prefix.pos.clone(), prefix_ent))
             }
             Name::Designator(designator) => {
-                let visible = scope.lookup(&name.pos, designator.designator())?;
+                let visible = scope
+                    .lookup(&name.pos, designator.designator())
+                    .into_eval_result(diagnostics)?;
                 designator.set_reference(&visible);
                 Ok(UsedNames::Single(visible))
             }
@@ -466,10 +475,12 @@ impl<'a> AnalyzeContext<'a> {
             Name::Slice(..)
             | Name::Attribute(..)
             | Name::CallOrIndexed(..)
-            | Name::External(..) => Err(AnalysisError::not_fatal_error(
-                &name.pos,
-                "Invalid selected name",
-            )),
+            | Name::External(..) => {
+                bail!(
+                    diagnostics,
+                    Diagnostic::error(&name.pos, "Invalid selected name",)
+                );
+            }
         }
     }
 
@@ -520,8 +531,14 @@ impl<'a> AnalyzeContext<'a> {
                             }
                         }
 
-                        match self.resolve_context_item_name(scope, name) {
-                            Ok(UsedNames::Single(visible)) => {
+                        let Some(context_item) =
+                            as_fatal(self.resolve_context_item_name(diagnostics, scope, name))?
+                        else {
+                            continue;
+                        };
+
+                        match context_item {
+                            UsedNames::Single(visible) => {
                                 let ent = visible.first();
                                 match ent.kind() {
                                     // OK
@@ -544,11 +561,8 @@ impl<'a> AnalyzeContext<'a> {
                                     }
                                 }
                             }
-                            Ok(UsedNames::AllWithin(..)) => {
+                            UsedNames::AllWithin(..) => {
                                 // Handled above
-                            }
-                            Err(err) => {
-                                err.add_to(diagnostics)?;
                             }
                         }
                     }
@@ -578,41 +592,40 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
 
-            match self.resolve_context_item_name(scope, name) {
-                Ok(UsedNames::Single(visible)) => {
+            let Some(context_item) =
+                as_fatal(self.resolve_context_item_name(diagnostics, scope, name))?
+            else {
+                continue;
+            };
+            match context_item {
+                UsedNames::Single(visible) => {
                     visible.make_potentially_visible_in(Some(&name.pos), scope);
                 }
-                Ok(UsedNames::AllWithin(visibility_pos, named_entity)) => {
-                    match named_entity.kind() {
-                        AnyEntKind::Library => {
-                            let library_name = named_entity.designator().expect_identifier();
-                            self.use_all_in_library(&name.pos, library_name, scope)?;
+                UsedNames::AllWithin(visibility_pos, named_entity) => match named_entity.kind() {
+                    AnyEntKind::Library => {
+                        let library_name = named_entity.designator().expect_identifier();
+                        self.use_all_in_library(&name.pos, library_name, scope)?;
+                    }
+                    AnyEntKind::Design(design) => match design {
+                        Design::UninstPackage(..) => {
+                            diagnostics.push(Diagnostic::invalid_selected_name_prefix(
+                                named_entity,
+                                &visibility_pos,
+                            ));
                         }
-                        AnyEntKind::Design(design) => match design {
-                            Design::UninstPackage(..) => {
-                                diagnostics.push(Diagnostic::invalid_selected_name_prefix(
-                                    named_entity,
-                                    &visibility_pos,
-                                ));
-                            }
-                            Design::Package(_, ref primary_region)
-                            | Design::PackageInstance(ref primary_region) => {
-                                scope.make_all_potentially_visible(Some(&name.pos), primary_region);
-                            }
-                            _ => {
-                                diagnostics
-                                    .error(visibility_pos, "Invalid prefix for selected name");
-                            }
-                        },
-
+                        Design::Package(_, ref primary_region)
+                        | Design::PackageInstance(ref primary_region) => {
+                            scope.make_all_potentially_visible(Some(&name.pos), primary_region);
+                        }
                         _ => {
                             diagnostics.error(visibility_pos, "Invalid prefix for selected name");
                         }
+                    },
+
+                    _ => {
+                        diagnostics.error(visibility_pos, "Invalid prefix for selected name");
                     }
-                }
-                Err(err) => {
-                    err.add_to(diagnostics)?;
-                }
+                },
             }
         }
 

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -241,23 +241,29 @@ impl<'a> AnalyzeContext<'a> {
 
     pub fn lookup_operator(
         &self,
+        diagnostics: &mut dyn DiagnosticHandler,
         scope: &Scope<'a>,
         op_pos: &SrcPos,
         op: Operator,
         arity: usize,
-    ) -> AnalysisResult<Vec<OverloadedEnt<'a>>> {
+    ) -> EvalResult<Vec<OverloadedEnt<'a>>> {
         let designator = Designator::OperatorSymbol(op);
-        match scope.lookup(op_pos, &designator)? {
+        match scope
+            .lookup(op_pos, &designator)
+            .into_eval_result(diagnostics)?
+        {
             NamedEntities::Single(ent) => {
                 // Should never happen but better know if it does
-                Err(Diagnostic::error(
-                    op_pos,
-                    format!(
-                        "Operator symbol cannot denote non-overloaded symbol {}",
-                        ent.describe(),
-                    ),
-                )
-                .into())
+                bail!(
+                    diagnostics,
+                    Diagnostic::error(
+                        op_pos,
+                        format!(
+                            "Operator symbol cannot denote non-overloaded symbol {}",
+                            ent.describe(),
+                        ),
+                    )
+                );
             }
             NamedEntities::Overloaded(overloaded) => {
                 // Candidates that match arity of operator
@@ -267,11 +273,13 @@ impl<'a> AnalyzeContext<'a> {
                     .collect();
 
                 if op_candidates.is_empty() {
-                    Err(Diagnostic::error(
-                        op_pos,
-                        format!("Found no match for {}", designator.describe()),
-                    )
-                    .into())
+                    bail!(
+                        diagnostics,
+                        Diagnostic::error(
+                            op_pos,
+                            format!("Found no match for {}", designator.describe()),
+                        )
+                    );
                 } else {
                     Ok(op_candidates)
                 }
@@ -425,13 +433,8 @@ impl<'a> AnalyzeContext<'a> {
         exprs: &mut [&mut WithPos<Expression>],
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<ExpressionType<'a>> {
-        let op_candidates = match self.lookup_operator(scope, &op.pos, op.item.item, exprs.len()) {
-            Ok(candidates) => candidates,
-            Err(err) => {
-                diagnostics.push(err.into_non_fatal()?);
-                return Err(EvalError::Unknown);
-            }
-        };
+        let op_candidates =
+            self.lookup_operator(diagnostics, scope, &op.pos, op.item.item, exprs.len())?;
 
         match self.disambiguate_op(scope, None, op, op_candidates, exprs, diagnostics)? {
             Disambiguated::Unambiguous(overloaded) => Ok(ExpressionType::Unambiguous(
@@ -745,12 +748,15 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             Expression::Binary(ref mut op, ref mut left, ref mut right) => {
-                let op_candidates = match self.lookup_operator(scope, &op.pos, op.item.item, 2) {
-                    Ok(candidates) => candidates,
-                    Err(err) => {
-                        diagnostics.push(err.into_non_fatal()?);
-                        return Ok(());
-                    }
+                let op_candidates = match as_fatal(self.lookup_operator(
+                    diagnostics,
+                    scope,
+                    &op.pos,
+                    op.item.item,
+                    2,
+                ))? {
+                    Some(candidates) => candidates,
+                    None => return Ok(()),
                 };
 
                 match as_fatal(self.disambiguate_op(
@@ -783,10 +789,15 @@ impl<'a> AnalyzeContext<'a> {
                 }
             }
             Expression::Unary(ref mut op, ref mut expr) => {
-                let op_candidates = match self.lookup_operator(scope, &op.pos, op.item.item, 1) {
-                    Ok(candidates) => candidates,
-                    Err(err) => {
-                        diagnostics.push(err.into_non_fatal()?);
+                let op_candidates = match as_fatal(self.lookup_operator(
+                    diagnostics,
+                    scope,
+                    &op.pos,
+                    op.item.item,
+                    1,
+                ))? {
+                    Some(candidates) => candidates,
+                    None => {
                         return Ok(());
                     }
                 };

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -1110,8 +1110,8 @@ impl<'a> AnalyzeContext<'a> {
                                 &choice.pos,
                                 index_expr,
                                 diagnostics,
-                            ) {
-                                Ok(Some(typ)) => {
+                            )? {
+                                Some(typ) => {
                                     if let Some(index_type) = index_type {
                                         if !self.can_be_target_type(typ, index_type) {
                                             diagnostics.push(Diagnostic::type_mismatch(
@@ -1124,7 +1124,7 @@ impl<'a> AnalyzeContext<'a> {
 
                                     can_be_array = true;
                                 }
-                                Ok(None) => {
+                                None => {
                                     if let Some(index_type) = index_type {
                                         self.expr_pos_with_ttyp(
                                             scope,
@@ -1135,10 +1135,6 @@ impl<'a> AnalyzeContext<'a> {
                                         )?;
                                     }
                                     can_be_array = false;
-                                }
-                                Err(err) => {
-                                    diagnostics.push(err.into_non_fatal()?);
-                                    return Ok(());
                                 }
                             }
                         }

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1536,7 +1536,7 @@ impl<'a> AnalyzeContext<'a> {
         type_mark: TypeEnt<'a>,
         indexes: &mut [Index],
         diagnostics: &mut dyn DiagnosticHandler,
-    ) -> AnalysisResult<TypeEnt<'a>> {
+    ) -> EvalResult<TypeEnt<'a>> {
         let base_type = type_mark.base_type();
 
         let base_type = if let Type::Access(ref subtype, ..) = base_type.kind() {
@@ -1566,11 +1566,13 @@ impl<'a> AnalyzeContext<'a> {
 
             Ok(*elem_type)
         } else {
-            Err(Diagnostic::error(
-                suffix_pos,
-                format!("{} cannot be indexed", type_mark.describe()),
-            )
-            .into())
+            bail!(
+                diagnostics,
+                Diagnostic::error(
+                    suffix_pos,
+                    format!("{} cannot be indexed", type_mark.describe()),
+                )
+            );
         }
     }
 

--- a/vhdl_lang/src/analysis/range.rs
+++ b/vhdl_lang/src/analysis/range.rs
@@ -77,10 +77,9 @@ impl<'a> AnalyzeContext<'a> {
             ResolvedName::Type(typ) => typ,
             ResolvedName::ObjectName(oname) => oname.type_mark(),
             ResolvedName::Overloaded(ref des, ref overloaded) => {
-                let disamb = catch_diagnostic(
-                    self.disambiguate_no_actuals(des, None, overloaded),
-                    diagnostics,
-                )?;
+                let disamb = self
+                    .disambiguate_no_actuals(des, None, overloaded)
+                    .into_eval_result(diagnostics)?;
 
                 if let Some(disamb) = disamb {
                     if let Disambiguated::Unambiguous(ref ent) = disamb {


### PR DESCRIPTION
Finally remove the `AnalysisResult` in favour of the `EvalResult`.
This makes the code more readable and more maintainable. Further additions to the analysis do not have to worry about what kind of result to return and simply return an `EvalResult`.

This also adds some documentation to the `Result`'s