### PR TITLE
Check raw entity IDs from an LSP client

### DIFF
--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -1466,6 +1466,6 @@ end configuration;
             .item_at_cursor(code.source(), code.s1("foo").start())
             .unwrap();
         assert_eq!(root.entity_id_from_raw(ent.id.to_raw()), Some(ent.id));
-        assert_eq!(root.entity_id_from_raw(0xFFFF << 32), None)
+        assert_eq!(root.entity_id_from_raw(0xFFFF << 32), None);
     }
 }

--- a/vhdl_lang/src/named_entity/arena.rs
+++ b/vhdl_lang/src/named_entity/arena.rs
@@ -82,6 +82,10 @@ impl LocalArena {
         std::mem::transmute(std::pin::Pin::into_inner(item) as *mut AnyEnt)
     }
 
+    pub fn contains(&self, id: LocalId) -> bool {
+        (id.0 as usize) < self.items.len()
+    }
+
     fn panic_on_missing(&self, id: LocalId) {
         if (id.0 as usize) < self.items.len() {
             return;
@@ -116,7 +120,9 @@ impl<'a> FinalArena {
     }
 
     pub fn is_valid_id(&self, id: EntityId) -> bool {
-        self.refs.contains_key(&id.arena_id().0)
+        self.refs
+            .get(&id.arena_id().0)
+            .is_some_and(|local_arena| local_arena.contains(id.local_id()))
     }
 
     pub fn link(&mut self, referenced: &FinalArena) {

--- a/vhdl_lang/src/named_entity/arena.rs
+++ b/vhdl_lang/src/named_entity/arena.rs
@@ -115,6 +115,10 @@ impl<'a> FinalArena {
         }
     }
 
+    pub fn is_valid_id(&self, id: EntityId) -> bool {
+        self.refs.contains_key(&id.arena_id().0)
+    }
+
     pub fn link(&mut self, referenced: &FinalArena) {
         for (id, arena) in referenced.refs.iter() {
             self.refs.entry(*id).or_insert_with(|| arena.clone());
@@ -304,7 +308,7 @@ impl EntityId {
 
     /// Returns an `EntityId` from a raw `usize` value
     /// for deserialization purposes.
-    pub fn from_raw(id: usize) -> EntityId {
+    pub(crate) fn from_raw(id: usize) -> EntityId {
         EntityId { id }
     }
 

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -326,6 +326,10 @@ impl Project {
     ) -> Vec<CompletionItem> {
         list_completion_options(&self.root, source, cursor)
     }
+
+    pub fn entity_id_from_raw(&self, raw: usize) -> Option<EntityId> {
+        self.root.entity_id_from_raw(raw)
+    }
 }
 
 /// Multiply cloneable value by cloning

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use vhdl_lang::{
-    kind_str, AnyEntKind, Concurrent, Config, Design, Diagnostic, EntHierarchy, EntRef, EntityId,
+    kind_str, AnyEntKind, Concurrent, Config, Design, Diagnostic, EntHierarchy, EntRef,
     InterfaceEnt, Message, MessageHandler, Object, Overloaded, Project, Severity, SeverityMap,
     Source, SrcPos, Token, Type, VHDLStandard,
 };
@@ -466,7 +466,7 @@ impl VHDLServer {
             .data
             .clone()
             .and_then(|val| serde_json::from_value::<usize>(val).ok())
-            .map(EntityId::from_raw);
+            .and_then(|raw| self.project.entity_id_from_raw(raw));
         if let Some(id) = eid {
             if let Some(text) = self.project.format_entity(id) {
                 params.documentation = Some(Documentation::MarkupContent(MarkupContent {


### PR DESCRIPTION
Closes #300 

While this might not be the final / ideal solution, checks that a raw entity id points to a valid entity reference before returning it.
This handles situations gracefully where raw entity IDs are used to pass information.