### PR TITLE
Move information to workspace and specify MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "brunch"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0213369ce5beadc65e9218c969c663c0fd6e730df41d8c02a39ecaf9c5022f70"
+checksum = "016d950e43311624fa0b3e1bfe340f49f1913d21d76165f883ede0cfee569b62"
 dependencies = [
  "dactyl",
  "unicode-width 0.2.0",
@@ -210,9 +210,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dactyl"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7da384f05892997ed02b2c29b5c90f67712c17f2bee88371d84dc5d4547e493"
+checksum = "8a4d2c8b71b31d345e76c2532f9c9a99eae384ec1f47a6eb6347e35b5645aae4"
 
 [[package]]
 name = "diff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,12 @@
 [workspace]
 resolver = "2"
 members = ["vhdl_lang_macros", "vhdl_lang", "vhdl_ls"]
+
+[workspace.package]
+version = "0.84.0"
+authors = ["Olof Kraigher <olof.kraigher@gmail.com>"]
+license = "MPL-2.0"
+edition = "2021"
+rust-version = "1.82"
+repository = "https://github.com/VHDL-LS/rust_hdl"
+readme = "README.md"

--- a/vhdl_lang/Cargo.toml
+++ b/vhdl_lang/Cargo.toml
@@ -6,12 +6,13 @@
 
 [package]
 name = "vhdl_lang"
-version = "0.84.0"
-authors = ["Olof Kraigher <olof.kraigher@gmail.com>"]
-license = "MPL-2.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "VHDL Language Frontend"
-repository = "https://github.com/kraigher/rust_hdl"
-edition = "2021"
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 vhdl_lang_macros = { version = "^0.84.0", path = "../vhdl_lang_macros" }
@@ -34,7 +35,7 @@ enum-map = "2.7.3"
 tempfile = "3"
 pretty_assertions = "1"
 assert_matches = "1"
-brunch = "0"
+brunch = "0.8"
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 

--- a/vhdl_lang_macros/Cargo.toml
+++ b/vhdl_lang_macros/Cargo.toml
@@ -6,12 +6,13 @@
 
 [package]
 name = "vhdl_lang_macros"
-version = "0.84.0"
-authors = ["Olof Kraigher <olof.kraigher@gmail.com>"]
-license = "MPL-2.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "VHDL Language Frontend - Macros"
-repository = "https://github.com/kraigher/rust_hdl"
-edition = "2021"
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/vhdl_ls/Cargo.toml
+++ b/vhdl_ls/Cargo.toml
@@ -6,13 +6,14 @@
 
 [package]
 name = "vhdl_ls"
-version = "0.84.0"
-authors = ["Olof Kraigher <olof.kraigher@gmail.com>"]
-license = "MPL-2.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "VHDL Language Server"
-repository = "https://github.com/kraigher/rust_hdl"
-edition = "2021"
-readme = "../README.md"
+repository.workspace = true
+edition.workspace = true
+readme.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 vhdl_lang = { version = "^0.84.0", path = "../vhdl_lang" }


### PR DESCRIPTION
Minimum supported rustc version (MSRV) was not provided. Also, it is more convenient to have shared info in the workspace Cargo.toml.

MSRV is 1.82 for the library (because of `iter::repeat_n`), but the use of brunch 0.9 require 1.85. As this is a test dependency, I decided to downgrade to 0.8 to keep MSRV a bit lower than the latest. Updating to 1.85 is now easier as that will also require updating to edition to 2024, which can be done in a single location.

In general, specifying version with "0" is a source for issues since it is OK to have breaking API changes for minor versions if major version is "0". For major version 1 and higher, there should be no breaking API changes without changing major version. I didn't specify a version for the crates that has "0" though (except for brunch then).  The drawback is that cargo will not automatically update minor versions for major version "0", so this will have to be done manually. Still, it is probably better to update manually rather than breaking it. (Or at least specify that `--locked` should be used when building locally.)

Finally, I also changed the repository to point to the "correct"(?) one (although there is a redirect).

One may consider moving the dependencies to using the workspace as well, but there weren't that many shared dependencies (and since the version specification is pretty wide it may not give that much of a benefit anyway).