### PR TITLE
Fix: Recognize file name as file

### DIFF
--- a/vhdl_lang/src/analysis/association.rs
+++ b/vhdl_lang/src/analysis/association.rs
@@ -536,7 +536,7 @@ impl<'a> AnalyzeContext<'a> {
                 };
                 if !matches!(name, ResolvedName::Final(ent) if matches!(
                     ent.kind(),
-                    AnyEntKind::File(_)
+                    AnyEntKind::File(_) | AnyEntKind::InterfaceFile(_)
                 )) {
                     diagnostics.error(actual_pos, "Name must denote a file name");
                 }

--- a/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
+++ b/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
@@ -640,3 +640,34 @@ end architecture foo;
         ],
     )
 }
+
+#[test]
+fn legal_file_names() {
+    let mut builder = LibraryBuilder::new();
+    builder.code(
+        "libname",
+        "\
+use std.textio.all;
+
+package foo is
+    procedure tee(
+      file     file_handle : text;
+      variable my_line     : inout line
+    );
+end package foo;
+
+package body foo is
+    procedure tee(
+      file     file_handle : text;
+      variable my_line     : inout line
+    ) is
+      variable v_line : line;
+    begin
+      write(v_line, my_line.all);
+      writeline(file_handle, v_line);
+    end procedure tee;
+end package body;
+   ",
+    );
+    check_no_diagnostics(&builder.analyze())
+}


### PR DESCRIPTION
The following snippet was incorrectly marked as erroneous:

```vhdl
procedure tee(
  file     file_handle : text;
  variable my_line     : inout line
) is
  variable v_line : line;
begin
  write(v_line, my_line.all);
  writeline(file_handle, v_line);
end procedure tee;
```

with the error message "Name must denote a file name".

The procedure `writeline` is from the standard library.

This fixes this behaviour by also checking whether the file is an `AnyEntKind::InterfaceFile`