### PR TITLE
Add baseline analysis and completions for simple external names

### DIFF
--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -47,24 +47,26 @@ impl Declaration {
         match parent {
             // LRM: block_declarative_item
             AnyEntKind::Design(Design::Architecture(..))
-            | AnyEntKind::Concurrent(Some(Concurrent::Block | Concurrent::Generate)) => matches!(
-                self,
-                Object(ObjectDeclaration {
-                    class: Constant | Signal | SharedVariable,
-                    ..
-                }) | File(_)
-                    | Type(_)
-                    | Component(_)
-                    | Attribute(_)
-                    | Alias(_)
-                    | SubprogramDeclaration(_)
-                    | SubprogramInstantiation(_)
-                    | SubprogramBody(_)
-                    | Use(_)
-                    | Package(_)
-                    | Configuration(_)
-                    | View(_)
-            ),
+            | AnyEntKind::Concurrent(Some(Concurrent::Block | Concurrent::Generate), _) => {
+                matches!(
+                    self,
+                    Object(ObjectDeclaration {
+                        class: Constant | Signal | SharedVariable,
+                        ..
+                    }) | File(_)
+                        | Type(_)
+                        | Component(_)
+                        | Attribute(_)
+                        | Alias(_)
+                        | SubprogramDeclaration(_)
+                        | SubprogramInstantiation(_)
+                        | SubprogramBody(_)
+                        | Use(_)
+                        | Package(_)
+                        | Configuration(_)
+                        | View(_)
+                )
+            }
             // LRM: configuration_declarative_item
             AnyEntKind::Design(Design::Configuration) => {
                 matches!(self, Use(_) | Attribute(ast::Attribute::Specification(_)))
@@ -92,7 +94,7 @@ impl Declaration {
                 | Overloaded::UninstSubprogramDecl(..)
                 | Overloaded::UninstSubprogram(..),
             )
-            | AnyEntKind::Concurrent(Some(Concurrent::Process))
+            | AnyEntKind::Concurrent(Some(Concurrent::Process), _)
             | AnyEntKind::Type(named_entity::Type::Protected(..)) => matches!(
                 self,
                 Object(ObjectDeclaration {
@@ -1261,7 +1263,7 @@ fn get_entity_class(ent: EntRef<'_>) -> Option<EntityClass> {
         AnyEntKind::Type(Type::Subtype(_)) => Some(EntityClass::Subtype),
         AnyEntKind::Type(_) => Some(EntityClass::Type),
         AnyEntKind::ElementDeclaration(_) => None,
-        AnyEntKind::Concurrent(_) => Some(EntityClass::Label),
+        AnyEntKind::Concurrent(..) => Some(EntityClass::Label),
         AnyEntKind::Sequential(_) => Some(EntityClass::Label),
         AnyEntKind::Object(obj) => match obj.class {
             ObjectClass::Signal => Some(EntityClass::Signal),

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1615,7 +1615,7 @@ impl<'a> AnalyzeContext<'a, '_> {
         Ok(resolved)
     }
 
-    // Currently, only resolved Package name
+    // Currently, only resolves Package name
     fn resolve_external_path(
         &self,
         scope: &Scope<'a>,

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -1280,8 +1280,7 @@ impl<'a> AnalyzeContext<'a, '_> {
                     ..
                 } = ename;
                 let subtype = self.resolve_subtype_indication(scope, subtype, diagnostics)?;
-                let resolved_path = self.resolve_external_path(scope, path, diagnostics)?;
-                match resolved_path {
+                match self.resolve_external_path(scope, path, diagnostics)? {
                     Some(ResolvedName::ObjectName(obj)) => {
                         if !self.can_be_target_type(obj.type_mark(), subtype.base()) {
                             diagnostics.push(Diagnostic::type_mismatch(
@@ -1630,8 +1629,7 @@ impl<'a> AnalyzeContext<'a, '_> {
                 &mut pkg.item,
                 diagnostics,
             )?)),
-            ExternalPath::Absolute(_) => Ok(None),
-            ExternalPath::Relative(_, _) => Ok(None),
+            _ => Ok(None),
         }
     }
 

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -202,7 +202,7 @@ impl<'a> ResolvedName<'a> {
             AnyEntKind::Library
             | AnyEntKind::Attribute(_)
             | AnyEntKind::ElementDeclaration(_)
-            | AnyEntKind::Concurrent(_)
+            | AnyEntKind::Concurrent(..)
             | AnyEntKind::Sequential(_)
             | AnyEntKind::LoopParameter(_) => {
                 return Err((
@@ -258,7 +258,7 @@ impl<'a> ResolvedName<'a> {
             | AnyEntKind::View(_)
             | AnyEntKind::InterfaceFile(_)
             | AnyEntKind::Component(_)
-            | AnyEntKind::Concurrent(_)
+            | AnyEntKind::Concurrent(..)
             | AnyEntKind::Sequential(_)
             | AnyEntKind::LoopParameter(_)
             | AnyEntKind::PhysicalLiteral(_) => ResolvedName::Final(ent),
@@ -1623,8 +1623,8 @@ impl<'a> AnalyzeContext<'a, '_> {
         path: &mut WithTokenSpan<ExternalPath>,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<Option<ResolvedName<'a>>> {
-        match path.item {
-            ExternalPath::Package(ref mut pkg) => Ok(Some(self.name_resolve(
+        match &mut path.item {
+            ExternalPath::Package(pkg) => Ok(Some(self.name_resolve(
                 scope,
                 pkg.span,
                 &mut pkg.item,
@@ -2303,7 +2303,7 @@ constant c0 : rec_t := (others => 0);
 ",
         );
 
-        assert_matches!(test.name_resolve(&test.snippet("c0.field"), None, &mut NoDiagnostics), 
+        assert_matches!(test.name_resolve(&test.snippet("c0.field"), None, &mut NoDiagnostics),
             Ok(ResolvedName::ObjectName(oname)) if oname.type_mark() == test.lookup_type("natural"));
     }
 
@@ -2545,7 +2545,7 @@ type enum2_t is (alpha, beta);
         test.declarative_part(
             "
 type ptr_t is access integer_vector;
-variable vptr : ptr_t; 
+variable vptr : ptr_t;
 ",
         );
         let code = test.snippet("vptr(0 to 1)");
@@ -2561,7 +2561,7 @@ variable vptr : ptr_t;
         test.declarative_part(
             "
 type ptr_t is access integer_vector;
-variable vptr : ptr_t; 
+variable vptr : ptr_t;
 ",
         );
         let code = test.snippet("vptr(0)");
@@ -2689,7 +2689,7 @@ variable c0 : arr_t;
         let test = TestSetup::new();
         test.declarative_part(
             "
-type arr_t is array (integer range 0 to 3) of integer;        
+type arr_t is array (integer range 0 to 3) of integer;
         ",
         );
         let code = test.snippet("arr_t'left");
@@ -2706,7 +2706,7 @@ type arr_t is array (integer range 0 to 3) of integer;
         let test = TestSetup::new();
         test.declarative_part(
             "
-type arr_t is array (integer range 0 to 3, character range 'a' to 'c') of integer;        
+type arr_t is array (integer range 0 to 3, character range 'a' to 'c') of integer;
         ",
         );
         let code = test.snippet("arr_t'left(1)");
@@ -2762,7 +2762,7 @@ type arr_t is array (integer range 0 to 3, character range 'a' to 'c') of intege
 
         test.declarative_part(
             "
-type arr_t is array (integer range 0 to 3) of integer;        
+type arr_t is array (integer range 0 to 3) of integer;
         ",
         );
 
@@ -2781,7 +2781,7 @@ type arr_t is array (integer range 0 to 3) of integer;
 
         test.declarative_part(
             "
-type arr_t is array (integer range 0 to 3) of integer;        
+type arr_t is array (integer range 0 to 3) of integer;
 constant c0 : arr_t := (others => 0);
         ",
         );
@@ -2801,7 +2801,7 @@ constant c0 : arr_t := (others => 0);
 
         test.declarative_part(
             "
-type arr_t is array (integer range 0 to 3) of integer;        
+type arr_t is array (integer range 0 to 3) of integer;
 constant c0 : arr_t := (others => 0);
         ",
         );
@@ -3006,7 +3006,7 @@ variable thevar : integer;
         let test = TestSetup::new();
         test.declarative_part(
             "
-signal thesig : integer; 
+signal thesig : integer;
         ",
         );
 
@@ -3152,7 +3152,7 @@ variable thevar : integer;
         let test = TestSetup::new();
         test.declarative_part(
             "
-signal thesig : integer; 
+signal thesig : integer;
         ",
         );
 

--- a/vhdl_lang/src/analysis/package_instance.rs
+++ b/vhdl_lang/src/analysis/package_instance.rs
@@ -360,7 +360,9 @@ impl<'a> AnalyzeContext<'a, '_> {
                 AnyEntKind::ElementDeclaration(self.map_subtype(mapping, *subtype, scope))
             }
             AnyEntKind::Sequential(s) => AnyEntKind::Sequential(*s),
-            AnyEntKind::Concurrent(c) => AnyEntKind::Concurrent(*c),
+            AnyEntKind::Concurrent(c, region) => {
+                AnyEntKind::Concurrent(*c, self.map_region(parent, mapping, region, scope)?)
+            }
             AnyEntKind::Object(obj) => AnyEntKind::Object(self.map_object(mapping, obj, scope)),
             AnyEntKind::LoopParameter(typ) => AnyEntKind::LoopParameter(
                 typ.map(|typ| self.map_type_ent(mapping, typ.into(), scope).base()),

--- a/vhdl_lang/src/analysis/scope.rs
+++ b/vhdl_lang/src/analysis/scope.rs
@@ -363,6 +363,13 @@ impl<'a> Scope<'a> {
     pub fn anonymous_designator(&self) -> Designator {
         Designator::Anonymous(self.next_anonymous())
     }
+
+    pub fn lookup_in_root(&self, designator: &Designator) -> Option<NamedEntities<'a>> {
+        match self.0.borrow().parent.as_ref() {
+            None => self.lookup_immediate(designator),
+            Some(parent) => parent.lookup_in_root(designator),
+        }
+    }
 }
 
 impl<'a> NamedEntities<'a> {

--- a/vhdl_lang/src/analysis/scope.rs
+++ b/vhdl_lang/src/analysis/scope.rs
@@ -363,13 +363,6 @@ impl<'a> Scope<'a> {
     pub fn anonymous_designator(&self) -> Designator {
         Designator::Anonymous(self.next_anonymous())
     }
-
-    pub fn lookup_in_root(&self, designator: &Designator) -> Option<NamedEntities<'a>> {
-        match self.0.borrow().parent.as_ref() {
-            None => self.lookup_immediate(designator),
-            Some(parent) => parent.lookup_in_root(designator),
-        }
-    }
 }
 
 impl<'a> NamedEntities<'a> {

--- a/vhdl_lang/src/analysis/sequential.rs
+++ b/vhdl_lang/src/analysis/sequential.rs
@@ -438,7 +438,7 @@ impl<'a> From<EntRef<'a>> for SequentialRoot<'a> {
                     SequentialRoot::Process
                 }
             }
-            AnyEntKind::Concurrent(Some(Concurrent::Process)) => SequentialRoot::Process,
+            AnyEntKind::Concurrent(Some(Concurrent::Process), _) => SequentialRoot::Process,
             _ => SequentialRoot::Process,
         }
     }

--- a/vhdl_lang/src/analysis/tests/external_names.rs
+++ b/vhdl_lang/src/analysis/tests/external_names.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
+
+use crate::analysis::tests::LibraryBuilder;
+use crate::data::ErrorCode;
+use crate::syntax::test::check_diagnostics;
+use crate::Diagnostic;
+
+#[test]
+fn external_package_name_must_point_to_signal_constant_or_variable() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.code(
+        "libname",
+        "\
+package test_pkg is
+    procedure foo(x: bit);
+end package;
+
+use work.test_pkg.all;
+
+entity test_ent is
+end entity;
+
+architecture arch of test_ent is
+begin
+    << signal @work.test_pkg.foo : bit >> <= '1';
+end arch;
+        ",
+    );
+
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::mismatched_kinds(
+            code.s1("@work.test_pkg.foo"),
+            "External path must point to a constant, variable or signal",
+        )],
+    );
+}
+#[test]
+fn external_package_name_must_match_target_type() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.code(
+        "libname",
+        "\
+package test_pkg is
+    signal foo : natural;
+end package;
+
+use work.test_pkg.all;
+
+entity test_ent is
+end entity;
+
+architecture arch of test_ent is
+begin
+    << signal @work.test_pkg.foo : bit >> <= '1';
+end arch;
+        ",
+    );
+
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::new(
+            code.s1("@work.test_pkg.foo"),
+            "signal 'foo' of subtype 'NATURAL' does not match type 'BIT'",
+            ErrorCode::TypeMismatch,
+        )],
+    );
+}
+
+#[test]
+fn external_package_class_must_match_target_class() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.code(
+        "libname",
+        "\
+package test_pkg is
+    shared variable foo : bit;
+end package;
+
+use work.test_pkg.all;
+
+entity test_ent is
+end entity;
+
+architecture arch of test_ent is
+begin
+    << signal @work.test_pkg.foo : bit >> <= '1';
+end arch;
+        ",
+    );
+
+    check_diagnostics(
+        builder.analyze(),
+        vec![Diagnostic::new(
+            code.s1("@work.test_pkg.foo"),
+            "class signal does not match shared variable",
+            ErrorCode::MismatchedObjectClass,
+        )],
+    );
+}

--- a/vhdl_lang/src/analysis/tests/mod.rs
+++ b/vhdl_lang/src/analysis/tests/mod.rs
@@ -12,6 +12,7 @@ mod custom_attributes;
 mod declarations;
 mod deferred_constant;
 mod discrete_ranges;
+mod external_names;
 mod hierarchy;
 mod homographs;
 mod implicit;

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -164,6 +164,16 @@ impl From<ExternalObjectClass> for ObjectClass {
     }
 }
 
+impl From<ObjectClass> for ExternalObjectClass {
+    fn from(object: ObjectClass) -> ExternalObjectClass {
+        match object {
+            ObjectClass::Constant => ExternalObjectClass::Constant,
+            ObjectClass::Variable | ObjectClass::SharedVariable => ExternalObjectClass::Variable,
+            ObjectClass::Signal => ExternalObjectClass::Signal,
+        }
+    }
+}
+
 /// LRM 8.7 External names
 #[derive(PartialEq, Debug, Clone)]
 pub enum ExternalPath {

--- a/vhdl_lang/src/completion.rs
+++ b/vhdl_lang/src/completion.rs
@@ -108,6 +108,7 @@ pub fn list_completion_options<'a>(
         [.., kind!(LeftPar | Comma)] | [.., kind!(LeftPar | Comma), kind!(Identifier)] => {
             completions_for_map_aspect(root, cursor, source)
         }
+        [.., kind!(CommAt)] | [.., kind!(CommAt), kind!(Identifier)] => list_all_libraries(root),
         _ => generic_completions(root, cursor, source),
     }
 }

--- a/vhdl_lang/src/completion/libraries.rs
+++ b/vhdl_lang/src/completion/libraries.rs
@@ -38,4 +38,22 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    pub fn completes_external_library_names() {
+        let input = LibraryBuilder::new();
+        let code = Code::new("<< signal @");
+        let (root, _) = input.get_analyzed_root();
+        let cursor = code.end();
+        let options = list_completion_options(&root, code.source(), cursor);
+        assert_eq_unordered(
+            &options,
+            &[
+                CompletionItem::Simple(
+                    root.get_ent(root.get_lib(&root.symbol_utf8("std")).unwrap().id()),
+                ),
+                CompletionItem::Work,
+            ],
+        )
+    }
 }

--- a/vhdl_lang/src/completion/selected.rs
+++ b/vhdl_lang/src/completion/selected.rs
@@ -243,7 +243,7 @@ end foo;
         )
     }
 
-    // It is currently unclear, whether the pack of this is a parser or analyzer limitation
+    // It is currently unclear, whether the lack of this feature is a parser or analyzer limitation
     #[test]
     #[ignore]
     pub fn completing_external_primary_unit_names() {

--- a/vhdl_lang/src/completion/selected.rs
+++ b/vhdl_lang/src/completion/selected.rs
@@ -242,4 +242,30 @@ end foo;
             &[CompletionItem::Simple(ent1), CompletionItem::Simple(ent2)],
         )
     }
+
+    // It is currently unclear, whether the pack of this is a parser or analyzer limitation
+    #[test]
+    #[ignore]
+    pub fn completing_external_primary_unit_names() {
+        let mut builder = LibraryBuilder::new();
+        let code = builder.code(
+            "libA",
+            "\
+package foo is
+    signal y: my_record;
+    signal z: bit := << signal @libA.
+end foo;
+        ",
+        );
+
+        let (root, _) = builder.get_analyzed_root();
+        let cursor = code.s1("@libA.").end();
+        let options = list_completion_options(&root, code.source(), cursor);
+
+        let ent1 = root
+            .search_reference(code.source(), code.s1("foo").start())
+            .unwrap();
+
+        assert_eq_unordered(&options, &[CompletionItem::Simple(ent1)])
+    }
 }

--- a/vhdl_lang/src/data/error_codes.rs
+++ b/vhdl_lang/src/data/error_codes.rs
@@ -186,7 +186,7 @@ pub enum ErrorCode {
     /// ```vhdl
     /// signal foo : bit;
     /// -- ...
-    /// << signal from.somewhere.foo : constant >>
+    /// << constant from.somewhere.foo : bit >>
     /// ```
     MismatchedObjectClass,
 

--- a/vhdl_lang/src/data/error_codes.rs
+++ b/vhdl_lang/src/data/error_codes.rs
@@ -180,6 +180,16 @@ pub enum ErrorCode {
     /// ```
     MismatchedEntityClass,
 
+    /// The object class of an external name does not match the declared
+    ///
+    /// # Example
+    /// ```vhdl
+    /// signal foo : bit;
+    /// -- ...
+    /// << signal from.somewhere.foo : constant >>
+    /// ```
+    MismatchedObjectClass,
+
     /// The attribute specification is not in the immediate declarative part
     ///
     /// # Example
@@ -494,6 +504,7 @@ impl Default for SeverityMap {
             | SignatureMismatch
             | AmbiguousInstantiation
             | MismatchedSubprogramInstantiation
+            | MismatchedObjectClass
             | VoidReturn
             | NonVoidReturn
             | IllegalReturn

--- a/vhdl_lang/src/lint/dead_code.rs
+++ b/vhdl_lang/src/lint/dead_code.rs
@@ -107,7 +107,7 @@ fn can_be_locally_unused(ent: EntRef<'_>) -> bool {
     // No labels
     if matches!(
         ent.kind(),
-        AnyEntKind::Concurrent(_) | AnyEntKind::Sequential(_)
+        AnyEntKind::Concurrent(..) | AnyEntKind::Sequential(_)
     ) {
         return false;
     }

--- a/vhdl_lang/src/named_entity.rs
+++ b/vhdl_lang/src/named_entity.rs
@@ -91,7 +91,7 @@ pub enum AnyEntKind<'a> {
     /// to the exact statement (i.e., block process or generate).
     /// Not all statements are handled at the moment, therefore the associated
     /// data is optional.
-    Concurrent(Option<Concurrent>),
+    Concurrent(Option<Concurrent>, Region<'a>),
     /// A sequential statement. The associated [Sequential] data is a reference
     /// to the exact statement (i.e., loop, if or else statement).
     /// Not all statements are handled at the moment, therefore the associated
@@ -188,8 +188,8 @@ impl<'a> AnyEntKind<'a> {
             Component(..) => "component",
             Attribute(..) => "attribute",
             Overloaded(overloaded) => overloaded.describe(),
-            Concurrent(Some(c)) => c.describe(),
-            Concurrent(None) => "label",
+            Concurrent(Some(c), _) => c.describe(),
+            Concurrent(None, _) => "label",
             Sequential(Some(s)) => s.describe(),
             Sequential(None) => "label",
             LoopParameter(_) => "loop parameter",

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -479,8 +479,8 @@ fn to_symbol_kind(kind: &AnyEntKind) -> SymbolKind {
         AnyEntKind::Type(t) => type_kind(t),
         AnyEntKind::ElementDeclaration(_) => SymbolKind::FIELD,
         AnyEntKind::Sequential(_) => SymbolKind::NAMESPACE,
-        AnyEntKind::Concurrent(Some(Concurrent::Instance)) => SymbolKind::MODULE,
-        AnyEntKind::Concurrent(_) => SymbolKind::NAMESPACE,
+        AnyEntKind::Concurrent(Some(Concurrent::Instance), _) => SymbolKind::MODULE,
+        AnyEntKind::Concurrent(..) => SymbolKind::NAMESPACE,
         AnyEntKind::Library => SymbolKind::NAMESPACE,
         AnyEntKind::View(_) => SymbolKind::INTERFACE,
         AnyEntKind::Design(d) => match d {

--- a/vhdl_ls/src/vhdl_server/completion.rs
+++ b/vhdl_ls/src/vhdl_server/completion.rs
@@ -209,7 +209,7 @@ fn entity_kind_to_completion_kind(kind: &AnyEntKind) -> CompletionItemKind {
         },
         AnyEntKind::Type(_) => CompletionItemKind::TYPE_PARAMETER,
         AnyEntKind::ElementDeclaration(_) => CompletionItemKind::FIELD,
-        AnyEntKind::Concurrent(_) => CompletionItemKind::MODULE,
+        AnyEntKind::Concurrent(..) => CompletionItemKind::MODULE,
         AnyEntKind::Sequential(_) => CompletionItemKind::MODULE,
         AnyEntKind::Object(object) => match object.class {
             ObjectClass::Signal => CompletionItemKind::EVENT,


### PR DESCRIPTION
Relates to #258 

Currently, we do not analyse external names at all. This adds a baseline implementation for package pathnames (i.e., `@lib.foo.bar`) in addition to type and kind checking in general.