### PR TITLE
AST normalization: store multiple identifiers per declaration instead of multiplying the declaration

### DIFF
--- a/vhdl_lang/src/analysis/analyze.rs
+++ b/vhdl_lang/src/analysis/analyze.rs
@@ -11,6 +11,7 @@ use crate::data::error_codes::ErrorCode;
 use crate::data::*;
 use crate::named_entity::*;
 use crate::syntax::TokenAccess;
+use crate::TokenSpan;
 use fnv::FnvHashSet;
 use std::cell::RefCell;
 use std::ops::Deref;
@@ -476,5 +477,16 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
 
     pub fn source(&self) -> Source {
         self.source.clone()
+    }
+
+    pub fn define<T: HasIdent>(
+        &self,
+        decl: &mut WithDecl<T>,
+        parent: EntRef<'a>,
+        kind: AnyEntKind<'a>,
+        src_span: TokenSpan,
+    ) -> EntRef<'a> {
+        self.arena
+            .define(self.ctx, decl, parent, kind, src_span, Some(self.source()))
     }
 }

--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -468,27 +468,18 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
 
                 if let Some(subtype) = subtype {
                     scope.add(
-                        self.arena.define(
-                            self.ctx,
-                            ident,
-                            parent,
-                            AnyEntKind::File(subtype),
-                            src_span,
-                            Some(self.source()),
-                        ),
+                        self.define(ident, parent, AnyEntKind::File(subtype), src_span),
                         diagnostics,
                     );
                 }
             }
             Declaration::Component(ref mut component) => {
                 let nested = scope.nested();
-                let ent = self.arena.define(
-                    self.ctx,
+                let ent = self.define(
                     &mut component.ident,
                     parent,
                     AnyEntKind::Component(Region::default()),
                     src_span,
-                    Some(self.source()),
                 );
                 if let Some(generic_list) = &mut component.generic_list {
                     self.analyze_interface_list(&nested, ent, generic_list, diagnostics)?;
@@ -513,13 +504,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                         diagnostics,
                     ))? {
                         scope.add(
-                            self.arena.define(
-                                self.ctx,
+                            self.define(
                                 &mut attr_decl.ident,
                                 parent,
                                 AnyEntKind::Attribute(typ),
                                 src_span,
-                                Some(self.source()),
                             ),
                             diagnostics,
                         );
@@ -550,8 +539,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 }
             }
             Declaration::SubprogramInstantiation(ref mut instance) => {
-                let subpgm_ent = self.arena.define(
-                    self.ctx,
+                let subpgm_ent = self.define(
                     &mut instance.ident,
                     parent,
                     AnyEntKind::Overloaded(Overloaded::Subprogram(Signature::new(
@@ -559,7 +547,6 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                         None,
                     ))),
                     src_span,
-                    Some(self.source()),
                 );
                 let referenced_name = &mut instance.subprogram_name;
                 if let Some(name) = as_fatal(self.name_resolve(
@@ -587,13 +574,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 self.analyze_use_clause(scope, use_clause, diagnostics)?;
             }
             Declaration::Package(ref mut instance) => {
-                let ent = self.arena.define(
-                    self.ctx,
+                let ent = self.define(
                     &mut instance.ident,
                     parent,
                     AnyEntKind::Design(Design::PackageInstance(Region::default())),
                     src_span,
-                    Some(self.source()),
                 );
 
                 if let Some(pkg_region) =
@@ -677,14 +662,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 ErrorCode::Unassociated,
             );
         }
-        Ok(self.arena.define(
-            self.ctx,
-            &mut view.ident,
-            parent,
-            AnyEntKind::View(typ),
-            src_span,
-            Some(self.source()),
-        ))
+        Ok(self.define(&mut view.ident, parent, AnyEntKind::View(typ), src_span))
     }
 
     fn find_deferred_constant_declaration(
@@ -888,28 +866,24 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     .idents
                     .iter_mut()
                     .map(|ident| {
-                        self.arena.define(
-                            self.ctx,
+                        self.define(
                             ident,
                             parent,
                             AnyEntKind::InterfaceFile(file_type.type_mark().to_owned()),
                             span,
-                            Some(self.source()),
                         )
                     })
-                    .collect_vec()
+                    .collect()
             }
             InterfaceDeclaration::Object(ref mut object_decl) => {
                 self.analyze_interface_object_declaration(scope, parent, object_decl, diagnostics)?
             }
             InterfaceDeclaration::Type(ref mut ident) => {
-                let typ = TypeEnt::from_any(self.arena.define(
-                    self.ctx,
+                let typ = TypeEnt::from_any(self.define(
                     ident,
                     parent,
                     AnyEntKind::Type(Type::Interface),
                     span,
-                    Some(self.source()),
                 ))
                 .unwrap();
 
@@ -946,13 +920,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     diagnostics,
                 )?;
 
-                vec![self.arena.define(
-                    self.ctx,
+                vec![self.define(
                     &mut instance.ident,
                     parent,
                     AnyEntKind::Design(Design::InterfacePackageInstance(package_region)),
                     span,
-                    Some(self.source()),
                 )]
             }
         };
@@ -975,8 +947,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     .idents
                     .iter_mut()
                     .map(|ident| {
-                        self.arena.define(
-                            self.ctx,
+                        self.define(
                             ident,
                             parent,
                             AnyEntKind::Object(Object {
@@ -989,7 +960,6 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                                 has_default: mode.expression.is_some(),
                             }),
                             span,
-                            Some(self.source()),
                         )
                     })
                     .collect_vec())
@@ -1016,8 +986,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     .idents
                     .iter_mut()
                     .map(|ident| {
-                        self.arena.define(
-                            self.ctx,
+                        self.define(
                             ident,
                             parent,
                             AnyEntKind::Object(Object {
@@ -1027,7 +996,6 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                                 has_default: false,
                             }),
                             span,
-                            Some(self.source()),
                         )
                     })
                     .collect_vec())

--- a/vhdl_lang/src/analysis/design_unit.rs
+++ b/vhdl_lang/src/analysis/design_unit.rs
@@ -120,13 +120,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             }
         };
 
-        self.arena.define(
-            self.ctx,
+        self.define(
             &mut unit.ident,
             self.work_library(),
             AnyEntKind::Design(Design::Configuration),
             src_span,
-            Some(self.source()),
         );
 
         Ok(())
@@ -224,13 +222,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
         let src_span = unit.span();
         self.analyze_context_clause(&scope, &mut unit.items, diagnostics)?;
 
-        self.arena.define(
-            self.ctx,
+        self.define(
             &mut unit.ident,
             self.work_library(),
             AnyEntKind::Design(Design::Context(scope.into_region())),
             src_span,
-            Some(self.source()),
         );
 
         Ok(())
@@ -271,8 +267,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
         let root_scope = Scope::new(Region::with_visibility(visibility.clone()));
         self.analyze_context_clause(&root_scope, &mut unit.context_clause, diagnostics)?;
 
-        let arch = self.arena.define(
-            self.ctx,
+        let arch = self.define(
             &mut unit.ident,
             primary.into(),
             AnyEntKind::Design(Design::Architecture(
@@ -281,7 +276,6 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 primary,
             )),
             src_span,
-            Some(self.source()),
         );
 
         root_scope.add(arch, diagnostics);

--- a/vhdl_lang/src/analysis/sequential.rs
+++ b/vhdl_lang/src/analysis/sequential.rs
@@ -262,13 +262,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                         let typ = as_fatal(self.drange_type(scope, drange, diagnostics))?;
                         let region = scope.nested();
                         region.add(
-                            self.arena.define(
-                                self.ctx,
+                            self.define(
                                 index,
                                 parent,
                                 AnyEntKind::LoopParameter(typ),
                                 index.tree.token.into(),
-                                Some(self.source()),
                             ),
                             diagnostics,
                         );

--- a/vhdl_lang/src/analysis/subprogram.rs
+++ b/vhdl_lang/src/analysis/subprogram.rs
@@ -25,11 +25,13 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     ) -> FatalResult<Region<'a>> {
         let mut region = Region::default();
         for decl in header.generic_list.items.iter_mut() {
-            if let Some(ent) =
+            if let Some(ents) =
                 as_fatal(self.analyze_interface_declaration(scope, parent, decl, diagnostics))?
             {
-                region.add(ent, diagnostics);
-                scope.add(ent, diagnostics);
+                for ent in ents {
+                    region.add(ent, diagnostics);
+                    scope.add(ent, diagnostics);
+                }
             }
         }
         self.analyze_map_aspect(scope, &mut header.map_aspect, diagnostics)?;

--- a/vhdl_lang/src/analysis/types.rs
+++ b/vhdl_lang/src/analysis/types.rs
@@ -249,16 +249,18 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     let subtype =
                         self.resolve_subtype_indication(scope, &mut elem_decl.subtype, diagnostics);
                     if let Some(subtype) = as_fatal(subtype)? {
-                        let elem = self.arena.define(
-                            self.ctx,
-                            &mut elem_decl.ident,
-                            type_ent.into(),
-                            AnyEntKind::ElementDeclaration(subtype),
-                            elem_decl.span,
-                            Some(self.source()),
-                        );
-                        region.add(elem, diagnostics);
-                        elems.add(elem);
+                        for ident in &mut elem_decl.idents {
+                            let elem = self.arena.define(
+                                self.ctx,
+                                ident,
+                                type_ent.into(),
+                                AnyEntKind::ElementDeclaration(subtype),
+                                elem_decl.span,
+                                Some(self.source()),
+                            );
+                            region.add(elem, diagnostics);
+                            elems.add(elem);
+                        }
                     }
                 }
                 region.close(diagnostics);

--- a/vhdl_lang/src/analysis/types.rs
+++ b/vhdl_lang/src/analysis/types.rs
@@ -250,13 +250,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                         self.resolve_subtype_indication(scope, &mut elem_decl.subtype, diagnostics);
                     if let Some(subtype) = as_fatal(subtype)? {
                         for ident in &mut elem_decl.idents {
-                            let elem = self.arena.define(
-                                self.ctx,
+                            let elem = self.define(
                                 ident,
                                 type_ent.into(),
                                 AnyEntKind::ElementDeclaration(subtype),
                                 elem_decl.span,
-                                Some(self.source()),
                             );
                             region.add(elem, diagnostics);
                             elems.add(elem);
@@ -388,13 +386,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 );
                 scope.add(phys_type.into(), diagnostics);
 
-                let primary = self.arena.define(
-                    self.ctx,
+                let primary = self.define(
                     &mut physical.primary_unit,
                     parent,
                     AnyEntKind::PhysicalLiteral(phys_type),
                     src_span,
-                    Some(self.source()),
                 );
 
                 unsafe {
@@ -420,13 +416,11 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                         Err(err) => diagnostics.push(err),
                     }
 
-                    let secondary_unit = self.arena.define(
-                        self.ctx,
+                    let secondary_unit = self.define(
                         secondary_unit_name,
                         parent,
                         AnyEntKind::PhysicalLiteral(phys_type),
                         src_span,
-                        Some(self.source()),
                     );
                     unsafe {
                         self.arena.add_implicit(phys_type.id(), secondary_unit);

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -728,7 +728,7 @@ pub struct SubprogramDeclaration {
 #[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct InterfaceFileDeclaration {
-    pub ident: WithDecl<Ident>,
+    pub idents: Vec<WithDecl<Ident>>,
     pub subtype_indication: SubtypeIndication,
 }
 
@@ -737,7 +737,7 @@ pub struct InterfaceFileDeclaration {
 #[derive(PartialEq, Debug, Clone)]
 pub struct InterfaceObjectDeclaration {
     pub list_type: InterfaceType,
-    pub ident: WithDecl<Ident>,
+    pub idents: Vec<WithDecl<Ident>>,
     pub mode: ModeIndication,
 }
 

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -622,7 +622,7 @@ pub enum InterfaceType {
 #[derive(PartialEq, Debug, Clone)]
 pub struct ObjectDeclaration {
     pub class: ObjectClass,
-    pub ident: WithDecl<Ident>,
+    pub idents: Vec<WithDecl<Ident>>,
     pub subtype_indication: SubtypeIndication,
     pub expression: Option<WithTokenSpan<Expression>>,
 }
@@ -845,6 +845,12 @@ pub enum Declaration {
     Package(PackageInstantiation),
     Configuration(ConfigurationSpecification),
     View(ModeViewDeclaration),
+}
+
+impl Declaration {
+    pub fn declarations(&self) -> Vec<EntityId> {
+        todo!()
+    }
 }
 
 /// LRM 10.2 Wait statement

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -391,7 +391,7 @@ pub enum ArrayIndex {
 #[with_token_span]
 #[derive(PartialEq, Debug, Clone)]
 pub struct ElementDeclaration {
-    pub ident: WithDecl<Ident>,
+    pub idents: Vec<WithDecl<Ident>>,
     pub subtype: SubtypeIndication,
 }
 

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -7,6 +7,7 @@
 //! Implementation of Display
 
 use super::*;
+use itertools::Itertools;
 use std::fmt::{Display, Formatter, Result};
 
 impl<T: Display> Display for WithTokenSpan<T> {
@@ -613,7 +614,12 @@ impl Display for ArrayIndex {
 
 impl Display for ElementDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{} : {}", self.ident, self.subtype)
+        write!(
+            f,
+            "{} : {}",
+            self.idents.iter().map(|item| format!("{item}")).join(", "),
+            self.subtype
+        )
     }
 }
 

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -763,7 +763,12 @@ impl Display for ObjectDeclaration {
         write!(
             f,
             "{} {} : {}",
-            self.class, self.ident, self.subtype_indication,
+            self.class,
+            self.idents
+                .iter()
+                .map(|ident| format!("{}", ident))
+                .join(", "),
+            self.subtype_indication,
         )?;
         match self.expression {
             Some(ref expr) => write!(f, " := {expr};"),

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -938,7 +938,15 @@ fn write_separated_list<T: Display>(
 
 impl Display for InterfaceFileDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "file {} : {}", self.ident, self.subtype_indication)
+        write!(
+            f,
+            "file {} : {}",
+            self.idents
+                .iter()
+                .map(|ident| format!("{ident}"))
+                .join(", "),
+            self.subtype_indication
+        )
     }
 }
 
@@ -985,16 +993,37 @@ impl Display for InterfaceObjectDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.list_type {
             InterfaceType::Port => {
-                write!(f, "{} : {}", self.ident, self.mode)
+                write!(
+                    f,
+                    "{} : {}",
+                    self.idents.iter().map(|el| format!("{el}")).join(", "),
+                    self.mode
+                )
             }
             InterfaceType::Generic => {
-                write!(f, "{} : {}", self.ident, self.mode)
+                write!(
+                    f,
+                    "{} : {}",
+                    self.idents.iter().map(|el| format!("{el}")).join(", "),
+                    self.mode
+                )
             }
             InterfaceType::Parameter => {
                 if let ModeIndication::Simple(mode) = &self.mode {
-                    write!(f, "{} {} : {}", mode.class, self.ident, self.mode)
+                    write!(
+                        f,
+                        "{} {} : {}",
+                        mode.class,
+                        self.idents.iter().map(|el| format!("{el}")).join(", "),
+                        self.mode
+                    )
                 } else {
-                    write!(f, "{} : {}", self.ident, self.mode)
+                    write!(
+                        f,
+                        "{} : {}",
+                        self.idents.iter().map(|el| format!("{el}")).join(", "),
+                        self.mode
+                    )
                 }
             }
         }

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -999,12 +999,14 @@ impl Search for WithTokenSpan<Expression> {
 
 impl Search for ObjectDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
-        return_if_found!(searcher
-            .search_decl(
-                ctx,
-                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Object(self))
-            )
-            .or_not_found());
+        for ident in &self.idents {
+            return_if_found!(searcher
+                .search_decl(
+                    ctx,
+                    FoundDeclaration::new(&ident.decl, DeclarationItem::Object(self))
+                )
+                .or_not_found());
+        }
         return_if_found!(self.subtype_indication.search(ctx, searcher));
         if let Some(ref expr) = self.expression {
             expr.search(ctx, searcher)

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -756,9 +756,11 @@ impl Search for TypeDeclaration {
             }
             TypeDefinition::Record(ref element_decls) => {
                 for elem in element_decls {
-                    return_if_found!(searcher
-                        .search_decl(ctx, FoundDeclaration::ElementDeclaration(elem))
-                        .or_not_found());
+                    for ident in &elem.idents {
+                        return_if_found!(searcher
+                            .search_decl(ctx, FoundDeclaration::ElementDeclaration(elem))
+                            .or_not_found());
+                    }
                     return_if_found!(elem.subtype.search(ctx, searcher));
                 }
             }
@@ -1713,7 +1715,7 @@ impl<'a> FoundDeclaration<'a> {
             FoundDeclaration::SubprogramDecl(value) => value.ent_id_ref(),
             FoundDeclaration::SubprogramInstantiation(value) => &value.ident.decl,
             FoundDeclaration::Object(value) => &value.ident.decl,
-            FoundDeclaration::ElementDeclaration(elem) => &elem.ident.decl,
+            FoundDeclaration::ElementDeclaration(_) => todo!(),
             FoundDeclaration::EnumerationLiteral(_, elem) => &elem.decl,
             FoundDeclaration::File(value) => &value.ident.decl,
             FoundDeclaration::Type(value) => &value.ident.decl,

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -1232,15 +1232,17 @@ impl Search for InterfaceDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         match self {
             InterfaceDeclaration::Object(ref decl) => {
-                return_if_found!(searcher
-                    .search_decl(
-                        ctx,
-                        FoundDeclaration::new(
-                            &decl.ident.decl,
-                            DeclarationItem::InterfaceObject(decl)
+                for ident in &decl.idents {
+                    return_if_found!(searcher
+                        .search_decl(
+                            ctx,
+                            FoundDeclaration::new(
+                                &ident.decl,
+                                DeclarationItem::InterfaceObject(decl)
+                            )
                         )
-                    )
-                    .or_not_found());
+                        .or_not_found());
+                }
                 return_if_found!(decl.mode.search(ctx, searcher));
             }
             InterfaceDeclaration::Subprogram(ref subprogram_decl) => {
@@ -1291,15 +1293,17 @@ impl Search for InterfaceDeclaration {
                 }
             }
             InterfaceDeclaration::File(decl) => {
-                return_if_found!(searcher
-                    .search_decl(
-                        ctx,
-                        FoundDeclaration::new(
-                            &decl.ident.decl,
-                            DeclarationItem::InterfaceFile(decl)
+                for ident in &decl.idents {
+                    return_if_found!(searcher
+                        .search_decl(
+                            ctx,
+                            FoundDeclaration::new(
+                                &ident.decl,
+                                DeclarationItem::InterfaceFile(decl)
+                            )
                         )
-                    )
-                    .or_not_found());
+                        .or_not_found());
+                }
             }
         };
         NotFound

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use crate::analysis::DesignRoot;
-use crate::named_entity::{EntRef, HasEntityId, Reference, Related};
+use crate::named_entity::{EntRef, HasEntityId, Reference};
 use crate::syntax::{HasTokenSpan, TokenAccess};
 
 #[must_use]
@@ -36,7 +36,7 @@ impl SearchState {
 }
 
 #[derive(PartialEq, Debug)]
-pub enum FoundDeclaration<'a> {
+pub enum DeclarationItem<'a> {
     Object(&'a ObjectDeclaration),
     ElementDeclaration(&'a ElementDeclaration),
     EnumerationLiteral(&'a Ident, &'a WithDecl<WithToken<EnumerationLiteral>>),
@@ -67,6 +67,17 @@ pub enum FoundDeclaration<'a> {
     ConcurrentStatement(&'a LabeledConcurrentStatement),
     SequentialStatement(&'a LabeledSequentialStatement),
     View(&'a ModeViewDeclaration),
+}
+
+pub struct FoundDeclaration<'a> {
+    pub reference: &'a Reference,
+    pub ast: DeclarationItem<'a>,
+}
+
+impl<'a> FoundDeclaration<'a> {
+    pub fn new(reference: &'a Reference, ast: DeclarationItem<'a>) -> FoundDeclaration<'a> {
+        FoundDeclaration { reference, ast }
+    }
 }
 
 pub trait Searcher {
@@ -278,7 +289,10 @@ impl<T: Search> Search for SeparatedList<T> {
 impl Search for LabeledSequentialStatement {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::SequentialStatement(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.label.decl, DeclarationItem::SequentialStatement(self))
+            )
             .or_not_found());
         match self.statement.item {
             SequentialStatement::Return(ref ret) => {
@@ -353,7 +367,13 @@ impl Search for LabeledSequentialStatement {
                 match iteration_scheme {
                     Some(IterationScheme::For(ref index, ref drange)) => {
                         return_if_found!(searcher
-                            .search_decl(ctx, FoundDeclaration::ForIndex(index, drange))
+                            .search_decl(
+                                ctx,
+                                FoundDeclaration::new(
+                                    &index.decl,
+                                    DeclarationItem::ForIndex(index, drange)
+                                )
+                            )
                             .or_not_found());
                         return_if_found!(drange.search(ctx, searcher));
                         return_if_found!(statements.search(ctx, searcher));
@@ -415,7 +435,10 @@ impl Search for GenerateBody {
         } = self;
         if let Some(ref label) = alternative_label {
             return_if_found!(searcher
-                .search_decl(ctx, FoundDeclaration::GenerateBody(label))
+                .search_decl(
+                    ctx,
+                    FoundDeclaration::new(&label.decl, DeclarationItem::GenerateBody(label))
+                )
                 .or_not_found());
         }
         return_if_found!(decl.search(ctx, searcher));
@@ -474,7 +497,10 @@ impl Search for SensitivityList {
 impl Search for LabeledConcurrentStatement {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::ConcurrentStatement(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.label.decl, DeclarationItem::ConcurrentStatement(self))
+            )
             .or_not_found());
         match self.statement.item {
             ConcurrentStatement::Block(ref block) => {
@@ -499,7 +525,10 @@ impl Search for LabeledConcurrentStatement {
                 return_if_found!(searcher
                     .search_decl(
                         ctx,
-                        FoundDeclaration::ForGenerateIndex(self.label.tree.as_ref(), gen)
+                        FoundDeclaration::new(
+                            &gen.index_name.decl,
+                            DeclarationItem::ForGenerateIndex(self.label.tree.as_ref(), gen)
+                        )
                     )
                     .or_not_found());
                 let ForGenerateStatement {
@@ -738,7 +767,10 @@ impl Search for DiscreteRange {
 impl Search for TypeDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Type(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Type(self))
+            )
             .or_not_found());
 
         match self.def {
@@ -758,7 +790,13 @@ impl Search for TypeDeclaration {
                 for elem in element_decls {
                     for ident in &elem.idents {
                         return_if_found!(searcher
-                            .search_decl(ctx, FoundDeclaration::ElementDeclaration(elem))
+                            .search_decl(
+                                ctx,
+                                FoundDeclaration::new(
+                                    &ident.decl,
+                                    DeclarationItem::ElementDeclaration(elem)
+                                )
+                            )
                             .or_not_found());
                     }
                     return_if_found!(elem.subtype.search(ctx, searcher));
@@ -800,7 +838,10 @@ impl Search for TypeDeclaration {
                     return_if_found!(searcher
                         .search_decl(
                             ctx,
-                            FoundDeclaration::EnumerationLiteral(&self.ident.tree, literal)
+                            FoundDeclaration::new(
+                                &literal.decl,
+                                DeclarationItem::EnumerationLiteral(&self.ident.tree, literal)
+                            )
                         )
                         .or_not_found());
                 }
@@ -813,11 +854,23 @@ impl Search for TypeDeclaration {
                 } = physical;
                 return_if_found!(range.search(ctx, searcher));
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::PhysicalTypePrimary(primary_unit))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &primary_unit.decl,
+                            DeclarationItem::PhysicalTypePrimary(primary_unit)
+                        )
+                    )
                     .or_not_found());
                 for (ident, literal) in secondary_units.iter() {
                     return_if_found!(searcher
-                        .search_decl(ctx, FoundDeclaration::PhysicalTypeSecondary(ident, literal))
+                        .search_decl(
+                            ctx,
+                            FoundDeclaration::new(
+                                &ident.decl,
+                                DeclarationItem::PhysicalTypeSecondary(ident, literal)
+                            )
+                        )
                         .or_not_found());
                     return_if_found!(searcher.search_ident_ref(ctx, &literal.unit).or_not_found());
                 }
@@ -947,7 +1000,10 @@ impl Search for WithTokenSpan<Expression> {
 impl Search for ObjectDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Object(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Object(self))
+            )
             .or_not_found());
         return_if_found!(self.subtype_indication.search(ctx, searcher));
         if let Some(ref expr) = self.expression {
@@ -990,7 +1046,13 @@ impl Search for Declaration {
             }
             Declaration::SubprogramBody(body) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::Subprogram(body))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            body.specification.ent_id_ref(),
+                            DeclarationItem::Subprogram(body)
+                        )
+                    )
                     .or_not_found());
                 return_if_found!(search_subpgm_inner(&body.specification, ctx, searcher));
                 return_if_found!(body.declarations.search(ctx, searcher));
@@ -1004,7 +1066,10 @@ impl Search for Declaration {
             }
             Declaration::Attribute(Attribute::Declaration(decl)) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::Attribute(decl))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(&decl.ident.decl, DeclarationItem::Attribute(decl))
+                    )
                     .or_not_found());
                 return_if_found!(decl.type_mark.search(ctx, searcher));
             }
@@ -1032,7 +1097,13 @@ impl Search for Declaration {
             }
             Declaration::Alias(alias) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::Alias(alias))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &alias.designator.decl,
+                            DeclarationItem::Alias(alias)
+                        )
+                    )
                     .or_not_found());
                 let AliasDeclaration {
                     designator: _,
@@ -1054,7 +1125,13 @@ impl Search for Declaration {
             }
             Declaration::Component(component) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::Component(component))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &component.ident.decl,
+                            DeclarationItem::Component(component)
+                        )
+                    )
                     .or_not_found());
                 let ComponentDeclaration {
                     ident: _,
@@ -1069,7 +1146,10 @@ impl Search for Declaration {
 
             Declaration::File(file) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::File(file))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(&file.ident.decl, DeclarationItem::File(file))
+                    )
                     .or_not_found());
                 let FileDeclaration {
                     ident: _,
@@ -1091,7 +1171,10 @@ impl Search for Declaration {
             }
             Declaration::View(view) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::View(view))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(&view.ident.decl, DeclarationItem::View(view))
+                    )
                     .or_not_found());
                 let ModeViewDeclaration {
                     ident: _,
@@ -1148,7 +1231,13 @@ impl Search for InterfaceDeclaration {
         match self {
             InterfaceDeclaration::Object(ref decl) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::InterfaceObject(decl))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &decl.ident.decl,
+                            DeclarationItem::InterfaceObject(decl)
+                        )
+                    )
                     .or_not_found());
                 return_if_found!(decl.mode.search(ctx, searcher));
             }
@@ -1156,7 +1245,10 @@ impl Search for InterfaceDeclaration {
                 return_if_found!(searcher
                     .search_decl(
                         ctx,
-                        FoundDeclaration::SubprogramDecl(&subprogram_decl.specification)
+                        FoundDeclaration::new(
+                            subprogram_decl.specification.ent_id_ref(),
+                            DeclarationItem::SubprogramDecl(&subprogram_decl.specification)
+                        )
                     )
                     .or_not_found());
 
@@ -1171,12 +1263,21 @@ impl Search for InterfaceDeclaration {
             }
             InterfaceDeclaration::Type(decl) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::InterfaceType(decl))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(&decl.decl, DeclarationItem::InterfaceType(decl))
+                    )
                     .or_not_found());
             }
             InterfaceDeclaration::Package(package_instance) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::InterfacePackage(package_instance))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &package_instance.ident.decl,
+                            DeclarationItem::InterfacePackage(package_instance)
+                        )
+                    )
                     .or_not_found());
                 return_if_found!(package_instance.package_name.search(ctx, searcher));
                 match package_instance.generic_map {
@@ -1189,7 +1290,13 @@ impl Search for InterfaceDeclaration {
             }
             InterfaceDeclaration::File(decl) => {
                 return_if_found!(searcher
-                    .search_decl(ctx, FoundDeclaration::InterfaceFile(decl))
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &decl.ident.decl,
+                            DeclarationItem::InterfaceFile(decl)
+                        )
+                    )
                     .or_not_found());
             }
         };
