### PR TITLE
Enable ignoring files that are not part of the project

### DIFF
--- a/vhdl_ls/src/main.rs
+++ b/vhdl_ls/src/main.rs
@@ -28,5 +28,6 @@ fn main() {
     vhdl_ls::start(VHDLServerSettings {
         no_lint: args.no_lint,
         silent: args.silent,
+        ..Default::default()
     });
 }

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -28,9 +28,6 @@ use vhdl_lang::{
 pub enum NonProjectFileHandling {
     /// Ignore any non-project files
     Ignore,
-    /// Only parse non-project files, do not analyze them.
-    /// Not implemented at the moment
-    // Parse,
     /// Add non-project files to an anonymous library and analyze them
     #[default]
     Analyze,
@@ -292,6 +289,10 @@ impl VHDLServer {
             match self.settings.non_project_file_handling {
                 NonProjectFileHandling::Ignore => {}
                 NonProjectFileHandling::Analyze => {
+                    self.message(Message::warning(format!(
+                        "Opening file {} that is not part of the project",
+                        file_name.to_string_lossy()
+                    )));
                     self.project
                         .update_source(&Source::inline(&file_name, text));
                     self.publish_diagnostics();

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -24,7 +24,7 @@ use vhdl_lang::{
 
 /// Defines how the language server handles files
 /// that are not part of the `vhdl_ls.toml` project settings file.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Eq, PartialEq)]
 pub enum NonProjectFileHandling {
     /// Ignore any non-project files
     Ignore,
@@ -270,7 +270,7 @@ impl VHDLServer {
             }
             self.project.update_source(&source);
             self.publish_diagnostics();
-        } else {
+        } else if self.settings.non_project_file_handling != NonProjectFileHandling::Ignore {
             self.message(Message::error(format!(
                 "Changing file {} that is not part of the project",
                 file_name.to_string_lossy()


### PR DESCRIPTION
This adds the initial configuration and closes #172 

The new configuration will be found (and must be set) in the Language Server Client configuration.

An additional desirable feature is that the project could be added and parsed only (without analysis) to show syntax errors only. However, this is not part of this PR but may be implemented at a later stage. 