### PR TITLE
Refactor name analysis for signal attributes

### DIFF
--- a/vhdl_lang/src/analysis/target.rs
+++ b/vhdl_lang/src/analysis/target.rs
@@ -12,7 +12,6 @@ use vhdl_lang::TokenSpan;
 /// examples:
 ///   target <= 1;
 ///   target(0).elem := 1
-
 impl<'a, 't> AnalyzeContext<'a, 't> {
     pub fn resolve_target(
         &self,

--- a/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
+++ b/vhdl_lang/src/analysis/tests/assignment_typecheck.rs
@@ -62,19 +62,19 @@ architecture a of ent is
 begin
   main : process
   begin
-    foo'stable := 1;
+    foo'stable := true;
   end process;
 end architecture;
 ",
     );
 
-    let expected = vec![Diagnostic::mismatched_kinds(
-        code.s("foo'stable", 1),
-        "Expression may not be the target of an assignment",
-    )];
-
-    let diagnostics = builder.analyze();
-    check_diagnostics(diagnostics, expected);
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::mismatched_kinds(
+            code.s("foo'stable", 1),
+            "signal 'stable' may not be the target of a variable assignment",
+        )],
+    );
 }
 
 #[test]

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -553,7 +553,7 @@ impl<'a> AnyEnt<'a> {
                     ),
                     ErrorCode::Duplicate,
                 )
-                    .related(last_pos, "Previously specified here"))
+                .related(last_pos, "Previously specified here"))
             }
             Entry::Vacant(entry) => {
                 entry.insert((pos.clone(), ent));


### PR DESCRIPTION
Closes #335 

Refactor the way signal attributes such as `x'delayed` or `x'quiet` are handled. This consequently correctly handles them in sensitivity lists.