### PR TITLE
fix crash when autocompleting port map

### DIFF
--- a/vhdl_ls/src/vhdl_server/completion.rs
+++ b/vhdl_ls/src/vhdl_server/completion.rs
@@ -28,7 +28,10 @@ impl VHDLServer {
                 let mut item = self.entity_to_completion_item(ent);
                 if self.client_supports_snippets() {
                     item.insert_text_format = Some(InsertTextFormat::SNIPPET);
-                    item.insert_text = Some(format!("{} => $1,", item.insert_text.unwrap()));
+                    item.insert_text = Some(format!(
+                        "{} => $1,",
+                        item.insert_text.as_ref().unwrap_or(&item.label)
+                    ));
                 }
                 item
             }


### PR DESCRIPTION
4f20cbd introduced a regression that causes
`completion_item_to_lsp_item` to fail for a formal as insert_text is no longer set now. The new implementation for the conversion function is robust and uses insert_text when available and falls back to the item's label (as an LSP client would).

It would be ideal to have a regression test for this but as the tests are set up now, it seems like a `VHDLServer` object to call `completion_item_to_lsp_item` on isn't easily available. But as this was the only `unwrap()` in the function, I'm carefully optimistic ;-)