### PR TITLE
Enable arrays of views

### DIFF
--- a/vhdl_lang/src/analysis/concurrent.rs
+++ b/vhdl_lang/src/analysis/concurrent.rs
@@ -58,7 +58,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             } else if statement.statement.item.can_have_label() {
                 // Generate an anonymous label if it is not explicitly defined
                 let ent = self.arena.alloc(
-                    Designator::Anonymous(scope.next_anonymous()),
+                    scope.anonymous_designator(),
                     Some(parent),
                     Related::None,
                     AnyEntKind::Concurrent(statement.statement.item.label_typ()),

--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -991,6 +991,30 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
         Ok(objects)
     }
 
+    /// Analyzes a mode view indication.
+    /// ## Example
+    /// ```vhdl
+    /// foo : view s_axis of axi_stream
+    /// ```
+    /// The opposite of t mode view indication is a simple mode view indication:
+    /// ```vhdl
+    /// foo : in std_logic
+    /// ```
+    ///
+    /// This function analyzes the view indication, resolves all used types and verifies them.
+    /// If the provided view describes an array but no actual array type is given, i.e.:
+    /// ```vhdl
+    /// multiple_foos : view (s_axis)
+    /// ```
+    /// This function will declare an anonymous array indication with a single index and the
+    /// view's subtype as element, similar as if the view was declared like so:
+    /// ```vhdl
+    /// -- pseudo code
+    /// type anonymous is array (integer range <>) of axi_stream;
+    /// multiple_foos : view (s_axis) of anonymous
+    /// ```
+    /// The anonymous array type will be marked as being linked to the interface declaration
+    /// (in the example above: the `anonymous` type is implicitly declared by `multiple_foos`)
     fn analyze_mode_indication(
         &self,
         scope: &Scope<'a>,

--- a/vhdl_lang/src/analysis/range.rs
+++ b/vhdl_lang/src/analysis/range.rs
@@ -173,8 +173,8 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
 
                 let types = match (left_types, right_types) {
                     (DisambiguatedType::Unambiguous(l), DisambiguatedType::Unambiguous(r)) => {
-                        if let Some(typ) = self.common_type(l.base(), r.base()) {
-                            return Ok(typ);
+                        return if let Some(typ) = self.common_type(l.base(), r.base()) {
+                            Ok(typ)
                         } else {
                             diagnostics.add(
                                 constraint.span().pos(self.ctx),
@@ -185,7 +185,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                                 ),
                                 ErrorCode::TypeMismatch,
                             );
-                            return Err(EvalError::Unknown);
+                            Err(EvalError::Unknown)
                         }
                     }
                     (DisambiguatedType::Unambiguous(l), DisambiguatedType::Ambiguous(r)) => {

--- a/vhdl_lang/src/analysis/scope.rs
+++ b/vhdl_lang/src/analysis/scope.rs
@@ -346,6 +346,10 @@ impl<'a> Scope<'a> {
         inner.anon_idx += 1;
         idx
     }
+
+    pub fn anonymous_designator(&self) -> Designator {
+        Designator::Anonymous(self.next_anonymous())
+    }
 }
 
 impl<'a> NamedEntities<'a> {

--- a/vhdl_lang/src/analysis/sequential.rs
+++ b/vhdl_lang/src/analysis/sequential.rs
@@ -38,7 +38,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
             } else if statement.statement.item.can_have_label() {
                 // Generate an anonymous label if it is not explicitly defined
                 let ent = self.arena.alloc(
-                    Designator::Anonymous(scope.next_anonymous()),
+                    scope.anonymous_designator(),
                     Some(parent),
                     Related::None,
                     AnyEntKind::Sequential(statement.statement.item.label_typ()),

--- a/vhdl_lang/src/analysis/standard.rs
+++ b/vhdl_lang/src/analysis/standard.rs
@@ -316,9 +316,6 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 FormalRegion::new_params(),
                 return_type,
             ))),
-            implicit_of.decl_pos(),
-            implicit_of.src_span,
-            Some(self.source()),
         );
 
         for (name, kind) in formals.into_iter() {

--- a/vhdl_lang/src/analysis/tests/subprogram_instance.rs
+++ b/vhdl_lang/src/analysis/tests/subprogram_instance.rs
@@ -22,14 +22,13 @@ procedure proc is new foo;
     ",
     );
 
-    let diagnostics = builder.analyze();
-    assert_eq!(
-        diagnostics,
+    check_diagnostics(
+        builder.analyze(),
         vec![Diagnostic::new(
             code.s1("foo").pos(),
             "No declaration of 'foo'",
-            ErrorCode::Unresolved
-        )]
+            ErrorCode::Unresolved,
+        )],
     );
 }
 
