### PR TITLE
fix handling of shutdown request and exit notification

### DIFF
--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -88,9 +88,10 @@ impl ConnectionRpcChannel {
             match message {
                 lsp_server::Message::Request(request) => {
                     match self.connection.handle_shutdown(&request) {
-                        Ok(shutdown) => {
-                            if shutdown {
+                        Ok(should_exit) => {
+                            if should_exit {
                                 server.shutdown_server();
+                                server.exit_notification();
                             } else {
                                 self.handle_request(&mut server, request)
                             }
@@ -270,11 +271,6 @@ impl ConnectionRpcChannel {
         // workspace.didChangeWatchedFiles
         let notification = match extract::<notification::DidChangeWatchedFiles>(notification) {
             Ok(params) => return server.workspace_did_change_watched_files(&params),
-            Err(notification) => notification,
-        };
-        // exit
-        let notification = match extract::<notification::Exit>(notification) {
-            Ok(_params) => return server.exit_notification(),
             Err(notification) => notification,
         };
 


### PR DESCRIPTION
vhdl_ls did not quit/exit after receiving the shutdown request and exit notification, because the lsp_server handle_shutdown request already waits for the exit notification and only returns true, if it is received. 

With the old setup, the handler for the exit notification was never called, because handle_shutdown consumed the notification.

fixes #142