### PR TITLE
Simplify analysis for `TypeMark` with analysis for `Name`

### DIFF
--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -507,9 +507,10 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             }
             Declaration::Attribute(ref mut attr) => match attr {
                 Attribute::Declaration(ref mut attr_decl) => {
-                    if let Some(typ) = as_fatal(self.resolve_type_mark(
+                    if let Some(typ) = as_fatal(self.type_name(
                         scope,
-                        &mut attr_decl.type_mark,
+                        attr_decl.type_mark.span,
+                        &mut attr_decl.type_mark.item,
                         diagnostics,
                     ))? {
                         scope.add(
@@ -1088,7 +1089,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     ) -> EvalResult<BaseType<'a>> {
         match array_index {
             ArrayIndex::IndexSubtypeDefintion(ref mut type_mark) => self
-                .resolve_type_mark(scope, type_mark, diagnostics)
+                .type_name(scope, type_mark.span, &mut type_mark.item, diagnostics)
                 .map(|typ| typ.base()),
             ArrayIndex::Discrete(ref mut drange) => self.drange_type(scope, drange, diagnostics),
         }

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -258,11 +258,8 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             if let Design::Entity(ref visibility, ref region) = primary.kind() {
                 (visibility, region)
             } else {
-                let mut diagnostic = Diagnostic::new(
-                    unit.ident_pos(self.ctx),
-                    "Expected an entity",
-                    ErrorCode::MismatchedKinds,
-                );
+                let mut diagnostic =
+                    Diagnostic::mismatched_kinds(unit.ident_pos(self.ctx), "Expected an entity");
 
                 if let Some(pos) = primary.decl_pos() {
                     diagnostic.add_related(pos, format!("Found {}", primary.describe()))
@@ -329,11 +326,8 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             Design::Package(ref visibility, ref region)
             | Design::UninstPackage(ref visibility, ref region) => (visibility, region),
             _ => {
-                let mut diagnostic = Diagnostic::new(
-                    unit.ident_pos(self.ctx),
-                    "Expected a package",
-                    ErrorCode::MismatchedKinds,
-                );
+                let mut diagnostic =
+                    Diagnostic::mismatched_kinds(unit.ident_pos(self.ctx), "Expected a package");
 
                 if let Some(pos) = primary.decl_pos() {
                     diagnostic.add_related(pos, format!("Found {}", primary.describe()))
@@ -491,10 +485,9 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 Err(_) => {
                     bail!(
                         diagnostics,
-                        Diagnostic::new(
+                        Diagnostic::mismatched_kinds(
                             &prefix.pos(self.ctx),
                             "Invalid prefix of a selected name",
-                            ErrorCode::MismatchedKinds
                         )
                     );
                 }
@@ -502,10 +495,9 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             UsedNames::AllWithin(..) => {
                 bail!(
                     diagnostics,
-                    Diagnostic::new(
+                    Diagnostic::mismatched_kinds(
                         &prefix.pos(self.ctx),
                         "'.all' may not be the prefix of a selected name",
-                        ErrorCode::MismatchedKinds
                     )
                 );
             }
@@ -545,11 +537,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             | Name::External(..) => {
                 bail!(
                     diagnostics,
-                    Diagnostic::new(
-                        &name.pos(self.ctx),
-                        "Invalid selected name",
-                        ErrorCode::MismatchedKinds
-                    )
+                    Diagnostic::mismatched_kinds(&name.pos(self.ctx), "Invalid selected name",)
                 );
             }
         }

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -585,7 +585,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     ) -> EvalResult<TypeEnt<'a>> {
         let QualifiedExpression { type_mark, expr } = qexpr;
 
-        match as_fatal(self.resolve_type_mark(scope, type_mark, diagnostics))? {
+        match as_fatal(self.type_name(scope, type_mark.span, &mut type_mark.item, diagnostics))? {
             Some(target_type) => {
                 self.expr_pos_with_ttyp(
                     scope,

--- a/vhdl_lang/src/analysis/literals.rs
+++ b/vhdl_lang/src/analysis/literals.rs
@@ -205,10 +205,9 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     ))
                 }
             }
-            NamedEntities::Overloaded(_) => Err(Diagnostic::new(
+            NamedEntities::Overloaded(_) => Err(Diagnostic::mismatched_kinds(
                 unit.item.pos(self.ctx),
                 "Overloaded name may not be physical unit",
-                ErrorCode::MismatchedKinds,
             )),
         }
     }

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1123,7 +1123,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 Err(EvalError::Unknown)
             }
             AttributeDesignator::Type(attr) => self
-                .resolve_type_attribute_suffix(prefix, &attr, name_pos, diagnostics)
+                .resolve_type_attribute_suffix(prefix, prefix_pos, &attr, name_pos, diagnostics)
                 .map(|typ| AttrResolveResult::Type(typ.base())),
             AttributeDesignator::Converse => {
                 let view = self.resolve_view_ent(prefix, diagnostics, prefix_pos)?;
@@ -1146,6 +1146,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     fn resolve_type_attribute_suffix(
         &self,
         prefix: &ResolvedName<'a>,
+        prefix_pos: TokenSpan,
         suffix: &TypeAttribute,
         pos: TokenSpan,
         diagnostics: &mut dyn DiagnosticHandler,
@@ -1191,7 +1192,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     Ok(elem_type)
                 } else {
                     diagnostics.add(
-                        pos.pos(self.ctx),
+                        prefix_pos.pos(self.ctx),
                         format!("array type expected for '{suffix} attribute",),
                         ErrorCode::IllegalAttribute,
                     );
@@ -2121,7 +2122,7 @@ variable thevar : integer;
         check_diagnostics(
             diagnostics,
             vec![Diagnostic::new(
-                code.s1("thevar'element"),
+                code.s1("thevar"),
                 "array type expected for 'element attribute",
                 ErrorCode::IllegalAttribute,
             )],

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1164,10 +1164,9 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             }
             ResolvedName::ObjectName(obj) => obj.type_mark(),
             other => {
-                let diag = Diagnostic::new(
+                let diag = Diagnostic::mismatched_kinds(
                     pos.pos(self.ctx),
                     format!("Expected type, got {}", other.describe()),
-                    ErrorCode::MismatchedKinds,
                 )
                 .opt_related(other.decl_pos(), "Defined here");
                 bail!(diagnostics, diag);

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1182,7 +1182,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 } else {
                     let diag = Diagnostic::illegal_attribute(
                         prefix_pos.pos(self.ctx),
-                        format!("array type expected for '{suffix} attribute",),
+                        format!("array type expected for '{suffix} attribute"),
                     );
                     bail!(diagnostics, diag);
                 }
@@ -1584,15 +1584,14 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             | ResolvedName::Overloaded { .. }
             | ResolvedName::Expression(_)
             | ResolvedName::Final(_) => {
-                diagnostics.push(
-                    Diagnostic::new(
+                bail!(
+                    diagnostics,
+                    Diagnostic::mismatched_kinds(
                         name_pos.pos(self.ctx),
-                        format!("Expected type, got {}", resolved.describe()),
-                        ErrorCode::MismatchedKinds,
+                        format!("Expected type, got {}", resolved.describe())
                     )
-                    .opt_related(resolved.decl_pos(), "Defined here"),
+                    .opt_related(resolved.decl_pos(), "Defined here")
                 );
-                Err(EvalError::Unknown)
             }
         }
     }

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -171,15 +171,13 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                                 if let Some(ent) = overloaded.get(&signature) {
                                     name.set_unique_reference(&ent);
                                 } else {
-                                    let mut diag = Diagnostic::new(
+                                    let mut diag = Diagnostic::mismatched_kinds(
                                         &assoc.actual.pos(self.ctx),
                                         format!(
-                                            "Cannot map '{}' to subprogram generic {}{}",
-                                            des,
+                                            "Cannot map '{des}' to subprogram generic {}{}",
                                             target.designator(),
                                             signature.key().describe()
                                         ),
-                                        ErrorCode::MismatchedKinds,
                                     );
 
                                     diag.add_subprogram_candidates(

--- a/vhdl_lang/src/analysis/range.rs
+++ b/vhdl_lang/src/analysis/range.rs
@@ -256,7 +256,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
         let typ = match drange {
             DiscreteRange::Discrete(ref mut type_mark, ref mut range) => {
                 let typ = self
-                    .resolve_type_mark(scope, type_mark, diagnostics)?
+                    .type_name(scope, type_mark.span, &mut type_mark.item, diagnostics)?
                     .base();
                 if let Some(ref mut range) = range {
                     self.range_with_ttyp(scope, typ.into(), range, diagnostics)?;
@@ -366,7 +366,12 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     ) -> FatalResult {
         match drange {
             DiscreteRange::Discrete(ref mut type_mark, ref mut range) => {
-                let _ = as_fatal(self.resolve_type_mark(scope, type_mark, diagnostics))?;
+                let _ = as_fatal(self.name_resolve(
+                    scope,
+                    type_mark.span,
+                    &mut type_mark.item,
+                    diagnostics,
+                ))?;
                 if let Some(ref mut range) = range {
                     self.range_with_ttyp(scope, target_type, range, diagnostics)?;
                 }

--- a/vhdl_lang/src/analysis/range.rs
+++ b/vhdl_lang/src/analysis/range.rs
@@ -469,10 +469,9 @@ mod tests {
 
         check_diagnostics(
             diagnostics,
-            vec![Diagnostic::new(
+            vec![Diagnostic::mismatched_kinds(
                 code.s1("0.0 to 1.0"),
                 "Non-discrete type universal_real cannot be used in discrete range",
-                ErrorCode::MismatchedKinds,
             )],
         )
     }
@@ -636,10 +635,9 @@ function myfun return arr_t;
 
         check_diagnostics(
             diagnostics,
-            vec![Diagnostic::new(
+            vec![Diagnostic::mismatched_kinds(
                 code.s1("character"),
                 "type 'CHARACTER' cannot be prefix of range attribute, array type or object is required",
-                ErrorCode::MismatchedKinds,
             )],
         );
     }

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -15,15 +15,6 @@ use crate::data::*;
 use crate::named_entity::*;
 
 impl<'a, 't> AnalyzeContext<'a, 't> {
-    pub fn resolve_type_mark(
-        &self,
-        scope: &Scope<'a>,
-        type_mark: &mut WithTokenSpan<TypeMark>,
-        diagnostics: &mut dyn DiagnosticHandler,
-    ) -> EvalResult<TypeEnt<'a>> {
-        self.type_name(scope, type_mark.span, &mut type_mark.item, diagnostics)
-    }
-
     pub fn choice_with_ttyp(
         &self,
         scope: &Scope<'a>,

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -198,10 +198,9 @@ impl Diagnostic {
 
 impl<'a> ResolvedName<'a> {
     pub(super) fn kind_error(&self, pos: impl AsRef<SrcPos>, expected: &str) -> Diagnostic {
-        let mut error = Diagnostic::new(
+        let mut error = Diagnostic::mismatched_kinds(
             pos,
-            format!("Expected {}, got {}", expected, self.describe()),
-            ErrorCode::MismatchedKinds,
+            format!("Expected {expected}, got {}", self.describe()),
         );
         if let Some(decl_pos) = self.decl_pos() {
             error.add_related(decl_pos, "Defined here");
@@ -223,13 +222,12 @@ impl Diagnostic {
         named_entity: &AnyEnt,
         prefix: &SrcPos,
     ) -> Diagnostic {
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             prefix,
             capitalize(&format!(
                 "{} may not be the prefix of a selected name",
                 named_entity.describe(),
             )),
-            ErrorCode::MismatchedKinds,
         )
     }
 

--- a/vhdl_lang/src/analysis/subprogram.rs
+++ b/vhdl_lang/src/analysis/subprogram.rs
@@ -117,8 +117,12 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     &mut fun.parameter_list,
                     diagnostics,
                 );
-                let return_type =
-                    self.resolve_type_mark(&subpgm_region, &mut fun.return_type, diagnostics);
+                let return_type = self.type_name(
+                    &subpgm_region,
+                    fun.return_type.span,
+                    &mut fun.return_type.item,
+                    diagnostics,
+                );
                 (Signature::new(params?, Some(return_type?)), generic_map)
             }
             SubprogramSpecification::Procedure(procedure) => {
@@ -191,15 +195,15 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             ast::Signature::Function(ref mut args, ref mut ret) => {
                 let args: Vec<_> = args
                     .iter_mut()
-                    .map(|arg| self.resolve_type_mark(scope, arg, diagnostics))
+                    .map(|arg| self.type_name(scope, arg.span, &mut arg.item, diagnostics))
                     .collect();
-                let return_type = self.resolve_type_mark(scope, ret, diagnostics);
+                let return_type = self.type_name(scope, ret.span, &mut ret.item, diagnostics);
                 (args, Some(return_type))
             }
             ast::Signature::Procedure(args) => {
                 let args: Vec<_> = args
                     .iter_mut()
-                    .map(|arg| self.resolve_type_mark(scope, arg, diagnostics))
+                    .map(|arg| self.type_name(scope, arg.span, &mut arg.item, diagnostics))
                     .collect();
                 (args, None)
             }

--- a/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
+++ b/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
@@ -34,15 +34,13 @@ end architecture;
     );
 
     let expected = vec![
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo1", 2),
             "function foo1[return NATURAL] may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo2", 2),
             "foo2[return enum_t] may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
     ];
 
@@ -70,10 +68,9 @@ end architecture;
 ",
     );
 
-    let expected = vec![Diagnostic::new(
+    let expected = vec![Diagnostic::mismatched_kinds(
         code.s("foo'stable", 1),
         "Expression may not be the target of an assignment",
-        ErrorCode::MismatchedKinds,
     )];
 
     let diagnostics = builder.analyze();
@@ -118,25 +115,21 @@ end architecture;
     );
 
     let expected = vec![
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s1("work.pkg.foo1(2)"),
             "Expression may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s1("foo2(2)"),
             "Expression may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s1("work.pkg.foo1(arg => 2)"),
             "Expression may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s1("foo2(arg => 2)"),
             "Expression may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
     ];
 
@@ -167,15 +160,13 @@ end architecture;
     );
 
     let expected = vec![
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo1", 3),
             "constant 'foo1' may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo2", 2),
             "alias 'foo2' of constant may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
     ];
 
@@ -300,15 +291,13 @@ end architecture;
     );
 
     let expected = vec![
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo1", 2),
             "interface constant 'foo1' may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo2", 2),
             "interface variable 'foo2' of mode in may not be the target of an assignment",
-            ErrorCode::MismatchedKinds,
         ),
     ];
 
@@ -348,25 +337,21 @@ end architecture;
     );
 
     let expected = vec![
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo1", 2),
             "interface signal 'foo1' of mode out may not be the target of a variable assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo2", 2),
             "interface variable 'foo2' of mode out may not be the target of a signal assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo3", 2),
             "signal 'foo3' may not be the target of a variable assignment",
-            ErrorCode::MismatchedKinds,
         ),
-        Diagnostic::new(
+        Diagnostic::mismatched_kinds(
             code.s("foo4", 2),
             "variable 'foo4' may not be the target of a signal assignment",
-            ErrorCode::MismatchedKinds,
         ),
     ];
 
@@ -391,10 +376,9 @@ end architecture;
 ",
     );
 
-    let expected = vec![Diagnostic::new(
+    let expected = vec![Diagnostic::mismatched_kinds(
         code.s("foo", 2),
         "signal 'foo' of subtype 'NATURAL' cannot be indexed",
-        ErrorCode::MismatchedKinds,
     )];
 
     let diagnostics = builder.analyze();
@@ -418,10 +402,9 @@ end architecture;
 ",
     );
 
-    let expected = vec![Diagnostic::new(
+    let expected = vec![Diagnostic::mismatched_kinds(
         code.s("foo", 2),
         "signal 'foo' of subtype 'NATURAL' cannot be sliced",
-        ErrorCode::MismatchedKinds,
     )];
 
     let diagnostics = builder.analyze();

--- a/vhdl_lang/src/analysis/tests/context_clause.rs
+++ b/vhdl_lang/src/analysis/tests/context_clause.rs
@@ -438,10 +438,9 @@ end entity;
 
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s("pkg", 2),
             "package 'pkg' does not denote a context declaration",
-            ErrorCode::MismatchedKinds,
         )],
     )
 }
@@ -471,30 +470,22 @@ end entity;
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("libname", 2),
                 "Context reference must be a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
-                code.s1("work"),
-                "Use clause must be a selected name",
-                ErrorCode::MismatchedKinds,
-            ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(code.s1("work"), "Use clause must be a selected name"),
+            Diagnostic::mismatched_kinds(
                 code.s("libname", 3),
                 "Use clause must be a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("work.pkg(0)"),
                 "Use clause must be a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("work.ctx'range"),
                 "Context reference must be a selected name",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -616,15 +607,13 @@ end entity;
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.all", 1),
                 "'.all' may not be the prefix of a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.all", 2),
                 "'.all' may not be the prefix of a selected name",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -651,15 +640,13 @@ end package;
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.gpkg", 1),
                 "Uninstantiated package 'gpkg' may not be the prefix of a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.gpkg", 2),
                 "Uninstantiated package 'gpkg' may not be the prefix of a selected name",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -687,15 +674,13 @@ end package;
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.pkg.enum_t", 1),
                 "Type 'enum_t' may not be the prefix of a selected name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("work.pkg.const", 1),
                 "Invalid prefix for selected name",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -936,10 +921,9 @@ end package;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s("work.pkg1.typ_t", 1),
             "Subtype 'typ_t' may not be the prefix of a selected name",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }

--- a/vhdl_lang/src/analysis/tests/custom_attributes.rs
+++ b/vhdl_lang/src/analysis/tests/custom_attributes.rs
@@ -186,10 +186,9 @@ end architecture;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("std'myattr"),
             "library std may not be the prefix of a user defined attribute",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }

--- a/vhdl_lang/src/analysis/tests/package_instance.rs
+++ b/vhdl_lang/src/analysis/tests/package_instance.rs
@@ -66,15 +66,13 @@ end package;
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("work.pkg"),
                 "'work.pkg' is not an uninstantiated generic package",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("work.pkg.const"),
                 "'work.pkg.const' is not an uninstantiated generic package",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -172,20 +170,17 @@ package bad_pkg2 is new work.gpkg
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("16#bad#", 1),
                 "Cannot map expression to type generic",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("natural"),
                 "subtype 'NATURAL' cannot be used in an expression",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("=> work").s1("work"),
                 "Expected type, got library libname",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );
@@ -295,10 +290,9 @@ end package;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("character"),
             "Cannot map type 'CHARACTER' to subprogram generic",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }
@@ -331,10 +325,9 @@ end package;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.sa("to_string => ", "my_to_string"),
             "Cannot map 'my_to_string' to subprogram generic to_string[INTEGER return STRING]",
-            ErrorCode::MismatchedKinds,
         )
         .related(
             code.s1("my_to_string"),

--- a/vhdl_lang/src/analysis/tests/package_instance.rs
+++ b/vhdl_lang/src/analysis/tests/package_instance.rs
@@ -184,7 +184,7 @@ package bad_pkg2 is new work.gpkg
             ),
             Diagnostic::new(
                 code.s1("=> work").s1("work"),
-                "Expected type name, got library libname",
+                "Expected type, got library libname",
                 ErrorCode::MismatchedKinds,
             ),
         ],

--- a/vhdl_lang/src/analysis/tests/resolves_names.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_names.rs
@@ -1732,10 +1732,9 @@ attribute bad of ram : signal is 0;
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("attribute bad").s1("bad"),
             "constant 'bad' is not an attribute",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }

--- a/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
+++ b/vhdl_lang/src/analysis/tests/resolves_type_mark.rs
@@ -508,10 +508,6 @@ pub fn kind_error(
     expected: &str,
     got: &str,
 ) -> Diagnostic {
-    Diagnostic::new(
-        code.s(name, occ),
-        format!("Expected {expected}, got {got}"),
-        ErrorCode::MismatchedKinds,
-    )
-    .related(code.s(name, occ_decl), "Defined here")
+    Diagnostic::mismatched_kinds(code.s(name, occ), format!("Expected {expected}, got {got}"))
+        .related(code.s(name, occ_decl), "Defined here")
 }

--- a/vhdl_lang/src/analysis/tests/subprogram_arguments.rs
+++ b/vhdl_lang/src/analysis/tests/subprogram_arguments.rs
@@ -74,10 +74,9 @@ end architecture;
                 code.s("subpgm", 1),
                 "function subpgm[NATURAL return NATURAL] is not a procedure",
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s("thesig", 2),
                 "signal 'thesig' of array type 'INTEGER_VECTOR' is not a procedure",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );

--- a/vhdl_lang/src/analysis/tests/subprogram_instance.rs
+++ b/vhdl_lang/src/analysis/tests/subprogram_instance.rs
@@ -47,10 +47,9 @@ function proc is new x;
     let diagnostics = builder.analyze();
     assert_eq!(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("new x").s1("x"),
             "signal 'x' does not denote an uninstantiated subprogram",
-            ErrorCode::MismatchedKinds
         )]
     )
 }
@@ -247,10 +246,9 @@ procedure proc is new proc;
 
     check_diagnostics(
         builder.analyze(),
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("procedure proc is new").s("proc", 2).pos(),
             "procedure proc[] does not denote an uninstantiated subprogram",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -446,10 +446,9 @@ constant bar : natural := foo(0);
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s("foo", 2),
             "constant 'foo' of subtype 'NATURAL' cannot be indexed",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }
@@ -467,10 +466,9 @@ constant bar : natural := foo(0 to 0);
     let diagnostics = builder.analyze();
     check_diagnostics(
         diagnostics,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s("foo", 2),
             "constant 'foo' of subtype 'NATURAL' cannot be sliced",
-            ErrorCode::MismatchedKinds,
         )],
     );
 }
