### PR TITLE
Add support for textDocument/documentHighlight request

### DIFF
--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -520,6 +520,12 @@ impl DesignRoot {
         searcher.references
     }
 
+    pub fn find_all_references_in_source(&self, source: &Source, ent: EntRef) -> Vec<SrcPos> {
+        let mut searcher = FindAllReferences::new(self, ent);
+        let _ = self.search_source(source, &mut searcher);
+        searcher.references
+    }
+
     pub fn public_symbols<'a>(&'a self) -> Box<dyn Iterator<Item = EntRef<'a>> + 'a> {
         Box::new(self.libraries.values().flat_map(|library| {
             std::iter::once(self.arenas.get(library.id)).chain(library.units.values().flat_map(

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -309,6 +309,10 @@ impl Project {
         self.root.find_all_references(ent)
     }
 
+    pub fn find_all_references_in_source(&self, source: &Source, ent: &AnyEnt) -> Vec<SrcPos> {
+        self.root.find_all_references_in_source(source, ent)
+    }
+
     /// Get source positions that are not resolved to a declaration
     /// This is used for development to test where the language server is blind
     pub fn find_all_unresolved(&self) -> (usize, Vec<SrcPos>) {

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -190,6 +190,14 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
+        let request = match extract::<request::DocumentHighlightRequest>(request) {
+            Ok((id, params)) => {
+                let result = server.document_highlight(&params.text_document_position_params);
+                self.send_response(lsp_server::Response::new_ok(id, result));
+                return;
+            }
+            Err(request) => request,
+        };
         let request = match extract::<request::HoverRequest>(request) {
             Ok((id, params)) => {
                 let result = server.text_document_hover(&params.text_document_position_params);

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -696,17 +696,11 @@ impl VHDLServer {
 
         Some(
             self.project
-                .find_all_references(ent)
+                .find_all_references_in_source(&source, ent)
                 .iter()
-                .filter_map(|pos| {
-                    if pos.source == source {
-                        Some(DocumentHighlight {
-                            range: to_lsp_range(pos.range()),
-                            kind: Some(DocumentHighlightKind::TEXT),
-                        })
-                    } else {
-                        None
-                    }
+                .map(|pos| DocumentHighlight {
+                    range: to_lsp_range(pos.range()),
+                    kind: Some(DocumentHighlightKind::TEXT),
                 })
                 .collect(),
         )

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -182,6 +182,7 @@ impl VHDLServer {
             })),
             workspace_symbol_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
+            document_highlight_provider: Some(OneOf::Left(true)),
             completion_provider: Some(CompletionOptions {
                 resolve_provider: Some(true),
                 trigger_characters: Some(trigger_chars),
@@ -679,6 +680,36 @@ impl VHDLServer {
             changes: Some(changes),
             ..Default::default()
         })
+    }
+
+    pub fn document_highlight(
+        &mut self,
+        params: &TextDocumentPositionParams,
+    ) -> Option<Vec<DocumentHighlight>> {
+        let source = self
+            .project
+            .get_source(&uri_to_file_name(&params.text_document.uri))?;
+
+        let ent = self
+            .project
+            .find_declaration(&source, from_lsp_pos(params.position))?;
+
+        Some(
+            self.project
+                .find_all_references(ent)
+                .iter()
+                .filter_map(|pos| {
+                    if pos.source == source {
+                        Some(DocumentHighlight {
+                            range: to_lsp_range(pos.range()),
+                            kind: Some(DocumentHighlightKind::TEXT),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
     }
 
     pub fn workspace_symbol(


### PR DESCRIPTION
Hi, thank you all for the great project, which has helped me a lot while writing VHDL code!

In most of the other language servers, I use a lot the `documentHighlight` feature, which highlights all the occurrences of a symbol in the current file. Noticing that it was missing from this LS I attempted my own implementation

See the result here:

https://github.com/VHDL-LS/rust_hdl/assets/10487071/ebb064ce-89f1-459c-a37b-edf11d7af977

## Edit

It seems that VScode has some kind of fallback that performs the same result even if the server does not have this capability! (I am actually using another editor - Zed - that would not do the same)

See the before and after in Zed:

### Before

https://github.com/VHDL-LS/rust_hdl/assets/10487071/6162dcfc-965a-4857-86e5-8dc6a060a4f0 

### After

https://github.com/VHDL-LS/rust_hdl/assets/10487071/382ad155-a142-44f8-b731-6372cbd82c85