@@ -1206,7 +1313,10 @@ impl Search for SubprogramDeclaration {
 impl Search for SubprogramSpecification {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::SubprogramDecl(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(self.ent_id_ref(), DeclarationItem::SubprogramDecl(self))
+            )
             .or_not_found());
         search_subpgm_inner(self, ctx, searcher)
     }
@@ -1288,7 +1398,10 @@ impl Search for EntityDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(self.context_clause.search(ctx, searcher));
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Entity(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Entity(self))
+            )
             .or_not_found());
         return_if_found!(self.generic_clause.search(ctx, searcher));
         return_if_found!(self.port_clause.search(ctx, searcher));
@@ -1304,7 +1417,10 @@ impl Search for ArchitectureBody {
             .search_ident_ref(ctx, &self.entity_name)
             .or_not_found());
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Architecture(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Architecture(self))
+            )
             .or_not_found());
         return_if_found!(self.decl.search(ctx, searcher));
         self.statements.search(ctx, searcher)
@@ -1315,7 +1431,10 @@ impl Search for PackageDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(self.context_clause.search(ctx, searcher));
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Package(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Package(self))
+            )
             .or_not_found());
         return_if_found!(self.generic_clause.search(ctx, searcher));
         self.decl.search(ctx, searcher)
@@ -1326,7 +1445,10 @@ impl Search for PackageBody {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(self.context_clause.search(ctx, searcher));
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::PackageBody(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::PackageBody(self))
+            )
             .or_not_found());
         self.decl.search(ctx, searcher)
     }
