### PR TITLE
fix formatting of block statements

### DIFF
--- a/vhdl_lang/src/formatting/concurrent_statement.rs
+++ b/vhdl_lang/src/formatting/concurrent_statement.rs
@@ -151,10 +151,10 @@ impl VHDLFormatter<'_> {
         });
         buffer.line_break();
         self.format_token_id(block.begin_token, buffer);
-        buffer.line_break();
         indented!(buffer, {
             self.format_concurrent_statements(&block.statements, buffer)
         });
+        buffer.line_break();
         self.format_token_span(
             TokenSpan::new(block.end_token, block.span.end_token - 1),
             buffer,


### PR DESCRIPTION
Thanks so much for this project!

Here is a little problem + fix I found using vhdl blocks

Before:
```vhdl
b_bla: block is
    signal s1: std_logic;
    signal s2: std_logic;
begin

    s1 <= s2;end block;
```

After:
```vhdl
b_bla: block is
    signal s1: std_logic;
    signal s2: std_logic;
begin
    s1 <= s2;
end block;
````

I cross referenced with how this is solved for process and it seems alright to me now.