@@ -44,14 +43,13 @@ function proc is new x;
     ",
     );
 
-    let diagnostics = builder.analyze();
-    assert_eq!(
-        diagnostics,
+    check_diagnostics(
+        builder.analyze(),
         vec![Diagnostic::mismatched_kinds(
             code.s1("new x").s1("x"),
             "signal 'x' does not denote an uninstantiated subprogram",
-        )]
-    )
+        )],
+    );
 }
 
 #[test]
@@ -75,9 +73,8 @@ procedure proc is new foo;
     ",
     );
 
-    let diagnostics = builder.analyze();
     check_diagnostics(
-        diagnostics,
+        builder.analyze(),
         vec![Diagnostic::new(
             code.s1("new foo").s1("foo"),
             "Ambiguous instantiation of 'foo'",
@@ -110,8 +107,7 @@ procedure proc2 is new foo [bit, bit] generic map (a => 5);
     ",
     );
 
-    let diagnostics = builder.analyze();
-    check_no_diagnostics(&diagnostics);
+    check_no_diagnostics(&builder.analyze());
 }
 
 #[test]
@@ -129,9 +125,8 @@ procedure proc is new foo [bit, bit];
     ",
     );
 
-    let diagnostics = builder.analyze();
     check_diagnostics(
-        diagnostics,
+        builder.analyze(),
         vec![Diagnostic::new(
             code.s1("[bit, bit]").pos(),
             "Signature does not match the the signature of procedure foo[BIT]",
@@ -154,8 +149,7 @@ procedure proc is new proc;
     ",
     );
 
-    let diagnostics = builder.analyze();
-    check_no_diagnostics(&diagnostics);
+    check_no_diagnostics(&builder.analyze());
 }
 
 #[test]

--- a/vhdl_lang/src/analysis/tests/tool_directive.rs
+++ b/vhdl_lang/src/analysis/tests/tool_directive.rs
@@ -9,9 +9,7 @@ use crate::analysis::tests::{check_no_diagnostics, LibraryBuilder};
 fn simple_tool_directive() {
     let mut builder = LibraryBuilder::new();
     builder.code("libname", "`protect begin");
-    let (_, diagnostics) = builder.get_analyzed_root();
-
-    check_no_diagnostics(&diagnostics);
+    check_no_diagnostics(&builder.analyze());
 }
 
 #[test]
@@ -31,7 +29,5 @@ end my_ent;
 `protect encoding = (enctype = \"BASE64\", line_length = 76, bytes = 64)
         ",
     );
-    let (_, diagnostics) = builder.get_analyzed_root();
-
-    check_no_diagnostics(&diagnostics);
+    check_no_diagnostics(&builder.analyze());
 }

--- a/vhdl_lang/src/analysis/tests/view_declarations.rs
+++ b/vhdl_lang/src/analysis/tests/view_declarations.rs
@@ -13,9 +13,8 @@ view my_view of undeclared is
 end view;
     ",
     );
-    let (_, diag) = builder.get_analyzed_root();
     check_diagnostics(
-        diag,
+        builder.analyze(),
         vec![Diagnostic::new(
             code.s1("undeclared"),
             "No declaration of 'undeclared'",
@@ -35,9 +34,8 @@ view my_view of foo is
 end view;
     ",
     );
-    let (_, diag) = builder.get_analyzed_root();
     check_diagnostics(
-        diag,
+        builder.analyze(),
         vec![Diagnostic::new(
             code.s("foo", 2),
             "The type of a view must be a record type, not type 'foo'",
@@ -58,8 +56,7 @@ view my_view of foo is
 end view;
     ",
     );
-    let (_, diag) = builder.get_analyzed_root();
-    check_no_diagnostics(&diag);
+    check_no_diagnostics(&builder.analyze());
 }
 
 #[test]

--- a/vhdl_lang/src/analysis/tests/view_declarations.rs
+++ b/vhdl_lang/src/analysis/tests/view_declarations.rs
@@ -468,3 +468,34 @@ end arch;
         )],
     );
 }
+
+#[test]
+fn arrays_of_views() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    builder.code(
+        "libname",
+        "\
+package test_pkg is
+    type test_t is record
+        a : bit;
+    end record;
+
+    view vone of test_t is
+        a : in;
+    end view;
+
+    type test_array is array (natural range <>) of test_t;
+end package;
+
+use work.test_pkg.all;
+
+entity test_sub_entity is
+    port (
+        my_if : view vone;
+        my_array_if: view (vone) of test_array(0 to 1)
+    );
+end entity;
+    ",
+    );
+    check_no_diagnostics(&builder.analyze());
+}

--- a/vhdl_lang/src/analysis/tests/view_declarations.rs
+++ b/vhdl_lang/src/analysis/tests/view_declarations.rs
@@ -470,7 +470,7 @@ end arch;
 }
 
 #[test]
-fn arrays_of_views() {
+fn arrays_of_views_with_matching_type() {
     let mut builder = LibraryBuilder::with_standard(VHDL2019);
     builder.code(
         "libname",
@@ -498,4 +498,78 @@ end entity;
     ",
     );
     check_no_diagnostics(&builder.analyze());
+}
+
+#[test]
+fn arrays_of_views_with_non_matching_type() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.code(
+        "libname",
+        "\
+package test_pkg is
+    type test_t is record
+        a : bit;
+    end record;
+
+    view vone of test_t is
+        a : in;
+    end view;
+
+    type test_array is array (natural range <>) of bit;
+end package;
+
+use work.test_pkg.all;
+
+entity test_sub_entity is
+    port (
+        my_if : view vone;
+        my_array_if: view (vone) of test_array(0 to 1)
+    );
+end entity;
+    ",
+    );
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::new(
+            code.s1("test_array(0 to 1)").s1("test_array"),
+            "Array element type 'BIT' must match record type 'test_t' declared for the view",
+            ErrorCode::TypeMismatch,
+        )],
+    )
+}
+
+#[test]
+fn arrays_of_views_that_are_not_arrays() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.code(
+        "libname",
+        "\
+package test_pkg is
+    type test_t is record
+        a : bit;
+    end record;
+
+    view vone of test_t is
+        a : in;
+    end view;
+end package;
+
+use work.test_pkg.all;
+
+entity test_sub_entity is
+    port (
+        my_if : view vone;
+        my_array_if: view (vone) of test_t
+    );
+end entity;
+    ",
+    );
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::new(
+            code.s1("view (vone) of test_t").s1("test_t"),
+            "Subtype must be an array",
+            ErrorCode::TypeMismatch,
+        )],
+    )
 }

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -286,18 +286,15 @@ impl Arena {
         of_ent: EntRef<'a>,
         designator: impl Into<Designator>,
         kind: AnyEntKind<'a>,
-        decl_pos: Option<&SrcPos>,
-        src_span: TokenSpan,
-        source: Option<Source>,
     ) -> EntRef<'a> {
         self.alloc(
             designator.into(),
             of_ent.parent,
             Related::ImplicitOf(of_ent),
             kind,
-            decl_pos.cloned(),
-            src_span,
-            source,
+            of_ent.decl_pos().cloned(),
+            of_ent.src_span,
+            of_ent.source.clone(),
         )
     }
 


### PR DESCRIPTION
Closes #325 

Now analyses arrays of views, i.e.,
```vhdl
some_interface: view (some_view) of some_array_type
```
correctly.
This also handles the special case where no array is given, i.e.,
```vhdl
some_interface: view (some_view)
```