### PR TITLE
Add option for the libraries location as part of the vhdl_lang executable

### DIFF
--- a/vhdl_ls/src/main.rs
+++ b/vhdl_ls/src/main.rs
@@ -14,6 +14,11 @@ struct Args {
     #[arg(long, default_value_t = false)]
     no_lint: bool,
 
+    /// Path to the config file for the VHDL standard libraries (i.e., IEEE std_logic_1164).
+    /// If omitted, will search for these libraries in a set of standard paths
+    #[arg(short = 'l', long)]
+    libraries: Option<String>,
+
     /// Normally warning and error messages are sent to window/showMessage
     /// This will silence all window/showMessage and only use window/logMessage
     #[arg(long, default_value_t = false)]
@@ -28,6 +33,7 @@ fn main() {
     vhdl_ls::start(VHDLServerSettings {
         no_lint: args.no_lint,
         silent: args.silent,
+        libraries_path: args.libraries,
         ..Default::default()
     });
 }

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -53,6 +53,7 @@ pub struct VHDLServerSettings {
     pub no_lint: bool,
     pub silent: bool,
     pub non_project_file_handling: NonProjectFileHandling,
+    pub libraries_path: Option<String>,
 }
 
 pub struct VHDLServer {
@@ -123,7 +124,10 @@ impl VHDLServer {
         let mut config = Config::default();
 
         if self.use_external_config {
-            config.load_external_config(&mut self.message_filter(), None);
+            config.load_external_config(
+                &mut self.message_filter(),
+                self.settings.libraries_path.clone(),
+            );
         }
 
         match self.load_root_uri_config() {


### PR DESCRIPTION
Introduces a flag so `vhdl_ls` can be called using `vhdl_ls --libararies /path/to/libraries`

Closes #339