### PR TITLE
added hint about vhdl_libraries directory when installing from crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ I very much appreciate help from other people especially regarding semantic anal
 - Find workspace symbols
 - View/find document symbols
 
+## When Installing it from Crate
+
+When installing the VHDL_LS from [crates.io](https://crates.io/crates/vhdl_ls) the required  
+[vhdl_libraries](https://github.com/VHDL-LS/rust_hdl/tree/master/vhdl_libraries) directory will not be installed automatically and  
+will need to be copied into the parent directory of the VHDL_LS binary manually.  
+
 ## Trying it out
 A language server is never used directly by the end user and it is integrated into different editor plugins. The ones I know about are listed here.
 


### PR DESCRIPTION
This is addressing [issue#113](https://github.com/VHDL-LS/rust_hdl/issues/113), which is quite old, but it came up in another issue recently. So I guess it makes sense to leave a little hint when installing VHDL_LS from crate.