@@ -668,15 +666,13 @@ subtype bad2_t is integer'element;
                 "character literal does not match integer type 'INTEGER'",
                 ErrorCode::TypeMismatch,
             ),
-            Diagnostic::new(
+            Diagnostic::illegal_attribute(
                 code.s1("good2'element").s1("good2"),
                 "array type expected for 'element attribute",
-                ErrorCode::IllegalAttribute,
             ),
-            Diagnostic::new(
+            Diagnostic::illegal_attribute(
                 code.s1("integer'element").s1("integer"),
                 "array type expected for 'element attribute",
-                ErrorCode::IllegalAttribute,
             ),
         ],
     );
@@ -938,20 +934,17 @@ constant bad3 : rec_t := (field | 0 => 0);
     check_diagnostics(
         diagnostics,
         vec![
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("field(0)"),
                 "Record aggregate choice must be a simple name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("0 to 1"),
                 "Record aggregate choice must be a simple name",
-                ErrorCode::MismatchedKinds,
             ),
-            Diagnostic::new(
+            Diagnostic::mismatched_kinds(
                 code.s1("field | 0"),
                 "Record aggregate choice must be a simple name",
-                ErrorCode::MismatchedKinds,
             ),
         ],
     );

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -669,12 +669,12 @@ subtype bad2_t is integer'element;
                 ErrorCode::TypeMismatch,
             ),
             Diagnostic::new(
-                code.s1("good2'element"),
+                code.s1("good2'element").s1("good2"),
                 "array type expected for 'element attribute",
                 ErrorCode::IllegalAttribute,
             ),
             Diagnostic::new(
-                code.s1("integer'element"),
+                code.s1("integer'element").s1("integer"),
                 "array type expected for 'element attribute",
                 ErrorCode::IllegalAttribute,
             ),

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -669,14 +669,14 @@ subtype bad2_t is integer'element;
                 ErrorCode::TypeMismatch,
             ),
             Diagnostic::new(
-                code.s1("good2'element").s1("good2"),
+                code.s1("good2'element"),
                 "array type expected for 'element attribute",
-                ErrorCode::TypeMismatch,
+                ErrorCode::IllegalAttribute,
             ),
             Diagnostic::new(
-                code.s1("integer'element").s1("integer"),
+                code.s1("integer'element"),
                 "array type expected for 'element attribute",
-                ErrorCode::TypeMismatch,
+                ErrorCode::IllegalAttribute,
             ),
         ],
     );

