### PR TITLE
Add casing categories and enable per-category override

### DIFF
--- a/vhdl_lang/src/config/case.rs
+++ b/vhdl_lang/src/config/case.rs
@@ -267,11 +267,11 @@ mod tests {
     }
 
     #[test]
-    fn enabled_by_default_only() {
+    fn default_preset_no_overrides() {
         let cfg = parse(
             r#"
             [casing]
-            preset = "default"
+            preset = "vhdl_common"
             "#,
         )
         .unwrap()
@@ -285,7 +285,7 @@ mod tests {
         let cfg = parse(
             r#"
             [casing]
-            default = "lower"
+            preset = "vhdl_common"
 
             [casing.overrides]
             constant = "upper"
@@ -304,7 +304,7 @@ mod tests {
         let err = parse(
             r#"
             [casing]
-            default = "lower"
+            preset = "vhdl_common"
 
             [casing.overrides]
             foo_bar = "upper"
@@ -320,11 +320,11 @@ mod tests {
         let err = parse(
             r#"
             [casing]
-            default = "snakeish"
+            preset = "dne"
             "#,
         )
         .unwrap_err();
 
-        assert!(err.contains("Unknown case"));
+        assert!(err.contains("Unknown casing preset"));
     }
 }

--- a/vhdl_lang/src/config/case.rs
+++ b/vhdl_lang/src/config/case.rs
@@ -1,0 +1,342 @@
+use enum_map::{enum_map, Enum, EnumMap};
+use fnv::FnvHashMap;
+use std::str::FromStr;
+use toml::Value;
+
+/// Defines standard VHDL case conventions.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Case {
+    /// All lower case, i.e., `std_logic_vector`
+    Lower,
+    /// All upper-case, i.e., `STD_LOGIC_VECTOR`
+    Upper,
+    /// Pascal case, i.e., `Std_Logic_Vector`
+    Pascal,
+    /// Keep the case without aplying any transformations
+    Keep,
+}
+
+impl FromStr for Case {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "lower" | "snake" => Case::Lower,
+            "upper" | "upper_snake" => Case::Upper,
+            "pascal" | "upper_camel" => Case::Pascal,
+            "keep" => Case::Keep,
+            other => return Err(other.to_string()),
+        })
+    }
+}
+
+impl Case {
+    /// Converts the case in place, modifying the passed string.
+    pub fn convert(&self, val: &mut str) {
+        match self {
+            Case::Lower => val.make_ascii_lowercase(),
+            Case::Upper => val.make_ascii_uppercase(),
+            Case::Pascal => {
+                // SAFETY: changing ASCII letters only does not invalidate UTF-8.
+                let bytes = unsafe { val.as_bytes_mut() };
+                // First letter should be uppercased
+                let mut next_uppercase = true;
+                for byte in bytes {
+                    if byte == &b'_' {
+                        next_uppercase = true;
+                        continue;
+                    }
+                    if next_uppercase {
+                        byte.make_ascii_uppercase();
+                    } else {
+                        byte.make_ascii_lowercase();
+                    }
+                    next_uppercase = false;
+                }
+            }
+            Case::Keep => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod case_tests {
+    use super::*;
+
+    #[test]
+    fn test_case_lower() {
+        let mut test = String::from("STD_LOGIC_VECTOR");
+        Case::Lower.convert(&mut test);
+        assert_eq!(test, "std_logic_vector");
+    }
+
+    #[test]
+    fn test_case_upper() {
+        let mut test = String::from("std_logic_vector");
+        Case::Upper.convert(&mut test);
+        assert_eq!(test, "STD_LOGIC_VECTOR");
+    }
+
+    #[test]
+    fn test_case_pascal() {
+        let mut test = String::from("std_logic_vector");
+        Case::Pascal.convert(&mut test);
+        assert_eq!(test, "Std_Logic_Vector");
+    }
+
+    #[test]
+    fn test_case_empty() {
+        for case in &[Case::Lower, Case::Upper, Case::Pascal] {
+            let mut test = String::new();
+            case.convert(&mut test);
+            assert_eq!(test, "");
+        }
+    }
+
+    #[test]
+    fn test_case_underscore_only() {
+        for case in &[Case::Lower, Case::Upper, Case::Pascal] {
+            let mut test = String::from("___");
+            case.convert(&mut test);
+            assert_eq!(test, "___");
+        }
+    }
+
+    #[test]
+    fn test_case_consecutive_underscore() {
+        let mut test = String::from("std__logic___vector");
+        Case::Pascal.convert(&mut test);
+        assert_eq!(test, "Std__Logic___Vector");
+    }
+
+    #[test]
+    fn test_case_mixed() {
+        let mut test = String::from("StD_LoGiC_VeCToR");
+        Case::Pascal.convert(&mut test);
+        assert_eq!(test, "Std_Logic_Vector");
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Enum, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum Category {
+    /// Constants and generics
+    Constant,
+    /// Design units (entities, architectures, packages)
+    DesignUnit,
+    /// Signals, Variables, Files
+    Object,
+    /// Functions and Procedures
+    Subprogram,
+    /// Types
+    Type,
+    /// Enumeration literal
+    EnumLiteral,
+    /// Statement labels.
+    Label,
+    /// Attrbiutes such as 'high, 'low, e.t.c.
+    Attribute,
+    /// Library names (ieee, std, ...)
+    Library,
+    /// Keywords
+    Keyword,
+    /// Aliases
+    Alias,
+}
+
+pub type CategoryToCaseMap = EnumMap<Category, Case>;
+
+pub fn default_category_to_case_map() -> CategoryToCaseMap {
+    enum_map! {
+        Category::Constant => Case::Upper,
+        Category::Attribute => Case::Lower,
+        Category::DesignUnit => Case::Lower,
+        Category::EnumLiteral => Case::Upper,
+        Category::Keyword => Case::Lower,
+        Category::Label => Case::Lower,
+        Category::Library => Case::Lower,
+        Category::Object => Case::Lower,
+        Category::Subprogram => Case::Lower,
+        Category::Type => Case::Lower,
+        Category::Alias => Case::Lower
+    }
+}
+
+pub fn all_same_case_category_to_case_map(case: Case) -> CategoryToCaseMap {
+    EnumMap::from_fn(|_| case)
+}
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone, Enum, Default, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum Preset {
+    #[default]
+    VhdlCommon,
+    Minimal,
+}
+
+impl Preset {
+    pub fn to_category_case_map(&self) -> CategoryToCaseMap {
+        match self {
+            Preset::VhdlCommon => enum_map! {
+                Category::Constant => Case::Upper,
+                Category::Attribute => Case::Lower,
+                Category::DesignUnit => Case::Lower,
+                Category::EnumLiteral => Case::Upper,
+                Category::Keyword => Case::Lower,
+                Category::Label => Case::Lower,
+                Category::Library => Case::Lower,
+                Category::Object => Case::Lower,
+                Category::Subprogram => Case::Lower,
+                Category::Type => Case::Lower,
+                Category::Alias => Case::Lower,
+            },
+            Preset::Minimal => enum_map! {
+                Category::Constant => Case::Upper,
+                Category::Attribute => Case::Keep,
+                Category::DesignUnit => Case::Keep,
+                Category::EnumLiteral => Case::Upper,
+                Category::Keyword => Case::Keep,
+                Category::Label => Case::Keep,
+                Category::Library => Case::Keep,
+                Category::Object => Case::Keep,
+                Category::Subprogram => Case::Keep,
+                Category::Type => Case::Keep,
+                Category::Alias => Case::Keep,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CasingConfig {
+    pub preset: Preset,
+    pub overrides: FnvHashMap<Category, Case>,
+}
+
+impl CasingConfig {
+    pub fn into_category_case_map(self) -> CategoryToCaseMap {
+        let mut ccm = self.preset.to_category_case_map();
+        for (category, case) in self.overrides {
+            ccm[category] = case
+        }
+        ccm
+    }
+}
+
+impl CasingConfig {
+    pub fn parse(root: &Value) -> Result<Option<CasingConfig>, String> {
+        let Some(casing) = root.get("casing") else {
+            return Ok(None);
+        };
+        let casing = casing
+            .as_table()
+            .ok_or("[casing] must be a table".to_string())?;
+
+        let preset_str = casing
+            .get("preset")
+            .ok_or("preset must be present under 'casing'")?
+            .as_str()
+            .ok_or("casing.preset must be a string".to_string())?;
+
+        let preset = Preset::from_str(preset_str)
+            .map_err(|_| format!("Unknown casing preset '{preset_str}'"))?;
+
+        let mut overrides = FnvHashMap::default();
+
+        if let Some(Value::Table(tbl)) = casing.get("overrides") {
+            for (key, value) in tbl {
+                let kind =
+                    Category::from_str(key).map_err(|_| format!("Unknown category '{key}'"))?;
+                let style_str = value
+                    .as_str()
+                    .ok_or_else(|| format!("Override for '{}' must be a string", key))?;
+                let style =
+                    Case::from_str(style_str).map_err(|_| format!("Unknown case '{style_str}'"))?;
+                overrides.insert(kind, style);
+            }
+        } else if casing.contains_key("overrides") {
+            return Err("casing.overrides must be a table".into());
+        }
+
+        Ok(Some(CasingConfig { preset, overrides }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml::Value;
+
+    fn parse(toml_str: &str) -> Result<Option<CasingConfig>, String> {
+        let value: Value = toml_str.parse().unwrap();
+        CasingConfig::parse(&value)
+    }
+
+    #[test]
+    fn disabled_when_missing() {
+        let cfg = parse("").unwrap();
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn enabled_by_default_only() {
+        let cfg = parse(
+            r#"
+            [casing]
+            preset = "default"
+            "#,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(cfg.preset == Preset::VhdlCommon);
+    }
+
+    #[test]
+    fn overrides_work() {
+        let cfg = parse(
+            r#"
+            [casing]
+            default = "lower"
+
+            [casing.overrides]
+            constant = "upper"
+            type = "pascal"
+            "#,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(cfg.overrides.get(&Category::Constant), Some(&Case::Upper));
+        assert_eq!(cfg.overrides.get(&Category::Type), Some(&Case::Pascal));
+    }
+
+    #[test]
+    fn invalid_category_errors() {
+        let err = parse(
+            r#"
+            [casing]
+            default = "lower"
+
+            [casing.overrides]
+            foo_bar = "upper"
+            "#,
+        )
+        .unwrap_err();
+
+        assert!(err.contains("Unknown category"));
+    }
+
+    #[test]
+    fn invalid_casing_style_errors() {
+        let err = parse(
+            r#"
+            [casing]
+            default = "snakeish"
+            "#,
+        )
+        .unwrap_err();
+
+        assert!(err.contains("Unknown case"));
+    }
+}

--- a/vhdl_lang/src/config/case.rs
+++ b/vhdl_lang/src/config/case.rs
@@ -171,7 +171,7 @@ pub fn all_same_case_category_to_case_map(case: Case) -> CategoryToCaseMap {
 pub enum Preset {
     #[default]
     VhdlCommon,
-    Minimal,
+    Keep,
 }
 
 impl Preset {
@@ -190,19 +190,7 @@ impl Preset {
                 Category::Type => Case::Lower,
                 Category::Alias => Case::Lower,
             },
-            Preset::Minimal => enum_map! {
-                Category::Constant => Case::Upper,
-                Category::Attribute => Case::Keep,
-                Category::DesignUnit => Case::Keep,
-                Category::EnumLiteral => Case::Upper,
-                Category::Keyword => Case::Keep,
-                Category::Label => Case::Keep,
-                Category::Library => Case::Keep,
-                Category::Object => Case::Keep,
-                Category::Subprogram => Case::Keep,
-                Category::Type => Case::Keep,
-                Category::Alias => Case::Keep,
-            },
+            Preset::Keep => CategoryToCaseMap::from_fn(|_| Case::Keep),
         }
     }
 }

--- a/vhdl_lang/src/config/mod.rs
+++ b/vhdl_lang/src/config/mod.rs
@@ -1,10 +1,11 @@
+//! Configuration of the design hierarchy and other settings
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
-//! Configuration of the design hierarchy and other settings
+pub mod case;
 
 use std::collections::BTreeSet;
 use std::env;
@@ -12,125 +13,16 @@ use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 use std::path::Path;
-use std::str::FromStr;
 
+use enum_map::EnumMap;
 use fnv::FnvHashMap;
 use subst::VariableMap;
 use toml::{Table, Value};
 
+use crate::config::case::{Case, CasingConfig, CategoryToCaseMap};
 use crate::data::error_codes::ErrorCode;
 use crate::data::*;
 use crate::standard::VHDLStandard;
-
-/// Defines standard VHDL case conventions.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Case {
-    /// All lower case, i.e., `std_logic_vector`
-    Lower,
-    /// All upper-case, i.e., `STD_LOGIC_VECTOR`
-    Upper,
-    /// Pascal case, i.e., `Std_Logic_Vector`
-    Pascal,
-}
-
-impl FromStr for Case {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "lower" | "snake" => Case::Lower,
-            "upper" | "upper_snake" => Case::Upper,
-            "pascal" | "upper_camel" => Case::Pascal,
-            other => return Err(other.to_string()),
-        })
-    }
-}
-
-impl Case {
-    /// Converts the case in place, modifying the passed string.
-    pub fn convert(&self, val: &mut str) {
-        match self {
-            Case::Lower => val.make_ascii_lowercase(),
-            Case::Upper => val.make_ascii_uppercase(),
-            Case::Pascal => {
-                // SAFETY: changing ASCII letters only does not invalidate UTF-8.
-                let bytes = unsafe { val.as_bytes_mut() };
-                // First letter should be uppercased
-                let mut next_uppercase = true;
-                for byte in bytes {
-                    if byte == &b'_' {
-                        next_uppercase = true;
-                        continue;
-                    }
-                    if next_uppercase {
-                        byte.make_ascii_uppercase();
-                    } else {
-                        byte.make_ascii_lowercase();
-                    }
-                    next_uppercase = false;
-                }
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod case_tests {
-    use super::*;
-
-    #[test]
-    fn test_case_lower() {
-        let mut test = String::from("STD_LOGIC_VECTOR");
-        Case::Lower.convert(&mut test);
-        assert_eq!(test, "std_logic_vector");
-    }
-
-    #[test]
-    fn test_case_upper() {
-        let mut test = String::from("std_logic_vector");
-        Case::Upper.convert(&mut test);
-        assert_eq!(test, "STD_LOGIC_VECTOR");
-    }
-
-    #[test]
-    fn test_case_pascal() {
-        let mut test = String::from("std_logic_vector");
-        Case::Pascal.convert(&mut test);
-        assert_eq!(test, "Std_Logic_Vector");
-    }
-
-    #[test]
-    fn test_case_empty() {
-        for case in &[Case::Lower, Case::Upper, Case::Pascal] {
-            let mut test = String::new();
-            case.convert(&mut test);
-            assert_eq!(test, "");
-        }
-    }
-
-    #[test]
-    fn test_case_underscore_only() {
-        for case in &[Case::Lower, Case::Upper, Case::Pascal] {
-            let mut test = String::from("___");
-            case.convert(&mut test);
-            assert_eq!(test, "___");
-        }
-    }
-
-    #[test]
-    fn test_case_consecutive_underscore() {
-        let mut test = String::from("std__logic___vector");
-        Case::Pascal.convert(&mut test);
-        assert_eq!(test, "Std__Logic___Vector");
-    }
-
-    #[test]
-    fn test_case_mixed() {
-        let mut test = String::from("StD_LoGiC_VeCToR");
-        Case::Pascal.convert(&mut test);
-        assert_eq!(test, "Std_Logic_Vector");
-    }
-}
 
 #[derive(Clone, PartialEq, Eq, Default, Debug)]
 pub struct Config {
@@ -139,7 +31,7 @@ pub struct Config {
     standard: VHDLStandard,
     // Defines the severity that diagnostics are displayed with
     severities: SeverityMap,
-    preferred_case: Option<Case>,
+    casing_config: Option<EnumMap<case::Category, Case>>,
 }
 
 #[derive(Clone, PartialEq, Eq, Default, Debug)]
@@ -238,22 +130,13 @@ impl Config {
             SeverityMap::default()
         };
 
-        let case = if let Some(case) = config.get("preferred_case") {
-            Some(
-                case.as_str()
-                    .ok_or("preferred_case must be a string")?
-                    .parse()
-                    .map_err(|other| format!("Case '{other}' not valid"))?,
-            )
-        } else {
-            None
-        };
+        let case = CasingConfig::parse(&config)?.map(|cfg| cfg.into_category_case_map());
 
         Ok(Config {
             libraries,
             severities,
             standard,
-            preferred_case: case,
+            casing_config: case,
         })
     }
 
@@ -316,7 +199,7 @@ impl Config {
             }
         }
         self.severities = config.severities;
-        self.preferred_case = config.preferred_case;
+        self.casing_config = config.casing_config;
     }
 
     /// Load configuration file from installation folder
@@ -428,8 +311,8 @@ impl Config {
     }
 
     /// Returns the casing that is preferred by the user for linting or completions.
-    pub fn preferred_case(&self) -> Option<Case> {
-        self.preferred_case
+    pub fn preferred_case(&self) -> Option<CategoryToCaseMap> {
+        self.casing_config
     }
 }
 

--- a/vhdl_lang/src/lib.rs
+++ b/vhdl_lang/src/lib.rs
@@ -16,7 +16,7 @@ extern crate self as vhdl_lang;
 pub mod ast;
 #[macro_use]
 mod analysis;
-mod config;
+pub mod config;
 mod data;
 mod lint;
 mod named_entity;
@@ -27,7 +27,7 @@ mod completion;
 mod formatting;
 mod standard;
 
-pub use crate::config::{Case, Config};
+pub use crate::config::Config;
 pub use crate::data::{
     Diagnostic, Latin1String, Message, MessageHandler, MessagePrinter, MessageType,
     NullDiagnostics, NullMessages, Position, Range, Severity, SeverityMap, Source, SrcPos,

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -22,8 +22,8 @@ use std::io;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use vhdl_lang::{
-    AnyEntKind, Case, Concurrent, Config, EntHierarchy, EntRef, Message, MessageHandler, Object,
-    Overloaded, Project, SeverityMap, SrcPos, Token, Type, VHDLStandard,
+    config::case::CategoryToCaseMap, AnyEntKind, Concurrent, Config, EntHierarchy, EntRef, Message,
+    MessageHandler, Object, Overloaded, Project, SeverityMap, SrcPos, Token, Type, VHDLStandard,
 };
 
 /// Defines how the language server handles files
@@ -66,7 +66,7 @@ pub struct VHDLServer {
     init_params: Option<InitializeParams>,
     config_file: Option<PathBuf>,
     severity_map: SeverityMap,
-    case_transform: Option<Case>,
+    case_transform: Option<CategoryToCaseMap>,
     string_matcher: SkimMatcherV2,
 }
 

--- a/vhdl_ls/src/vhdl_server/completion.rs
+++ b/vhdl_ls/src/vhdl_server/completion.rs
@@ -4,13 +4,14 @@ use lsp_types::{
     InsertTextFormat, MarkupContent, MarkupKind,
 };
 use vhdl_lang::ast::{Designator, ObjectClass};
+use vhdl_lang::config::case::{self, Category};
 use vhdl_lang::{kind_str, AnyEntKind, Design, EntRef, InterfaceEnt, Overloaded};
 
 impl VHDLServer {
-    fn insert_text(&self, val: impl ToString) -> String {
+    fn insert_text(&self, val: impl ToString, category: case::Category) -> String {
         let mut val = val.to_string();
         if let Some(case) = &self.case_transform {
-            case.convert(&mut val)
+            case[category].convert(&mut val);
         }
         val
     }
@@ -19,7 +20,7 @@ impl VHDLServer {
         match item {
             vhdl_lang::CompletionItem::Simple(ent) => self.entity_to_completion_item(ent),
             vhdl_lang::CompletionItem::Work => CompletionItem {
-                label: self.insert_text("work"),
+                label: self.insert_text("work", Category::Library),
                 detail: Some("work library".to_string()),
                 kind: Some(CompletionItemKind::MODULE),
                 ..Default::default()
@@ -42,23 +43,26 @@ impl VHDLServer {
                     _ => None,
                 };
                 CompletionItem {
-                    label: self.insert_text(desi),
+                    label: self.insert_text(desi, Category::Subprogram),
                     detail: Some(format!("+{count} overloaded")),
                     kind,
                     ..Default::default()
                 }
             }
             vhdl_lang::CompletionItem::Keyword(kind) => CompletionItem {
-                label: self.insert_text(kind_str(kind)),
+                label: self.insert_text(kind_str(kind), Category::Keyword),
                 detail: Some(kind_str(kind).to_string()),
                 kind: Some(CompletionItemKind::KEYWORD),
                 ..Default::default()
             },
             vhdl_lang::CompletionItem::Instantiation(ent, architectures) => {
-                let work_name = self.insert_text("work");
+                let work_name = self.insert_text("work", Category::Library);
 
                 let library_names = if let Some(lib_name) = ent.library_name() {
-                    vec![work_name, self.insert_text(lib_name.name())]
+                    vec![
+                        work_name,
+                        self.insert_text(lib_name.name(), Category::Library),
+                    ]
                 } else {
                     vec![work_name]
                 };
@@ -68,7 +72,7 @@ impl VHDLServer {
                     // should never happen but better return some value instead of crashing
                     _ => return self.entity_to_completion_item(ent),
                 };
-                let designator = self.insert_text(&ent.designator);
+                let designator = self.insert_text(&ent.designator, Category::DesignUnit);
                 let template = if self.client_supports_snippets() {
                     let mut line = if is_component_instantiation {
                         format!("${{1:{designator}_inst}}: {designator}",)
@@ -81,7 +85,9 @@ impl VHDLServer {
                     if architectures.len() > 1 {
                         line.push_str("(${3|");
                         for (i, architecture) in architectures.iter().enumerate() {
-                            line.push_str(&self.insert_text(architecture.designator()));
+                            line.push_str(
+                                &self.insert_text(architecture.designator(), Category::DesignUnit),
+                            );
                             if i != architectures.len() - 1 {
                                 line.push(',')
                             }
@@ -91,9 +97,13 @@ impl VHDLServer {
                     let (ports, generics) = region.ports_and_generics();
                     let mut idx = 4;
                     let mut interface_ent = |elements: Vec<InterfaceEnt>, purpose: &str| {
-                        line += &*format!("\n {purpose} {}(\n", self.insert_text("map"));
+                        line += &*format!(
+                            "\n {purpose} {}(\n",
+                            self.insert_text("map", Category::Keyword)
+                        );
                         for (i, generic) in elements.iter().enumerate() {
-                            let generic_designator = self.insert_text(&generic.designator);
+                            let generic_designator =
+                                self.insert_text(&generic.designator, Category::Constant);
                             line += &*format!(
                                 "    {generic_designator} => ${{{idx}:{generic_designator}}}",
                             );
@@ -106,10 +116,10 @@ impl VHDLServer {
                         line += ")";
                     };
                     if !generics.is_empty() {
-                        interface_ent(generics, &self.insert_text("generic"));
+                        interface_ent(generics, &self.insert_text("generic", Category::Keyword));
                     }
                     if !ports.is_empty() {
-                        interface_ent(ports, &self.insert_text("port"));
+                        interface_ent(ports, &self.insert_text("port", Category::Keyword));
                     }
                     line += ";";
                     line
@@ -125,7 +135,7 @@ impl VHDLServer {
                 }
             }
             vhdl_lang::CompletionItem::Attribute(attribute) => CompletionItem {
-                label: self.insert_text(attribute),
+                label: self.insert_text(attribute, Category::Attribute),
                 kind: Some(CompletionItemKind::REFERENCE),
                 ..Default::default()
             },
@@ -185,12 +195,46 @@ impl VHDLServer {
 
     fn entity_to_completion_item(&self, ent: EntRef) -> CompletionItem {
         CompletionItem {
-            label: self.insert_text(&ent.designator),
+            label: self.insert_text(&ent.designator, entity_kind_to_casing_category(ent.kind())),
             detail: Some(ent.describe()),
             kind: Some(entity_kind_to_completion_kind(ent.kind())),
             data: serde_json::to_value(ent.id.to_raw()).ok(),
             ..Default::default()
         }
+    }
+}
+
+fn entity_kind_to_casing_category(kind: &AnyEntKind) -> Category {
+    match kind {
+        AnyEntKind::ExternalAlias { .. } | AnyEntKind::ObjectAlias { .. } => Category::Alias,
+        AnyEntKind::File(_) | AnyEntKind::InterfaceFile(_) => Category::Object,
+        AnyEntKind::Component(_) => Category::DesignUnit,
+        AnyEntKind::Attribute(_) => Category::Attribute,
+        AnyEntKind::Overloaded(overloaded) => match overloaded {
+            Overloaded::SubprogramDecl(_)
+            | Overloaded::Subprogram(_)
+            | Overloaded::UninstSubprogramDecl(..)
+            | Overloaded::UninstSubprogram(..)
+            | Overloaded::InterfaceSubprogram(_) => Category::Subprogram,
+            Overloaded::EnumLiteral(_) => Category::EnumLiteral,
+            Overloaded::Alias(_) => Category::Alias,
+        },
+        AnyEntKind::Type(_) => Category::Type,
+        AnyEntKind::ElementDeclaration(_) => Category::Object,
+        AnyEntKind::Concurrent(..) => Category::Label,
+        AnyEntKind::Sequential(_) => Category::Label,
+        AnyEntKind::Object(object) => match object.class {
+            ObjectClass::Constant => Category::Constant,
+            ObjectClass::Variable | ObjectClass::SharedVariable | ObjectClass::Signal => {
+                Category::Object
+            }
+        },
+        AnyEntKind::LoopParameter(_) => Category::Label,
+        AnyEntKind::PhysicalLiteral(_) => Category::Object,
+        AnyEntKind::DeferredConstant(_) => Category::Constant,
+        AnyEntKind::Library => Category::Library,
+        AnyEntKind::Design(_) => Category::DesignUnit,
+        AnyEntKind::View(_) => Category::DesignUnit,
     }
 }
 


### PR DESCRIPTION
This PR makes the case transformations for completions more usable.

Closes #422 

# Old
Previously, there was one `preferred_case` option:

```toml
preferred_case = "..." # lower, upper, pascal
```

# New
This PR enables more elaborate casing rules. The following are available categories:
- `constant` for constants (also includes generics)
- `design_unit` for all design units like entities, architectures, packages, e.t.c.
- `object` for all non-constant objects, i.e., signals, variables, files
- `subprograms` for functions and procedures
- `type` for types
- `enum_literal` for enumeration literals
- `label` for labels
- `attribute` for attribute names, i.e., `foo'high`
- `library` for library names, i.e, `ieee`, `work`
- `keyword` for VHDL keywords
- `alias` for aliases

A user configures the case setting by selecting a preset and optionally overrides:
```toml
[casing]
preset = "vhdl-common"

[casing.overrides]
type = "pascal" # Use the `vhdl-common` preset, but use pascal-case for types
```

There are two presets in this initial release:
1) `vhdl-common`: More or less opinionated casing styles that seem to be common:
```toml
constant = "upper"
attribute = "lower"
design_unit = "lower"
enum_literal = "lower"
keyword = "lower"
label = "lower"
library = "lower"
object = "lower"
subprogram = "lower"
type = "lower"
alias = "lower"
```

2) `keep`: Keep every category. This is intended as a starting point:
```toml
constant = "keep"
attribute = "keep"
design_unit = "keep"
# ...
```