### PR TITLE
CI: Use hashes for GitHub actions

### DIFF
--- a/.github/workflows/build-test-all.yml
+++ b/.github/workflows/build-test-all.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
       - name: Add Apple Silicon Dependencies
         run: rustup target add aarch64-apple-darwin
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      - uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40  # v1.5.0
         if: matrix.os == 'ubuntu-latest'
         with:
           packages: musl-tools # provides musl-gcc
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload
         if: matrix.rust == 'stable'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ matrix.crate }}-${{ matrix.target }}
           path: ${{ matrix.crate }}-${{ matrix.target }}
@@ -103,9 +103,9 @@ jobs:
         run: |
           echo "v=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
           echo "Version is v${GITHUB_REF/refs\/tags\/v/}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: vhdl_*
           path: ~/temp
@@ -144,7 +144,7 @@ jobs:
           zip -r vhdl_ls-aarch64-apple-darwin.zip vhdl_ls-aarch64-apple-darwin
           zip -r vhdl_lang-aarch64-apple-darwin.zip vhdl_lang-aarch64-apple-darwin
       - name: Do release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174  # v1.16.0
         with:
           draft: false
           artifacts: "~/temp/*.zip"

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -11,12 +11,12 @@ jobs:
     if: github.repository == 'VHDL-LS/rust_hdl'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f  # v1.0.6
         with:
           toolchain: stable
           override: true
-      - uses: katyo/publish-crates@v2
+      - uses: katyo/publish-crates@02cc2f1ad653fb25c7d1ff9eb590a8a50d06186b  # v2
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
           ignore-unpublished-changes: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ jobs:
         - vhdl_ls
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: jerray/publish-docker-action@v1.0.3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: jerray/publish-docker-action@87d84711629b0dc9f6bb127b568413cc92a2088e  # v1.0.5
       env:
         CRATE: ${{ matrix.crate }}
       with:
@@ -28,7 +28,7 @@ jobs:
         repository: kraigher/${{ matrix.crate }}
         auto_tag: true
         build_args: CRATE
-  
+
   # A job is required when the publish job is skipped
   skip-publish:
     name: Skip publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "brunch"
-version = "0.8.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016d950e43311624fa0b3e1bfe340f49f1913d21d76165f883ede0cfee569b62"
+checksum = "a920310c664a15b3a57bb9982acf60c86b31497aeaa9ff4e68ff558951e76bdd"
 dependencies = [
  "dactyl",
  "unicode-width 0.2.0",
@@ -210,9 +210,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dactyl"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4d2c8b71b31d345e76c2532f9c9a99eae384ec1f47a6eb6347e35b5645aae4"
+checksum = "cf3b5987c326a75231408ec70d57c059e31680f839efcf37f1bf6df102c65cf2"
 
 [[package]]
 name = "diff"

--- a/vhdl_lang/Cargo.toml
+++ b/vhdl_lang/Cargo.toml
@@ -35,7 +35,7 @@ enum-map = "2.7.3"
 tempfile = "3"
 pretty_assertions = "1"
 assert_matches = "1"
-brunch = "0.8"
+brunch = "0.10"
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 


### PR DESCRIPTION
See https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash for motivation why this is the safer way to handle action versions.

Also update the brunch depedency version.

One may consider activating the dependabot action, see https://github.com/apytypes/apytypes/blob/main/.github/dependabot.yml for an example (although one may consider checking weekly rather than monthly). This will create a PR to update the versions/hashes to the latest version when a new one is available.