@@ -1336,7 +1458,10 @@ impl Search for PackageInstantiation {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(self.context_clause.search(ctx, searcher));
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::PackageInstance(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::PackageInstance(self))
+            )
             .or_not_found());
         return_if_found!(self.generic_map.search(ctx, searcher));
         self.package_name.search(ctx, searcher)
@@ -1347,7 +1472,10 @@ impl Search for ConfigurationDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(self.context_clause.search(ctx, searcher));
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Configuration(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Configuration(self))
+            )
             .or_not_found());
         self.entity_name.search(ctx, searcher)
     }
@@ -1356,7 +1484,10 @@ impl Search for ConfigurationDeclaration {
 impl Search for ContextDeclaration {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::Context(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(&self.ident.decl, DeclarationItem::Context(self))
+            )
             .or_not_found());
         self.items.search(ctx, searcher)
     }
@@ -1385,7 +1516,13 @@ impl Search for MapAspect {
 impl Search for SubprogramInstantiation {
     fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
         return_if_found!(searcher
-            .search_decl(ctx, FoundDeclaration::SubprogramInstantiation(self))
+            .search_decl(
+                ctx,
+                FoundDeclaration::new(
+                    &self.ident.decl,
+                    DeclarationItem::SubprogramInstantiation(self)
+                )
+            )
             .or_not_found());
         return_if_found!(self.subprogram_name.search(ctx, searcher));
         if let Some(signature) = &self.signature {
@@ -1554,17 +1691,17 @@ impl<'a> Searcher for FormatDeclaration<'a> {
             return NotFinished;
         };
 
-        if is_implicit_of(self.ent, id) {
+        if self.ent.is_implicit_of(id) {
             // Implicit
             self.result = Some(format!(
                 "-- {}\n\n-- Implicitly defined by:\n{}\n",
                 self.ent.describe(),
-                decl,
+                decl.ast,
             ));
             return Finished(Found);
         } else if self.ent.id() == id {
             // Explicit
-            self.result = Some(decl.to_string());
+            self.result = Some(decl.ast.to_string());
             return Finished(Found);
         }
         NotFinished
@@ -1578,49 +1715,16 @@ pub struct FindAllReferences<'a> {
     pub references: Vec<SrcPos>,
 }
 
-fn is_instance_of(ent: EntRef, other: EntRef) -> bool {
-    if let Related::InstanceOf(ent) = ent.related {
-        if ent.id() == other.id() {
-            return true;
-        }
-
-        if is_instance_of(ent, other) {
-            return true;
-        }
-    }
-
-    false
-}
-
-fn is_declared_by(ent: EntRef, other: EntRef) -> bool {
-    if let Related::DeclaredBy(ent) = ent.related {
-        if ent.id() == other.id() {
-            return true;
-        }
-    }
-
-    false
-}
-
-fn is_implicit_of(ent: EntRef, id: EntityId) -> bool {
-    match ent.related {
-        Related::ImplicitOf(ent) => ent.id() == id,
-        Related::InstanceOf(ent) => is_implicit_of(ent, id),
-        Related::None => false,
-        Related::DeclaredBy(_) => false,
-    }
-}
-
-fn is_reference(ent: EntRef, other: EntRef) -> bool {
+pub fn is_reference(ent: EntRef, other: EntRef) -> bool {
     if ent.id() == other.id() {
         return true;
     }
 
-    if is_instance_of(ent, other) || is_instance_of(other, ent) {
+    if ent.is_instance_of(other) || other.is_instance_of(ent) {
         return true;
     }
 
-    if is_declared_by(ent, other) || is_declared_by(other, ent) {
+    if ent.is_declared_by(other) || other.is_declared_by(ent) {
         return true;
     }
 
@@ -1672,73 +1776,42 @@ impl<'a> Searcher for FindAllReferences<'a> {
 
 impl<'a> FoundDeclaration<'a> {
     fn end_ident_pos(&self) -> Option<TokenId> {
-        match self {
-            FoundDeclaration::InterfaceObject(_) => None,
-            FoundDeclaration::ForIndex(..) => None,
-            FoundDeclaration::ForGenerateIndex(..) => None,
-            FoundDeclaration::Subprogram(value) => value.end_ident_pos,
-            FoundDeclaration::SubprogramDecl(..) => None,
-            FoundDeclaration::Object(..) => None,
-            FoundDeclaration::ElementDeclaration(..) => None,
-            FoundDeclaration::EnumerationLiteral(..) => None,
-            FoundDeclaration::File(..) => None,
-            FoundDeclaration::Type(value) => value.end_ident_pos,
-            FoundDeclaration::InterfaceType(..) => None,
-            FoundDeclaration::InterfacePackage(..) => None,
-            FoundDeclaration::InterfaceFile(..) => None,
-            FoundDeclaration::PhysicalTypePrimary(..) => None,
-            FoundDeclaration::PhysicalTypeSecondary(..) => None,
-            FoundDeclaration::Component(value) => value.end_ident_pos,
-            FoundDeclaration::Attribute(..) => None,
-            FoundDeclaration::Alias(..) => None,
-            FoundDeclaration::Package(value) => value.end_ident_pos,
-            FoundDeclaration::PackageBody(value) => value.end_ident_pos,
-            FoundDeclaration::PackageInstance(..) => None,
-            FoundDeclaration::Configuration(value) => value.end_ident_pos,
-            FoundDeclaration::Entity(value) => value.end_ident_pos,
-            FoundDeclaration::Architecture(value) => value.end_ident_pos,
-            FoundDeclaration::Context(value) => value.end_ident_pos,
-            FoundDeclaration::GenerateBody(..) => None,
-            FoundDeclaration::ConcurrentStatement(..) => None,
-            FoundDeclaration::SequentialStatement(..) => None,
-            FoundDeclaration::SubprogramInstantiation(_) => None,
-            FoundDeclaration::View(view) => view.end_ident_pos,
+        match &self.ast {
+            DeclarationItem::InterfaceObject(_) => None,
+            DeclarationItem::ForIndex(..) => None,
+            DeclarationItem::ForGenerateIndex(..) => None,
+            DeclarationItem::Subprogram(value) => value.end_ident_pos,
+            DeclarationItem::SubprogramDecl(..) => None,
+            DeclarationItem::Object(..) => None,
+            DeclarationItem::ElementDeclaration(..) => None,
+            DeclarationItem::EnumerationLiteral(..) => None,
+            DeclarationItem::File(..) => None,
+            DeclarationItem::Type(value) => value.end_ident_pos,
+            DeclarationItem::InterfaceType(..) => None,
+            DeclarationItem::InterfacePackage(..) => None,
+            DeclarationItem::InterfaceFile(..) => None,
+            DeclarationItem::PhysicalTypePrimary(..) => None,
+            DeclarationItem::PhysicalTypeSecondary(..) => None,
+            DeclarationItem::Component(value) => value.end_ident_pos,
+            DeclarationItem::Attribute(..) => None,
+            DeclarationItem::Alias(..) => None,
+            DeclarationItem::Package(value) => value.end_ident_pos,
+            DeclarationItem::PackageBody(value) => value.end_ident_pos,
+            DeclarationItem::PackageInstance(..) => None,
+            DeclarationItem::Configuration(value) => value.end_ident_pos,
+            DeclarationItem::Entity(value) => value.end_ident_pos,
+            DeclarationItem::Architecture(value) => value.end_ident_pos,
+            DeclarationItem::Context(value) => value.end_ident_pos,
+            DeclarationItem::GenerateBody(..) => None,
+            DeclarationItem::ConcurrentStatement(..) => None,
+            DeclarationItem::SequentialStatement(..) => None,
+            DeclarationItem::SubprogramInstantiation(_) => None,
+            DeclarationItem::View(view) => view.end_ident_pos,
         }
     }
 
     fn ent_id_ref(&self) -> &Reference {
-        match self {
-            FoundDeclaration::InterfaceObject(value) => &value.ident.decl,
-            FoundDeclaration::ForIndex(ident, _) => &ident.decl,
-            FoundDeclaration::ForGenerateIndex(_, value) => &value.index_name.decl,
-            FoundDeclaration::Subprogram(value) => value.specification.ent_id_ref(),
-            FoundDeclaration::SubprogramDecl(value) => value.ent_id_ref(),
-            FoundDeclaration::SubprogramInstantiation(value) => &value.ident.decl,
-            FoundDeclaration::Object(value) => &value.ident.decl,
-            FoundDeclaration::ElementDeclaration(_) => todo!(),
-            FoundDeclaration::EnumerationLiteral(_, elem) => &elem.decl,
-            FoundDeclaration::File(value) => &value.ident.decl,
-            FoundDeclaration::Type(value) => &value.ident.decl,
-            FoundDeclaration::InterfaceType(value) => &value.decl,
-            FoundDeclaration::InterfacePackage(value) => &value.ident.decl,
-            FoundDeclaration::InterfaceFile(value) => &value.ident.decl,
-            FoundDeclaration::PhysicalTypePrimary(value) => &value.decl,
-            FoundDeclaration::PhysicalTypeSecondary(value, _) => &value.decl,
-            FoundDeclaration::Component(value) => &value.ident.decl,
-            FoundDeclaration::Attribute(value) => &value.ident.decl,
-            FoundDeclaration::Alias(value) => &value.designator.decl,
-            FoundDeclaration::Package(value) => &value.ident.decl,
-            FoundDeclaration::PackageBody(value) => &value.ident.decl,
-            FoundDeclaration::PackageInstance(value) => &value.ident.decl,
-            FoundDeclaration::Configuration(value) => &value.ident.decl,
-            FoundDeclaration::Entity(value) => &value.ident.decl,
-            FoundDeclaration::Architecture(value) => &value.ident.decl,
-            FoundDeclaration::Context(value) => &value.ident.decl,
-            FoundDeclaration::GenerateBody(value) => &value.decl,
-            FoundDeclaration::ConcurrentStatement(value) => &value.label.decl,
-            FoundDeclaration::SequentialStatement(value) => &value.label.decl,
-            FoundDeclaration::View(value) => &value.ident.decl,
-        }
+        self.reference
     }
 }
 
@@ -1757,109 +1830,109 @@ impl<'a> HasEntityId for FoundDeclaration<'a> {
     }
 }
 
-impl std::fmt::Display for FoundDeclaration<'_> {
+impl std::fmt::Display for DeclarationItem<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FoundDeclaration::InterfaceObject(ref value) => match value.list_type {
+            DeclarationItem::InterfaceObject(ref value) => match value.list_type {
                 InterfaceType::Port => write!(f, "port {value};"),
                 InterfaceType::Generic => write!(f, "generic {value};"),
                 InterfaceType::Parameter => write!(f, "{value};"),
             },
-            FoundDeclaration::ForIndex(ref ident, ref drange) => {
+            DeclarationItem::ForIndex(ref ident, ref drange) => {
                 write!(f, "for {ident} in {drange} loop")
             }
-            FoundDeclaration::ForGenerateIndex(ref ident, ref value) => match ident {
+            DeclarationItem::ForGenerateIndex(ref ident, ref value) => match ident {
                 Some(ident) => write!(f, "{ident}: {value}"),
                 None => write!(f, "{value}"),
             },
-            FoundDeclaration::Subprogram(value) => {
+            DeclarationItem::Subprogram(value) => {
                 write!(f, "{};", value.specification)
             }
-            FoundDeclaration::SubprogramDecl(ref value) => {
+            DeclarationItem::SubprogramDecl(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::SubprogramInstantiation(ref value) => {
+            DeclarationItem::SubprogramInstantiation(ref value) => {
                 write!(f, "{value};")
             }
-            FoundDeclaration::Object(ref value) => {
+            DeclarationItem::Object(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::ElementDeclaration(elem) => {
+            DeclarationItem::ElementDeclaration(elem) => {
                 write!(f, "{elem}")
             }
-            FoundDeclaration::EnumerationLiteral(ident, elem) => {
+            DeclarationItem::EnumerationLiteral(ident, elem) => {
                 write!(f, "{elem} : {ident}")
             }
-            FoundDeclaration::File(ref value) => {
+            DeclarationItem::File(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::PhysicalTypePrimary(ref value) => {
+            DeclarationItem::PhysicalTypePrimary(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::PhysicalTypeSecondary(_, ref literal) => {
+            DeclarationItem::PhysicalTypeSecondary(_, ref literal) => {
                 write!(f, "{literal}")
             }
-            FoundDeclaration::Type(ref value) => {
+            DeclarationItem::Type(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::InterfaceType(ref value) => {
+            DeclarationItem::InterfaceType(ref value) => {
                 write!(f, "type {value}")
             }
-            FoundDeclaration::InterfacePackage(value) => {
+            DeclarationItem::InterfacePackage(value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::InterfaceFile(value) => {
+            DeclarationItem::InterfaceFile(value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Component(ref value) => {
+            DeclarationItem::Component(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Alias(ref value) => {
+            DeclarationItem::Alias(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Attribute(ref value) => {
+            DeclarationItem::Attribute(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Package(ref value) => {
+            DeclarationItem::Package(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::PackageBody(value) => {
+            DeclarationItem::PackageBody(value) => {
                 // Will never be shown has hover will goto the declaration
                 write!(f, "package body {}", value.name())
             }
-            FoundDeclaration::PackageInstance(ref value) => {
+            DeclarationItem::PackageInstance(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Configuration(ref value) => {
+            DeclarationItem::Configuration(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Entity(ref value) => {
+            DeclarationItem::Entity(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::Architecture(value) => {
+            DeclarationItem::Architecture(value) => {
                 write!(f, "architecture {} of {}", value.ident(), value.entity_name)
             }
-            FoundDeclaration::Context(ref value) => {
+            DeclarationItem::Context(ref value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::GenerateBody(value) => {
+            DeclarationItem::GenerateBody(value) => {
                 write!(f, "{value}")
             }
-            FoundDeclaration::ConcurrentStatement(value) => {
+            DeclarationItem::ConcurrentStatement(value) => {
                 if let Some(ref label) = value.label.tree {
                     write!(f, "{label}")
                 } else {
                     write!(f, "<anonymous statement>")
                 }
             }
-            FoundDeclaration::SequentialStatement(value) => {
+            DeclarationItem::SequentialStatement(value) => {
                 if let Some(ref label) = value.label.tree {
                     write!(f, "{label}")
                 } else {
                     write!(f, "<anonymous statement>")
                 }
             }
-            FoundDeclaration::View(value) => write!(f, "view {} of {}", value.ident, value.typ),
+            DeclarationItem::View(value) => write!(f, "view {} of {}", value.ident, value.typ),
         }
     }
 }

--- a/vhdl_lang/src/completion/generic.rs
+++ b/vhdl_lang/src/completion/generic.rs
@@ -10,7 +10,7 @@ use crate::ast::ArchitectureBody;
 use crate::completion::entity_instantiation::get_visible_entities_from_architecture;
 use crate::completion::region::completion_items_from_region;
 use crate::named_entity::{DesignEnt, Visibility};
-use crate::{CompletionItem, Design, HasEntityId, HasTokenSpan, Position, Source, TokenAccess};
+use crate::{CompletionItem, Design, HasTokenSpan, Position, Source, TokenAccess};
 use itertools::{chain, Itertools};
 use vhdl_lang::analysis::DesignRoot;
 
@@ -108,7 +108,7 @@ impl<'a> Searcher for CompletionSearcher<'a> {
                     subprogram
                         .declarations
                         .iter()
-                        .flat_map(|decl| decl.item.ent_id())
+                        .flat_map(|decl| decl.item.declarations())
                         .map(|id| CompletionItem::Simple(self.root.get_ent(id))),
                 );
                 return NotFinished;

--- a/vhdl_lang/src/completion/generic.rs
+++ b/vhdl_lang/src/completion/generic.rs
@@ -3,7 +3,9 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) 2024, Olof Kraigher olof.kraigher@gmail.com
-use crate::ast::search::{Finished, Found, FoundDeclaration, NotFinished, SearchState, Searcher};
+use crate::ast::search::{
+    DeclarationItem, Finished, Found, FoundDeclaration, NotFinished, SearchState, Searcher,
+};
 use crate::ast::ArchitectureBody;
 use crate::completion::entity_instantiation::get_visible_entities_from_architecture;
 use crate::completion::region::completion_items_from_region;
@@ -72,33 +74,33 @@ impl<'a> CompletionSearcher<'a> {
 
 impl<'a> Searcher for CompletionSearcher<'a> {
     fn search_decl(&mut self, ctx: &dyn TokenAccess, decl: FoundDeclaration) -> SearchState {
-        let ent_id = match decl {
-            FoundDeclaration::Entity(ent_decl) => {
+        let ent_id = match &decl.ast {
+            DeclarationItem::Entity(ent_decl) => {
                 if !ent_decl.get_pos(ctx).contains(self.cursor) {
                     return NotFinished;
                 }
                 ent_decl.ident.decl.get()
             }
-            FoundDeclaration::Architecture(body) => {
+            DeclarationItem::Architecture(body) => {
                 if !body.get_pos(ctx).contains(self.cursor) {
                     return NotFinished;
                 }
                 self.add_entity_instantiations(ctx, body);
                 body.ident.decl.get()
             }
-            FoundDeclaration::Package(package) => {
+            DeclarationItem::Package(package) => {
                 if !package.get_pos(ctx).contains(self.cursor) {
                     return NotFinished;
                 }
                 package.ident.decl.get()
             }
-            FoundDeclaration::PackageBody(package) => {
+            DeclarationItem::PackageBody(package) => {
                 if !package.get_pos(ctx).contains(self.cursor) {
                     return NotFinished;
                 }
                 package.ident.decl.get()
             }
-            FoundDeclaration::Subprogram(subprogram) => {
+            DeclarationItem::Subprogram(subprogram) => {
                 if !subprogram.get_pos(ctx).contains(self.cursor) {
                     return NotFinished;
                 }

--- a/vhdl_lang/src/completion/map_aspect.rs
+++ b/vhdl_lang/src/completion/map_aspect.rs
@@ -4,7 +4,9 @@
 //
 // Copyright (c) 2024, Olof Kraigher olof.kraigher@gmail.com
 use crate::analysis::DesignRoot;
-use crate::ast::search::{Finished, Found, FoundDeclaration, NotFinished, SearchState, Searcher};
+use crate::ast::search::{
+    DeclarationItem, Finished, Found, FoundDeclaration, NotFinished, SearchState, Searcher,
+};
 use crate::ast::{ConcurrentStatement, MapAspect, ObjectClass};
 use crate::named_entity::{AsUnique, Region};
 use crate::{
@@ -75,8 +77,8 @@ impl<'a> MapAspectSearcher<'a> {
 impl<'a> Searcher for MapAspectSearcher<'a> {
     /// Visit an instantiation statement extracting completions for ports or generics.
     fn search_decl(&mut self, ctx: &dyn TokenAccess, decl: FoundDeclaration) -> SearchState {
-        match decl {
-            FoundDeclaration::ConcurrentStatement(stmt) => {
+        match &decl.ast {
+            DeclarationItem::ConcurrentStatement(stmt) => {
                 if let ConcurrentStatement::Instance(inst) = &stmt.statement.item {
                     if let Some(map) = &inst.generic_map {
                         if self.load_completions_for_map_aspect(
@@ -100,7 +102,7 @@ impl<'a> Searcher for MapAspectSearcher<'a> {
                     }
                 }
             }
-            FoundDeclaration::PackageInstance(inst) => {
+            DeclarationItem::PackageInstance(inst) => {
                 if let Some(map) = &inst.generic_map {
                     if self.load_completions_for_map_aspect(
                         inst.package_name.item.get_suffix_reference(),

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -4,14 +4,14 @@
 //
 // Copyright (c) 2022, Olof Kraigher olof.kraigher@gmail.com
 
+use crate::ast::ExternalObjectClass;
 use crate::ast::{
     AliasDeclaration, AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, Attribute,
     AttributeDeclaration, AttributeSpecification, ComponentDeclaration, Designator,
-    FileDeclaration, HasIdent, Ident, InterfaceFileDeclaration, InterfacePackageDeclaration,
-    ModeViewDeclaration, ObjectClass, PackageInstantiation, SubprogramBody,
-    SubprogramInstantiation, SubprogramSpecification, TypeDeclaration, WithDecl,
+    FileDeclaration, HasIdent, Ident, InterfacePackageDeclaration, ModeViewDeclaration,
+    ObjectClass, PackageInstantiation, SubprogramBody, SubprogramInstantiation,
+    SubprogramSpecification, TypeDeclaration, WithDecl,
 };
-use crate::ast::{ExternalObjectClass, InterfaceDeclaration, InterfaceObjectDeclaration};
 use crate::data::*;
 mod types;
 use fnv::FnvHashMap;
@@ -673,30 +673,6 @@ impl HasEntityId for AnyDesignUnit {
                 AnySecondaryUnit::PackageBody(bod) => bod.ident.decl.get(),
             },
         }
-    }
-}
-
-impl HasEntityId for InterfaceDeclaration {
-    fn ent_id(&self) -> Option<EntityId> {
-        match self {
-            InterfaceDeclaration::Object(object) => object.ent_id(),
-            InterfaceDeclaration::File(file) => file.ent_id(),
-            InterfaceDeclaration::Type(typ) => typ.decl.get(),
-            InterfaceDeclaration::Subprogram(declaration) => declaration.specification.ent_id(),
-            InterfaceDeclaration::Package(pkg) => pkg.ent_id(),
-        }
-    }
-}
-
-impl HasEntityId for InterfaceObjectDeclaration {
-    fn ent_id(&self) -> Option<EntityId> {
-        self.ident.decl.get()
-    }
-}
-
-impl HasEntityId for InterfaceFileDeclaration {
-    fn ent_id(&self) -> Option<EntityId> {
-        self.ident.decl.get()
     }
 }
 

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -6,9 +6,9 @@
 
 use crate::ast::{
     AliasDeclaration, AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, Attribute,
-    AttributeDeclaration, AttributeSpecification, ComponentDeclaration, Declaration, Designator,
+    AttributeDeclaration, AttributeSpecification, ComponentDeclaration, Designator,
     FileDeclaration, HasIdent, Ident, InterfaceFileDeclaration, InterfacePackageDeclaration,
-    ModeViewDeclaration, ObjectClass, ObjectDeclaration, PackageInstantiation, SubprogramBody,
+    ModeViewDeclaration, ObjectClass, PackageInstantiation, SubprogramBody,
     SubprogramInstantiation, SubprogramSpecification, TypeDeclaration, WithDecl,
 };
 use crate::ast::{ExternalObjectClass, InterfaceDeclaration, InterfaceObjectDeclaration};
@@ -715,26 +715,6 @@ impl HasEntityId for InterfacePackageDeclaration {
     }
 }
 
-impl HasEntityId for Declaration {
-    fn ent_id(&self) -> Option<EntityId> {
-        match self {
-            Declaration::Object(object) => object.ent_id(),
-            Declaration::File(file) => file.ent_id(),
-            Declaration::Type(typ) => typ.ent_id(),
-            Declaration::Component(comp) => comp.ent_id(),
-            Declaration::Attribute(attr) => attr.ent_id(),
-            Declaration::Alias(alias) => alias.ent_id(),
-            Declaration::SubprogramDeclaration(decl) => decl.specification.ent_id(),
-            Declaration::SubprogramBody(body) => body.ent_id(),
-            Declaration::SubprogramInstantiation(decl) => decl.ent_id(),
-            Declaration::Package(pkg) => pkg.ent_id(),
-            Declaration::Use(_) => None,
-            Declaration::Configuration(_) => None,
-            Declaration::View(decl) => decl.ent_id(),
-        }
-    }
-}
-
 impl HasEntityId for SubprogramInstantiation {
     fn ent_id(&self) -> Option<EntityId> {
         self.ident.decl.get()
@@ -756,12 +736,6 @@ impl HasEntityId for SubprogramBody {
 impl HasEntityId for AliasDeclaration {
     fn ent_id(&self) -> Option<EntityId> {
         self.designator.decl.get()
-    }
-}
-
-impl HasEntityId for ObjectDeclaration {
-    fn ent_id(&self) -> Option<EntityId> {
-        self.ident.decl.get()
     }
 }
 

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -426,6 +426,23 @@ impl<'a> AnyEnt<'a> {
         false
     }
 
+    pub fn is_implicit_of(&self, other: EntityId) -> bool {
+        match &self.related {
+            Related::ImplicitOf(ent) => ent.id() == other,
+            Related::InstanceOf(ent) => ent.is_implicit_of(other),
+            Related::None => false,
+            Related::DeclaredBy(_) => false,
+        }
+    }
+
+    pub fn is_instance_of(&self, other: EntRef) -> bool {
+        if let Related::InstanceOf(ent) = &self.related {
+            ent.id() == other.id()
+        } else {
+            false
+        }
+    }
+
     pub fn is_explicit(&self) -> bool {
         !self.is_implicit()
     }

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -126,14 +126,8 @@ pub fn parse_declarative_part(
                             .map(|decl| decl.map_into(Declaration::File))
                             .collect()
                     }),
-                    Shared | Constant | Signal | Variable => {
-                        parse_object_declaration(ctx).map(|decls| {
-                            decls
-                                .into_iter()
-                                .map(|decl| decl.map_into(Declaration::Object))
-                                .collect()
-                        })
-                    }
+                    Shared | Constant | Signal | Variable => parse_object_declaration(ctx)
+                        .map(|decl| vec![decl.map_into(Declaration::Object)]),
                     Attribute => parse_attribute(ctx).map(|decls| {
                         decls
                             .into_iter()
@@ -268,7 +262,7 @@ constant x: natural := 5;
             Ok(vec![WithTokenSpan::new(
                 Declaration::Object(ObjectDeclaration {
                     class: ObjectClass::Constant,
-                    ident: code.s1("x").decl_ident(),
+                    idents: vec![code.s1("x").decl_ident()],
                     subtype_indication: code.s1("natural").subtype_indication(),
                     expression: Some(code.s1("5").expr())
                 }),

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -128,7 +128,7 @@ fn parse_interface_object_declaration(
     Ok(InterfaceDeclaration::Object(InterfaceObjectDeclaration {
         list_type,
         mode: mode.clone(),
-        idents: idents,
+        idents,
         span: TokenSpan::new(start_token, end_token),
     }))
 }

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -16,6 +16,7 @@ use crate::ast::token_range::WithToken;
 /// LRM 6.5 Interface declarations
 use crate::ast::*;
 use crate::data::*;
+use itertools::Itertools;
 use vhdl_lang::syntax::parser::ParsingContext;
 use vhdl_lang::VHDLStandard::VHDL2019;
 
@@ -64,9 +65,12 @@ fn parse_optional_object_class(
 
 fn parse_interface_file_declaration(
     ctx: &mut ParsingContext<'_>,
-) -> ParseResult<Vec<InterfaceDeclaration>> {
+) -> ParseResult<InterfaceDeclaration> {
     let start_token = ctx.stream.expect_kind(File)?;
-    let idents = parse_identifier_list(ctx)?;
+    let idents = parse_identifier_list(ctx)?
+        .into_iter()
+        .map(WithDecl::new)
+        .collect_vec();
     ctx.stream.expect_kind(Colon)?;
     let subtype = parse_subtype_indication(ctx)?;
 
@@ -89,26 +93,24 @@ fn parse_interface_file_declaration(
 
     let end_token = ctx.stream.get_last_token_id();
 
-    Ok(idents
-        .into_iter()
-        .map(|ident| {
-            InterfaceDeclaration::File(InterfaceFileDeclaration {
-                ident: ident.into(),
-                subtype_indication: subtype.clone(),
-                span: TokenSpan::new(start_token, end_token),
-            })
-        })
-        .collect())
+    Ok(InterfaceDeclaration::File(InterfaceFileDeclaration {
+        idents,
+        subtype_indication: subtype.clone(),
+        span: TokenSpan::new(start_token, end_token),
+    }))
 }
 
 fn parse_interface_object_declaration(
     ctx: &mut ParsingContext<'_>,
     list_type: InterfaceType,
-) -> ParseResult<Vec<InterfaceDeclaration>> {
+) -> ParseResult<InterfaceDeclaration> {
     let start_token = ctx.stream.get_current_token_id();
     let explicit_object_class = parse_optional_object_class(ctx, list_type)?;
 
-    let idents = parse_identifier_list(ctx)?;
+    let idents = parse_identifier_list(ctx)?
+        .into_iter()
+        .map(WithDecl::new)
+        .collect_vec();
 
     ctx.stream.expect_kind(Colon)?;
     let mode = if ctx.stream.next_kind_is(View) {
@@ -123,17 +125,12 @@ fn parse_interface_object_declaration(
     };
 
     let end_token = ctx.stream.get_last_token_id();
-    Ok(idents
-        .into_iter()
-        .map(|ident| {
-            InterfaceDeclaration::Object(InterfaceObjectDeclaration {
-                list_type,
-                mode: mode.clone(),
-                ident: ident.into(),
-                span: TokenSpan::new(start_token, end_token),
-            })
-        })
-        .collect())
+    Ok(InterfaceDeclaration::Object(InterfaceObjectDeclaration {
+        list_type,
+        mode: mode.clone(),
+        idents: idents,
+        span: TokenSpan::new(start_token, end_token),
+    }))
 }
 
 fn parse_view_mode_indication(ctx: &mut ParsingContext<'_>) -> ParseResult<ModeViewIndication> {
@@ -161,7 +158,7 @@ fn parse_simple_mode_indication(
     ctx: &mut ParsingContext<'_>,
     list_type: InterfaceType,
     explicit_object_class: Option<&WithToken<ObjectClass>>,
-    idents: &[Ident],
+    idents: &[WithDecl<Ident>],
 ) -> ParseResult<SimpleModeIndication> {
     let object_class_tok = explicit_object_class.map(|class| class.token);
     let mode_with_pos = parse_optional_mode(ctx)?;
@@ -187,7 +184,7 @@ fn parse_simple_mode_indication(
     // @TODO maybe move this to a semantic check?
     for ident in idents.iter() {
         if object_class == ObjectClass::Constant && mode.unwrap_or_default() != Mode::In {
-            let token_id = mode_tok.unwrap_or(ident.token);
+            let token_id = mode_tok.unwrap_or(ident.tree.token);
             return Err(Diagnostic::syntax_error(
                 ctx.get_pos(token_id),
                 "Interface constant declaration may only have mode=in",
@@ -195,7 +192,7 @@ fn parse_simple_mode_indication(
         };
 
         if list_type == InterfaceType::Port && object_class != ObjectClass::Signal {
-            let tok = object_class_tok.unwrap_or(ident.token);
+            let tok = object_class_tok.unwrap_or(ident.tree.token);
             return Err(Diagnostic::syntax_error(
                 ctx.get_pos(tok),
                 "Port list only allows signal object class",
@@ -203,7 +200,7 @@ fn parse_simple_mode_indication(
         };
 
         if list_type == InterfaceType::Generic && object_class != ObjectClass::Constant {
-            let tok = object_class_tok.unwrap_or(ident.token);
+            let tok = object_class_tok.unwrap_or(ident.tree.token);
             return Err(Diagnostic::syntax_error(
                 ctx.get_pos(tok),
                 "Generic list only allows constant object class",
@@ -285,7 +282,7 @@ fn parse_interface_package(
 fn parse_interface_declaration(
     ctx: &mut ParsingContext,
     list_type: InterfaceType,
-) -> ParseResult<Vec<InterfaceDeclaration>> {
+) -> ParseResult<InterfaceDeclaration> {
     peek_token!(
         ctx.stream, token, start_token,
         Signal | Constant | Variable | Identifier => {
@@ -295,7 +292,7 @@ fn parse_interface_declaration(
         Type => {
             ctx.stream.skip();
             let ident = ctx.stream.expect_ident()?;
-            Ok(vec![InterfaceDeclaration::Type(WithDecl::new(ident))])
+            Ok(InterfaceDeclaration::Type(WithDecl::new(ident)))
         },
         Function | Procedure | Impure | Pure => {
             let spec = parse_subprogram_specification(ctx)?;
@@ -303,10 +300,10 @@ fn parse_interface_declaration(
 
             let end_token = ctx.stream.get_last_token_id();
 
-            Ok(vec![InterfaceDeclaration::Subprogram(InterfaceSubprogramDeclaration { specification: spec, default, span: TokenSpan::new(start_token, end_token)})])
+            Ok(InterfaceDeclaration::Subprogram(InterfaceSubprogramDeclaration { specification: spec, default, span: TokenSpan::new(start_token, end_token)}))
         },
         Package => {
-            Ok(vec![InterfaceDeclaration::Package (parse_interface_package(ctx)?)])
+            Ok(InterfaceDeclaration::Package (parse_interface_package(ctx)?))
         }
     )
 }
@@ -368,8 +365,8 @@ fn parse_interface_list(
                 let state = ctx.stream.state();
 
                 match parse_interface_declaration(ctx, list_type) {
-                    Ok(ref mut decl_list) => {
-                        interface_list.append(decl_list);
+                    Ok(decl_list) => {
+                        interface_list.push(decl_list);
                     }
                     Err(err) => {
                         ctx.diagnostics.push(err);
@@ -436,10 +433,7 @@ fn parse_one_interface_declaration(
     ctx: &mut ParsingContext<'_>,
     list_type: InterfaceType,
 ) -> ParseResult<InterfaceDeclaration> {
-    parse_interface_declaration(ctx, list_type).map(|decls| {
-        assert_eq!(decls.len(), 1);
-        decls[0].clone()
-    })
+    parse_interface_declaration(ctx, list_type)
 }
 
 #[cfg(test)]
@@ -475,34 +469,19 @@ mod tests {
             code.with_stream_no_diagnostics(parse_generic_interface_list),
             InterfaceList {
                 interface_type: InterfaceType::Generic,
-                items: vec![
-                    InterfaceDeclaration::Object(InterfaceObjectDeclaration {
-                        list_type: InterfaceType::Generic,
-                        mode: ModeIndication::Simple(SimpleModeIndication {
-                            bus: false,
-                            mode: None,
-                            class: ObjectClass::Constant,
+                items: vec![InterfaceDeclaration::Object(InterfaceObjectDeclaration {
+                    list_type: InterfaceType::Generic,
+                    mode: ModeIndication::Simple(SimpleModeIndication {
+                        bus: false,
+                        mode: None,
+                        class: ObjectClass::Constant,
 
-                            subtype_indication: code.s1("natural").subtype_indication(),
-                            expression: None
-                        }),
-                        ident: code.s1("foo").decl_ident(),
-                        span: code.between("constant", "natural").token_span()
+                        subtype_indication: code.s1("natural").subtype_indication(),
+                        expression: None
                     }),
-                    InterfaceDeclaration::Object(InterfaceObjectDeclaration {
-                        list_type: InterfaceType::Generic,
-                        mode: ModeIndication::Simple(SimpleModeIndication {
-                            bus: false,
-                            mode: None,
-                            class: ObjectClass::Constant,
-
-                            subtype_indication: code.s1("natural").subtype_indication(),
-                            expression: None
-                        }),
-                        ident: code.s1("bar").decl_ident(),
-                        span: code.between("constant", "natural").token_span()
-                    })
-                ],
+                    idents: vec![code.s1("foo").decl_ident(), code.s1("bar").decl_ident()],
+                    span: code.between("constant", "natural").token_span()
+                })],
                 span: code.token_span(),
             }
         );
@@ -523,7 +502,7 @@ mod tests {
                     subtype_indication: code.s1("std_logic").subtype_indication(),
                     expression: None
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -535,7 +514,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_parameter),
             InterfaceDeclaration::File(InterfaceFileDeclaration {
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 subtype_indication: code.s1("text").subtype_indication(),
                 span: code.token_span()
             })
@@ -589,7 +568,7 @@ mod tests {
                 InterfaceList {
                     interface_type: InterfaceType::Parameter,
                     items: vec![InterfaceDeclaration::File(InterfaceFileDeclaration {
-                        ident: code.s1("valid").decl_ident(),
+                        idents: vec![code.s1("valid").decl_ident()],
                         subtype_indication: code.s("text", 2).subtype_indication(),
                         span: code.s1("file valid : text").token_span()
                     })],
@@ -624,7 +603,7 @@ mod tests {
                     subtype_indication: code.s1("std_logic").subtype_indication(),
                     expression: None
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -732,7 +711,7 @@ mod tests {
                     subtype_indication: code.s1("std_logic").subtype_indication(),
                     expression: None
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -752,7 +731,7 @@ mod tests {
                     subtype_indication: code.s1("std_logic").subtype_indication(),
                     expression: None
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -1151,7 +1130,7 @@ function foo() return bit;
                     subtype_indication: code.s1("std_logic").subtype_indication(),
                     expression: None
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -1169,7 +1148,7 @@ function foo() return bit;
                     subtype_indication: None,
                     kind: ModeViewIndicationKind::Record
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -1184,7 +1163,7 @@ function foo() return bit;
                     subtype_indication: None,
                     kind: ModeViewIndicationKind::Array
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -1198,7 +1177,7 @@ function foo() return bit;
                     subtype_indication: Some(code.s1("baz").subtype_indication()),
                     kind: ModeViewIndicationKind::Record
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );
@@ -1212,7 +1191,7 @@ function foo() return bit;
                     subtype_indication: Some(code.s1("baz").subtype_indication()),
                     kind: ModeViewIndicationKind::Array
                 }),
-                ident: code.s1("foo").decl_ident(),
+                idents: vec![code.s1("foo").decl_ident()],
                 span: code.token_span()
             })
         );

--- a/vhdl_lang/src/syntax/recover.rs
+++ b/vhdl_lang/src/syntax/recover.rs
@@ -75,7 +75,7 @@ signal y: bit;
                 WithTokenSpan::new(
                     Declaration::Object(ObjectDeclaration {
                         class: ObjectClass::Signal,
-                        ident: code.s1("x").decl_ident(),
+                        idents: vec![code.s1("x").decl_ident()],
                         subtype_indication: code.s1("std_logic").subtype_indication(),
                         expression: Some(code.s1("a.").s1("a").expr())
                     }),
@@ -84,7 +84,7 @@ signal y: bit;
                 WithTokenSpan::new(
                     Declaration::Object(ObjectDeclaration {
                         class: ObjectClass::Signal,
-                        ident: code.s1("y").decl_ident(),
+                        idents: vec![code.s1("y").decl_ident()],
                         subtype_indication: code.s1("bit").subtype_indication(),
                         expression: None
                     }),

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -622,9 +622,7 @@ impl Code {
     }
 
     pub fn object_decl(&self) -> ObjectDeclaration {
-        self.parse_ok_no_diagnostics(parse_object_declaration)
-            .remove(0)
-            .item
+        self.parse_ok_no_diagnostics(parse_object_declaration).item
     }
 
     pub fn file_decl(&self) -> FileDeclaration {

--- a/vhdl_lang/src/syntax/type_declaration.rs
+++ b/vhdl_lang/src/syntax/type_declaration.rs
@@ -17,6 +17,7 @@ use crate::ast::{AbstractLiteral, Range};
 use crate::named_entity::Reference;
 use crate::syntax::names::parse_type_mark;
 use crate::syntax::recover::{expect_semicolon, expect_semicolon_or_last};
+use itertools::Itertools;
 use vhdl_lang::syntax::parser::ParsingContext;
 
 /// LRM 5.2.2 Enumeration types
@@ -83,17 +84,18 @@ fn parse_record_type_definition(
 
         let start_token = ctx.stream.get_current_token_id();
 
-        let idents = parse_identifier_list(ctx)?;
+        let idents = parse_identifier_list(ctx)?
+            .into_iter()
+            .map(WithDecl::new)
+            .collect_vec();
         ctx.stream.expect_kind(Colon)?;
         let subtype = parse_subtype_indication(ctx)?;
         let end_token = expect_semicolon_or_last(ctx);
-        for ident in idents {
-            elem_decls.push(ElementDeclaration {
-                ident: ident.into(),
-                subtype: subtype.clone(),
-                span: TokenSpan::new(start_token, end_token),
-            });
-        }
+        elem_decls.push(ElementDeclaration {
+            idents,
+            subtype: subtype.clone(),
+            span: TokenSpan::new(start_token, end_token),
+        });
     }
 }
 
@@ -530,7 +532,7 @@ end record;",
         );
 
         let elem_decl = ElementDeclaration {
-            ident: code.s1("element").decl_ident(),
+            idents: vec![code.s1("element").decl_ident()],
             subtype: code.s1("boolean").subtype_indication(),
             span: code.s1("element : boolean;").token_span(),
         };
@@ -558,20 +560,17 @@ end record;",
 end foo;",
         );
 
-        let elem_decl0a = ElementDeclaration {
-            ident: code.s1("element").decl_ident(),
-            subtype: code.s1("boolean").subtype_indication(),
-            span: code.s1("element, field : boolean;").token_span(),
-        };
-
-        let elem_decl0b = ElementDeclaration {
-            ident: code.s1("field").decl_ident(),
+        let elem_decl0 = ElementDeclaration {
+            idents: vec![
+                code.s1("element").decl_ident(),
+                code.s1("field").decl_ident(),
+            ],
             subtype: code.s1("boolean").subtype_indication(),
             span: code.s1("element, field : boolean;").token_span(),
         };
 
         let elem_decl1 = ElementDeclaration {
-            ident: code.s1("other_element").decl_ident(),
+            idents: vec![code.s1("other_element").decl_ident()],
             subtype: code.s1("std_logic_vector(0 to 1)").subtype_indication(),
             span: code
                 .s1("other_element : std_logic_vector(0 to 1);")
@@ -581,7 +580,7 @@ end foo;",
         let type_decl = TypeDeclaration {
             span: code.token_span(),
             ident: code.s1("foo").decl_ident(),
-            def: TypeDefinition::Record(vec![elem_decl0a, elem_decl0b, elem_decl1]),
+            def: TypeDefinition::Record(vec![elem_decl0, elem_decl1]),
             end_ident_pos: Some(code.s("foo", 2).token()),
         };
 


### PR DESCRIPTION
For example, the declaration
```vhdl
signal a, b : std_logic;
```
would previously be stores as two separate declarations as if they had been declared like this:
```vhdl
signal a: std_logic;
signal b: std_logic;
```

Now, the AST element contains both identifiers.
This change is mostly for internal purposes. The only noticeable change is that hovers will now produce the former version, instead of the latter where applicable.