--- a/vhdl_lang/src/analysis/tests/view_declarations.rs
+++ b/vhdl_lang/src/analysis/tests/view_declarations.rs
@@ -246,10 +246,9 @@ end entity;
     let diag = builder.analyze();
     check_diagnostics(
         diag,
-        vec![Diagnostic::new(
+        vec![Diagnostic::mismatched_kinds(
             code.s1("bit"),
             "type 'BIT' is not a view",
-            ErrorCode::MismatchedKinds,
         )],
     );
 

--- a/vhdl_lang/src/analysis/types.rs
+++ b/vhdl_lang/src/analysis/types.rs
@@ -26,7 +26,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             ..
         } = subtype_indication;
 
-        let base_type = self.resolve_type_mark(scope, type_mark, diagnostics)?;
+        let base_type = self.type_name(scope, type_mark.span, &mut type_mark.item, diagnostics)?;
 
         if let Some(constraint) = constraint {
             self.analyze_subtype_constraint(
@@ -502,9 +502,12 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     self.source(),
                 );
 
-                if let Some(type_mark) =
-                    as_fatal(self.resolve_type_mark(scope, type_mark, diagnostics))?
-                {
+                if let Some(type_mark) = as_fatal(self.type_name(
+                    scope,
+                    type_mark.span,
+                    &mut type_mark.item,
+                    diagnostics,
+                ))? {
                     for ent in self.create_implicit_file_type_subprograms(file_type, type_mark) {
                         unsafe {
                             self.arena.add_implicit(file_type.id(), ent);

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -271,7 +271,7 @@ pub enum Allocator {
 /// LRM 9.3.5 Qualified expressions
 #[derive(PartialEq, Debug, Clone)]
 pub struct QualifiedExpression {
-    pub type_mark: WithTokenSpan<TypeMark>,
+    pub type_mark: WithTokenSpan<Name>,
     pub expr: WithTokenSpan<Expression>,
 }
 
@@ -317,7 +317,7 @@ pub enum Direction {
 ///   | simple_expression direction simple_expression
 #[derive(PartialEq, Debug, Clone)]
 pub enum DiscreteRange {
-    Discrete(WithTokenSpan<TypeMark>, Option<Range>),
+    Discrete(WithTokenSpan<Name>, Option<Range>),
     Range(Range),
 }
 
@@ -368,13 +368,11 @@ pub enum ResolutionIndication {
     Unresolved,
 }
 
-pub type TypeMark = Name;
-
 /// LRM 6.3 Subtype declarations
 #[derive(PartialEq, Debug, Clone)]
 pub struct SubtypeIndication {
     pub resolution: ResolutionIndication,
-    pub type_mark: WithTokenSpan<TypeMark>,
+    pub type_mark: WithTokenSpan<Name>,
     pub constraint: Option<WithTokenSpan<SubtypeConstraint>>,
 }
 
@@ -383,7 +381,7 @@ pub struct SubtypeIndication {
 pub enum ArrayIndex {
     /// Unbounded
     /// {identifier} range <>
-    IndexSubtypeDefintion(WithTokenSpan<TypeMark>),
+    IndexSubtypeDefintion(WithTokenSpan<Name>),
 
     /// Constraint
     Discrete(DiscreteRange),
@@ -480,7 +478,7 @@ pub struct AliasDeclaration {
 #[derive(PartialEq, Debug, Clone)]
 pub struct AttributeDeclaration {
     pub ident: WithDecl<Ident>,
-    pub type_mark: WithTokenSpan<TypeMark>,
+    pub type_mark: WithTokenSpan<Name>,
 }
 
 /// LRM 7.2 Attribute specification
@@ -588,7 +586,7 @@ pub enum TypeDefinition {
     /// LRM 5.4.2 Incomplete type declarations
     Incomplete(Reference),
     /// LRM 5.5 File types
-    File(WithTokenSpan<TypeMark>),
+    File(WithTokenSpan<Name>),
     /// LRM 5.6 Protected types
     Protected(ProtectedTypeDeclaration),
     ProtectedBody(ProtectedTypeBody),
@@ -664,7 +662,7 @@ pub struct FunctionSpecification {
     // The `parameter` token, if such a token exists
     pub param_tok: Option<TokenId>,
     pub parameter_list: Vec<InterfaceDeclaration>,
-    pub return_type: WithTokenSpan<TypeMark>,
+    pub return_type: WithTokenSpan<Name>,
 }
 
 /// LRM 4.3 Subprogram bodies
@@ -708,8 +706,8 @@ pub struct SubprogramInstantiation {
 /// LRM 4.5.3 Signatures
 #[derive(PartialEq, Debug, Clone)]
 pub enum Signature {
-    Function(Vec<WithTokenSpan<TypeMark>>, WithTokenSpan<TypeMark>),
-    Procedure(Vec<WithTokenSpan<TypeMark>>),
+    Function(Vec<WithTokenSpan<Name>>, WithTokenSpan<Name>),
+    Procedure(Vec<WithTokenSpan<Name>>),
 }
 
 #[derive(PartialEq, Debug, Clone, TokenSpan)]

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -368,11 +368,7 @@ pub enum ResolutionIndication {
     Unresolved,
 }
 
-#[derive(PartialEq, Debug, Clone)]
-pub struct TypeMark {
-    pub name: WithTokenSpan<Name>,
-    pub attr: Option<TypeAttribute>,
-}
+pub type TypeMark = Name;
 
 /// LRM 6.3 Subtype declarations
 #[derive(PartialEq, Debug, Clone)]

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -598,16 +598,6 @@ impl Display for SubtypeIndication {
     }
 }
 
-impl Display for TypeMark {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.name)?;
-        if let Some(attr) = self.attr {
-            write!(f, "'{attr}")?;
-        }
-        Ok(())
-    }
-}
-
 impl Display for ArrayIndex {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -683,13 +683,6 @@ impl Search for SubtypeIndication {
     }
 }
 
-impl Search for WithTokenSpan<TypeMark> {
-    fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
-        return_if_finished!(searcher.search_with_pos(ctx, &self.pos(ctx)));
-        self.item.name.search(ctx, searcher)
-    }
-}
-
 impl Search for RangeConstraint {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         let RangeConstraint {

--- a/vhdl_lang/src/data/error_codes.rs
+++ b/vhdl_lang/src/data/error_codes.rs
@@ -569,6 +569,14 @@ impl Diagnostic {
     pub fn internal(item: impl AsRef<SrcPos>, msg: impl Into<String>) -> Diagnostic {
         Self::new(item, msg, ErrorCode::Internal)
     }
+
+    pub fn illegal_attribute(item: impl AsRef<SrcPos>, msg: impl Into<String>) -> Diagnostic {
+        Self::new(item, msg, ErrorCode::IllegalAttribute)
+    }
+
+    pub fn mismatched_kinds(item: impl AsRef<SrcPos>, msg: impl Into<String>) -> Diagnostic {
+        Self::new(item, msg, ErrorCode::MismatchedKinds)
+    }
 }
 
 impl Display for ErrorCode {

--- a/vhdl_lang/src/named_entity/types.rs
+++ b/vhdl_lang/src/named_entity/types.rs
@@ -234,13 +234,12 @@ impl<'a> TypeEnt<'a> {
             Type::Protected(region, _) => {
                 if let Some(decl) = region.lookup_immediate(suffix.designator()) {
                     match decl {
-                        NamedEntities::Single(ent) => Err(Diagnostic::new(
+                        NamedEntities::Single(ent) => Err(Diagnostic::mismatched_kinds(
                             suffix.pos(ctx),
                             format!(
                                 "Protected type selection must be a method, got {}",
                                 ent.describe()
                             ),
-                            ErrorCode::MismatchedKinds,
                         )),
                         NamedEntities::Overloaded(overloaded) => {
                             Ok(TypedSelection::ProtectedMethod(overloaded.clone()))

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -295,7 +295,7 @@ fn parse_allocator(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<Al
 pub fn name_to_type_mark(
     ctx: &mut ParsingContext<'_>,
     name: WithTokenSpan<Name>,
-) -> ParseResult<WithTokenSpan<TypeMark>> {
+) -> ParseResult<WithTokenSpan<Name>> {
     let pos = name.pos(ctx);
     let type_mark = name
         .try_map_into(|name| match name {

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -302,18 +302,17 @@ pub fn name_to_type_mark(
         .try_map_into(|name| match name {
             Name::Attribute(attr) => {
                 if let Some(typattr) = attr.as_type() {
-                    Some(TypeMark {
+                    Some(Name::Attribute(Box::new(AttributeName {
                         name: attr.name.try_map_into(name_to_selected_name)?,
-                        attr: Some(typattr),
-                    })
+                        attr: attr.attr,
+                        expr: None,
+                        signature: None,
+                    })))
                 } else {
                     None
                 }
             }
-            _ => Some(TypeMark {
-                name: WithTokenSpan::from(name_to_selected_name(name)?, name_span),
-                attr: None,
-            }),
+            _ => Some(name_to_selected_name(name)?),
         })
         .ok_or_else(|| Diagnostic::syntax_error(&pos, "Expected type mark"))?;
 

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -297,11 +297,10 @@ pub fn name_to_type_mark(
     name: WithTokenSpan<Name>,
 ) -> ParseResult<WithTokenSpan<TypeMark>> {
     let pos = name.pos(ctx);
-    let name_span = name.span;
     let type_mark = name
         .try_map_into(|name| match name {
             Name::Attribute(attr) => {
-                if let Some(typattr) = attr.as_type() {
+                if attr.as_type().is_some() {
                     Some(Name::Attribute(Box::new(AttributeName {
                         name: attr.name.try_map_into(name_to_selected_name)?,
                         attr: attr.attr,

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -68,7 +68,7 @@ pub fn parse_type_mark_starting_with_name(
     if ctx.stream.pop_if_kind(Tick).is_some() {
         if let Ok(attr) = ctx.stream.expect_attribute_designator() {
             let token = attr.token;
-            if let AttributeDesignator::Type(typattr) = attr.item {
+            if let AttributeDesignator::Type(_) = attr.item {
                 return Ok(WithTokenSpan {
                     item: Name::Attribute(Box::new(AttributeName {
                         name,

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -51,7 +51,7 @@ pub fn parse_selected_name(ctx: &mut ParsingContext<'_>) -> ParseResult<WithToke
     Ok(name)
 }
 
-pub fn parse_type_mark(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<TypeMark>> {
+pub fn parse_type_mark(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<Name>> {
     let name = parse_selected_name(ctx)?;
     parse_type_mark_starting_with_name(ctx, name)
 }
@@ -59,7 +59,7 @@ pub fn parse_type_mark(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpa
 pub fn parse_type_mark_starting_with_name(
     ctx: &mut ParsingContext<'_>,
     name: WithTokenSpan<Name>,
-) -> ParseResult<WithTokenSpan<TypeMark>> {
+) -> ParseResult<WithTokenSpan<Name>> {
     let state = ctx.stream.state();
     let name_span = name.span;
 

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -604,7 +604,7 @@ impl Code {
         self.parse_ok_no_diagnostics(parse_ident_list)
     }
 
-    pub fn type_mark(&self) -> WithTokenSpan<TypeMark> {
+    pub fn type_mark(&self) -> WithTokenSpan<Name> {
         self.parse_ok_no_diagnostics(parse_type_mark)
     }
 


### PR DESCRIPTION
This simplifies the AST and removes obsolete code, for example for `Searcher` and `Display` implementation. Parsing is unaffected, some error messages might be slightly different after this change.