### PR TITLE
Add a checked API

### DIFF
--- a/vhdl_syntax/src/builder.rs
+++ b/vhdl_syntax/src/builder.rs
@@ -102,6 +102,18 @@ impl From<&[u8]> for Identifier {
     }
 }
 
+impl From<&Latin1Str> for Identifier {
+    fn from(value: &Latin1Str) -> Self {
+        Identifier::new(Latin1String::from(value))
+    }
+}
+
+impl From<Latin1String> for Identifier {
+    fn from(value: Latin1String) -> Self {
+        Identifier::new(value)
+    }
+}
+
 impl<const N: usize> From<[u8; N]> for Identifier {
     fn from(value: [u8; N]) -> Self {
         Identifier::new(Latin1String::from(&value))

--- a/vhdl_syntax/src/syntax/checked/generated/concurrent_statements.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/concurrent_statements.rs
@@ -1,0 +1,1266 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedDeclarationStatementSeparator(DeclarationStatementSeparatorSyntax);
+impl CheckedNode for CheckedDeclarationStatementSeparator {
+    type Syntax = DeclarationStatementSeparatorSyntax;
+    fn cast_unchecked(syntax: DeclarationStatementSeparatorSyntax) -> Self {
+        CheckedDeclarationStatementSeparator(syntax)
+    }
+    fn raw(&self) -> DeclarationStatementSeparatorSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDeclarationStatementSeparator {
+    pub fn begin_token(&self) -> SyntaxToken {
+        self.0.begin_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSemiColonTerminatedGenericMapAspect(SemiColonTerminatedGenericMapAspectSyntax);
+impl CheckedNode for CheckedSemiColonTerminatedGenericMapAspect {
+    type Syntax = SemiColonTerminatedGenericMapAspectSyntax;
+    fn cast_unchecked(syntax: SemiColonTerminatedGenericMapAspectSyntax) -> Self {
+        CheckedSemiColonTerminatedGenericMapAspect(syntax)
+    }
+    fn raw(&self) -> SemiColonTerminatedGenericMapAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSemiColonTerminatedGenericMapAspect {
+    pub fn generic_map_aspect(&self) -> CheckedGenericMapAspect {
+        CheckedGenericMapAspect::cast_unchecked(self.0.generic_map_aspect().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSemiColonTerminatedPortMapAspect(SemiColonTerminatedPortMapAspectSyntax);
+impl CheckedNode for CheckedSemiColonTerminatedPortMapAspect {
+    type Syntax = SemiColonTerminatedPortMapAspectSyntax;
+    fn cast_unchecked(syntax: SemiColonTerminatedPortMapAspectSyntax) -> Self {
+        CheckedSemiColonTerminatedPortMapAspect(syntax)
+    }
+    fn raw(&self) -> SemiColonTerminatedPortMapAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSemiColonTerminatedPortMapAspect {
+    pub fn port_map_aspect(&self) -> CheckedPortMapAspect {
+        CheckedPortMapAspect::cast_unchecked(self.0.port_map_aspect().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockHeader(BlockHeaderSyntax);
+impl CheckedNode for CheckedBlockHeader {
+    type Syntax = BlockHeaderSyntax;
+    fn cast_unchecked(syntax: BlockHeaderSyntax) -> Self {
+        CheckedBlockHeader(syntax)
+    }
+    fn raw(&self) -> BlockHeaderSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockHeader {
+    pub fn generic_clause(&self) -> Option<CheckedGenericClause> {
+        self.0
+            .generic_clause()
+            .map(CheckedGenericClause::cast_unchecked)
+    }
+    pub fn semi_colon_terminated_generic_map_aspect(
+        &self,
+    ) -> Option<CheckedSemiColonTerminatedGenericMapAspect> {
+        self.0
+            .semi_colon_terminated_generic_map_aspect()
+            .map(CheckedSemiColonTerminatedGenericMapAspect::cast_unchecked)
+    }
+    pub fn port_clause(&self) -> Option<CheckedPortClause> {
+        self.0.port_clause().map(CheckedPortClause::cast_unchecked)
+    }
+    pub fn semi_colon_terminated_port_map_aspect(
+        &self,
+    ) -> Option<CheckedSemiColonTerminatedPortMapAspect> {
+        self.0
+            .semi_colon_terminated_port_map_aspect()
+            .map(CheckedSemiColonTerminatedPortMapAspect::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockStatement(BlockStatementSyntax);
+impl CheckedNode for CheckedBlockStatement {
+    type Syntax = BlockStatementSyntax;
+    fn cast_unchecked(syntax: BlockStatementSyntax) -> Self {
+        CheckedBlockStatement(syntax)
+    }
+    fn raw(&self) -> BlockStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockStatement {
+    pub fn block_preamble(&self) -> CheckedBlockPreamble {
+        CheckedBlockPreamble::cast_unchecked(self.0.block_preamble().unwrap())
+    }
+    pub fn block_header(&self) -> Option<CheckedBlockHeader> {
+        self.0
+            .block_header()
+            .map(CheckedBlockHeader::cast_unchecked)
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> CheckedDeclarationStatementSeparator {
+        CheckedDeclarationStatementSeparator::cast_unchecked(
+            self.0.declaration_statement_separator().unwrap(),
+        )
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn block_epilogue(&self) -> CheckedBlockEpilogue {
+        CheckedBlockEpilogue::cast_unchecked(self.0.block_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedExpression(ParenthesizedExpressionSyntax);
+impl CheckedNode for CheckedParenthesizedExpression {
+    type Syntax = ParenthesizedExpressionSyntax;
+    fn cast_unchecked(syntax: ParenthesizedExpressionSyntax) -> Self {
+        CheckedParenthesizedExpression(syntax)
+    }
+    fn raw(&self) -> ParenthesizedExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedExpression {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockPreamble(BlockPreambleSyntax);
+impl CheckedNode for CheckedBlockPreamble {
+    type Syntax = BlockPreambleSyntax;
+    fn cast_unchecked(syntax: BlockPreambleSyntax) -> Self {
+        CheckedBlockPreamble(syntax)
+    }
+    fn raw(&self) -> BlockPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockPreamble {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn block_token(&self) -> SyntaxToken {
+        self.0.block_token().unwrap()
+    }
+    pub fn condition(&self) -> Option<CheckedParenthesizedExpression> {
+        self.0
+            .condition()
+            .map(CheckedParenthesizedExpression::cast_unchecked)
+    }
+    pub fn is_token(&self) -> Option<SyntaxToken> {
+        self.0.is_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockEpilogue(BlockEpilogueSyntax);
+impl CheckedNode for CheckedBlockEpilogue {
+    type Syntax = BlockEpilogueSyntax;
+    fn cast_unchecked(syntax: BlockEpilogueSyntax) -> Self {
+        CheckedBlockEpilogue(syntax)
+    }
+    fn raw(&self) -> BlockEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn block_token(&self) -> SyntaxToken {
+        self.0.block_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseGenerateAlternative(CaseGenerateAlternativeSyntax);
+impl CheckedNode for CheckedCaseGenerateAlternative {
+    type Syntax = CaseGenerateAlternativeSyntax;
+    fn cast_unchecked(syntax: CaseGenerateAlternativeSyntax) -> Self {
+        CheckedCaseGenerateAlternative(syntax)
+    }
+    fn raw(&self) -> CaseGenerateAlternativeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseGenerateAlternative {
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn choices(&self) -> Option<CheckedChoices> {
+        self.0.choices().map(CheckedChoices::cast_unchecked)
+    }
+    pub fn right_arrow_token(&self) -> SyntaxToken {
+        self.0.right_arrow_token().unwrap()
+    }
+    pub fn generate_statement_body(&self) -> Option<CheckedGenerateStatementBody> {
+        self.0
+            .generate_statement_body()
+            .map(CheckedGenerateStatementBody::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseGenerateStatement(CaseGenerateStatementSyntax);
+impl CheckedNode for CheckedCaseGenerateStatement {
+    type Syntax = CaseGenerateStatementSyntax;
+    fn cast_unchecked(syntax: CaseGenerateStatementSyntax) -> Self {
+        CheckedCaseGenerateStatement(syntax)
+    }
+    fn raw(&self) -> CaseGenerateStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseGenerateStatement {
+    pub fn case_generate_statement_preamble(&self) -> CheckedCaseGenerateStatementPreamble {
+        CheckedCaseGenerateStatementPreamble::cast_unchecked(
+            self.0.case_generate_statement_preamble().unwrap(),
+        )
+    }
+    pub fn case_generate_alternatives(
+        &self,
+    ) -> impl Iterator<Item = CheckedCaseGenerateAlternative> + use<'_> {
+        self.0
+            .case_generate_alternatives()
+            .map(CheckedCaseGenerateAlternative::cast_unchecked)
+    }
+    pub fn case_generate_statement_epilogue(&self) -> CheckedCaseGenerateStatementEpilogue {
+        CheckedCaseGenerateStatementEpilogue::cast_unchecked(
+            self.0.case_generate_statement_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseGenerateStatementPreamble(CaseGenerateStatementPreambleSyntax);
+impl CheckedNode for CheckedCaseGenerateStatementPreamble {
+    type Syntax = CaseGenerateStatementPreambleSyntax;
+    fn cast_unchecked(syntax: CaseGenerateStatementPreambleSyntax) -> Self {
+        CheckedCaseGenerateStatementPreamble(syntax)
+    }
+    fn raw(&self) -> CaseGenerateStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseGenerateStatementPreamble {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn case_token(&self) -> SyntaxToken {
+        self.0.case_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseGenerateStatementEpilogue(CaseGenerateStatementEpilogueSyntax);
+impl CheckedNode for CheckedCaseGenerateStatementEpilogue {
+    type Syntax = CaseGenerateStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: CaseGenerateStatementEpilogueSyntax) -> Self {
+        CheckedCaseGenerateStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> CaseGenerateStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseGenerateStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentInstantiationStatement(ComponentInstantiationStatementSyntax);
+impl CheckedNode for CheckedComponentInstantiationStatement {
+    type Syntax = ComponentInstantiationStatementSyntax;
+    fn cast_unchecked(syntax: ComponentInstantiationStatementSyntax) -> Self {
+        CheckedComponentInstantiationStatement(syntax)
+    }
+    fn raw(&self) -> ComponentInstantiationStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentInstantiationStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn instantiated_unit(&self) -> CheckedInstantiatedUnit {
+        CheckedInstantiatedUnit::cast_unchecked(self.0.instantiated_unit().unwrap())
+    }
+    pub fn component_instantiation_items(&self) -> Option<CheckedComponentInstantiationItems> {
+        self.0
+            .component_instantiation_items()
+            .map(CheckedComponentInstantiationItems::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentInstantiationItems(ComponentInstantiationItemsSyntax);
+impl CheckedNode for CheckedComponentInstantiationItems {
+    type Syntax = ComponentInstantiationItemsSyntax;
+    fn cast_unchecked(syntax: ComponentInstantiationItemsSyntax) -> Self {
+        CheckedComponentInstantiationItems(syntax)
+    }
+    fn raw(&self) -> ComponentInstantiationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentInstantiationItems {
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+    pub fn port_map_aspect(&self) -> Option<CheckedPortMapAspect> {
+        self.0
+            .port_map_aspect()
+            .map(CheckedPortMapAspect::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentProcedureCallOrComponentInstantiationStatement(
+    ConcurrentProcedureCallOrComponentInstantiationStatementSyntax,
+);
+impl CheckedNode for CheckedConcurrentProcedureCallOrComponentInstantiationStatement {
+    type Syntax = ConcurrentProcedureCallOrComponentInstantiationStatementSyntax;
+    fn cast_unchecked(
+        syntax: ConcurrentProcedureCallOrComponentInstantiationStatementSyntax,
+    ) -> Self {
+        CheckedConcurrentProcedureCallOrComponentInstantiationStatement(syntax)
+    }
+    fn raw(&self) -> ConcurrentProcedureCallOrComponentInstantiationStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentProcedureCallOrComponentInstantiationStatement {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentAssertionStatement(ConcurrentAssertionStatementSyntax);
+impl CheckedNode for CheckedConcurrentAssertionStatement {
+    type Syntax = ConcurrentAssertionStatementSyntax;
+    fn cast_unchecked(syntax: ConcurrentAssertionStatementSyntax) -> Self {
+        CheckedConcurrentAssertionStatement(syntax)
+    }
+    fn raw(&self) -> ConcurrentAssertionStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentAssertionStatement {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn assertion(&self) -> CheckedAssertion {
+        CheckedAssertion::cast_unchecked(self.0.assertion().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentSimpleSignalAssignment(ConcurrentSimpleSignalAssignmentSyntax);
+impl CheckedNode for CheckedConcurrentSimpleSignalAssignment {
+    type Syntax = ConcurrentSimpleSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: ConcurrentSimpleSignalAssignmentSyntax) -> Self {
+        CheckedConcurrentSimpleSignalAssignment(syntax)
+    }
+    fn raw(&self) -> ConcurrentSimpleSignalAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentSimpleSignalAssignment {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn guarded_token(&self) -> Option<SyntaxToken> {
+        self.0.guarded_token()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentConditionalSignalAssignment(
+    ConcurrentConditionalSignalAssignmentSyntax,
+);
+impl CheckedNode for CheckedConcurrentConditionalSignalAssignment {
+    type Syntax = ConcurrentConditionalSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: ConcurrentConditionalSignalAssignmentSyntax) -> Self {
+        CheckedConcurrentConditionalSignalAssignment(syntax)
+    }
+    fn raw(&self) -> ConcurrentConditionalSignalAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentConditionalSignalAssignment {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn guarded_token(&self) -> Option<SyntaxToken> {
+        self.0.guarded_token()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn conditional_waveforms(&self) -> CheckedConditionalWaveforms {
+        CheckedConditionalWaveforms::cast_unchecked(self.0.conditional_waveforms().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentSelectedSignalAssignment(ConcurrentSelectedSignalAssignmentSyntax);
+impl CheckedNode for CheckedConcurrentSelectedSignalAssignment {
+    type Syntax = ConcurrentSelectedSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: ConcurrentSelectedSignalAssignmentSyntax) -> Self {
+        CheckedConcurrentSelectedSignalAssignment(syntax)
+    }
+    fn raw(&self) -> ConcurrentSelectedSignalAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentSelectedSignalAssignment {
+    pub fn concurrent_selected_signal_assignment_preamble(
+        &self,
+    ) -> CheckedConcurrentSelectedSignalAssignmentPreamble {
+        CheckedConcurrentSelectedSignalAssignmentPreamble::cast_unchecked(
+            self.0
+                .concurrent_selected_signal_assignment_preamble()
+                .unwrap(),
+        )
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn guarded_token(&self) -> Option<SyntaxToken> {
+        self.0.guarded_token()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn selected_waveforms(&self) -> Option<CheckedSelectedWaveforms> {
+        self.0
+            .selected_waveforms()
+            .map(CheckedSelectedWaveforms::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentSelectedSignalAssignmentPreamble(
+    ConcurrentSelectedSignalAssignmentPreambleSyntax,
+);
+impl CheckedNode for CheckedConcurrentSelectedSignalAssignmentPreamble {
+    type Syntax = ConcurrentSelectedSignalAssignmentPreambleSyntax;
+    fn cast_unchecked(syntax: ConcurrentSelectedSignalAssignmentPreambleSyntax) -> Self {
+        CheckedConcurrentSelectedSignalAssignmentPreamble(syntax)
+    }
+    fn raw(&self) -> ConcurrentSelectedSignalAssignmentPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentSelectedSignalAssignmentPreamble {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn with_token(&self) -> SyntaxToken {
+        self.0.with_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn select_token(&self) -> SyntaxToken {
+        self.0.select_token().unwrap()
+    }
+    pub fn que_token(&self) -> Option<SyntaxToken> {
+        self.0.que_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedConcurrentStatement {
+    BlockStatement(CheckedBlockStatement),
+    ProcessStatement(CheckedProcessStatement),
+    ConcurrentAssertionStatement(CheckedConcurrentAssertionStatement),
+    ComponentInstantiationStatement(CheckedComponentInstantiationStatement),
+    ConcurrentSelectedSignalAssignment(CheckedConcurrentSelectedSignalAssignment),
+    ConcurrentConditionalSignalAssignment(CheckedConcurrentConditionalSignalAssignment),
+    ConcurrentSimpleSignalAssignment(CheckedConcurrentSimpleSignalAssignment),
+    ConcurrentProcedureCallOrComponentInstantiationStatement(
+        CheckedConcurrentProcedureCallOrComponentInstantiationStatement,
+    ),
+    ForGenerateStatement(CheckedForGenerateStatement),
+    IfGenerateStatement(CheckedIfGenerateStatement),
+    CaseGenerateStatement(CheckedCaseGenerateStatement),
+    PslDirective(CheckedPslDirective),
+}
+impl CheckedNode for CheckedConcurrentStatement {
+    type Syntax = ConcurrentStatementSyntax;
+    fn cast_unchecked(syntax: ConcurrentStatementSyntax) -> Self {
+        match syntax {
+            ConcurrentStatementSyntax::BlockStatement(inner) => {
+                CheckedConcurrentStatement::BlockStatement(CheckedBlockStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            ConcurrentStatementSyntax::ProcessStatement(inner) => {
+                CheckedConcurrentStatement::ProcessStatement(
+                    CheckedProcessStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ConcurrentAssertionStatement(inner) => {
+                CheckedConcurrentStatement::ConcurrentAssertionStatement(
+                    CheckedConcurrentAssertionStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ComponentInstantiationStatement(inner) => {
+                CheckedConcurrentStatement::ComponentInstantiationStatement(
+                    CheckedComponentInstantiationStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ConcurrentSelectedSignalAssignment(inner) => {
+                CheckedConcurrentStatement::ConcurrentSelectedSignalAssignment(
+                    CheckedConcurrentSelectedSignalAssignment::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ConcurrentConditionalSignalAssignment(inner) => {
+                CheckedConcurrentStatement::ConcurrentConditionalSignalAssignment(
+                    CheckedConcurrentConditionalSignalAssignment::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ConcurrentSimpleSignalAssignment(inner) => {
+                CheckedConcurrentStatement::ConcurrentSimpleSignalAssignment(
+                    CheckedConcurrentSimpleSignalAssignment::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::ConcurrentProcedureCallOrComponentInstantiationStatement(
+                inner,
+            ) => {
+                CheckedConcurrentStatement::ConcurrentProcedureCallOrComponentInstantiationStatement(
+                    CheckedConcurrentProcedureCallOrComponentInstantiationStatement::cast_unchecked(
+                        inner,
+                    ),
+                )
+            }
+            ConcurrentStatementSyntax::ForGenerateStatement(inner) => {
+                CheckedConcurrentStatement::ForGenerateStatement(
+                    CheckedForGenerateStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::IfGenerateStatement(inner) => {
+                CheckedConcurrentStatement::IfGenerateStatement(
+                    CheckedIfGenerateStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::CaseGenerateStatement(inner) => {
+                CheckedConcurrentStatement::CaseGenerateStatement(
+                    CheckedCaseGenerateStatement::cast_unchecked(inner),
+                )
+            }
+            ConcurrentStatementSyntax::PslDirective(inner) => {
+                CheckedConcurrentStatement::PslDirective(CheckedPslDirective::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self { CheckedConcurrentStatement :: BlockStatement (inner) => ConcurrentStatementSyntax :: BlockStatement (inner . raw ()) , CheckedConcurrentStatement :: ProcessStatement (inner) => ConcurrentStatementSyntax :: ProcessStatement (inner . raw ()) , CheckedConcurrentStatement :: ConcurrentAssertionStatement (inner) => ConcurrentStatementSyntax :: ConcurrentAssertionStatement (inner . raw ()) , CheckedConcurrentStatement :: ComponentInstantiationStatement (inner) => ConcurrentStatementSyntax :: ComponentInstantiationStatement (inner . raw ()) , CheckedConcurrentStatement :: ConcurrentSelectedSignalAssignment (inner) => ConcurrentStatementSyntax :: ConcurrentSelectedSignalAssignment (inner . raw ()) , CheckedConcurrentStatement :: ConcurrentConditionalSignalAssignment (inner) => ConcurrentStatementSyntax :: ConcurrentConditionalSignalAssignment (inner . raw ()) , CheckedConcurrentStatement :: ConcurrentSimpleSignalAssignment (inner) => ConcurrentStatementSyntax :: ConcurrentSimpleSignalAssignment (inner . raw ()) , CheckedConcurrentStatement :: ConcurrentProcedureCallOrComponentInstantiationStatement (inner) => ConcurrentStatementSyntax :: ConcurrentProcedureCallOrComponentInstantiationStatement (inner . raw ()) , CheckedConcurrentStatement :: ForGenerateStatement (inner) => ConcurrentStatementSyntax :: ForGenerateStatement (inner . raw ()) , CheckedConcurrentStatement :: IfGenerateStatement (inner) => ConcurrentStatementSyntax :: IfGenerateStatement (inner . raw ()) , CheckedConcurrentStatement :: CaseGenerateStatement (inner) => ConcurrentStatementSyntax :: CaseGenerateStatement (inner . raw ()) , CheckedConcurrentStatement :: PslDirective (inner) => ConcurrentStatementSyntax :: PslDirective (inner . raw ()) , }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConcurrentStatements(ConcurrentStatementsSyntax);
+impl CheckedNode for CheckedConcurrentStatements {
+    type Syntax = ConcurrentStatementsSyntax;
+    fn cast_unchecked(syntax: ConcurrentStatementsSyntax) -> Self {
+        CheckedConcurrentStatements(syntax)
+    }
+    fn raw(&self) -> ConcurrentStatementsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConcurrentStatements {
+    pub fn concurrent_statements(
+        &self,
+    ) -> impl Iterator<Item = CheckedConcurrentStatement> + use<'_> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatement::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedForGenerateStatement(ForGenerateStatementSyntax);
+impl CheckedNode for CheckedForGenerateStatement {
+    type Syntax = ForGenerateStatementSyntax;
+    fn cast_unchecked(syntax: ForGenerateStatementSyntax) -> Self {
+        CheckedForGenerateStatement(syntax)
+    }
+    fn raw(&self) -> ForGenerateStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedForGenerateStatement {
+    pub fn for_generate_statement_preamble(&self) -> CheckedForGenerateStatementPreamble {
+        CheckedForGenerateStatementPreamble::cast_unchecked(
+            self.0.for_generate_statement_preamble().unwrap(),
+        )
+    }
+    pub fn generate_statement_body(&self) -> Option<CheckedGenerateStatementBody> {
+        self.0
+            .generate_statement_body()
+            .map(CheckedGenerateStatementBody::cast_unchecked)
+    }
+    pub fn for_generate_statement_epilogue(&self) -> CheckedForGenerateStatementEpilogue {
+        CheckedForGenerateStatementEpilogue::cast_unchecked(
+            self.0.for_generate_statement_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedForGenerateStatementPreamble(ForGenerateStatementPreambleSyntax);
+impl CheckedNode for CheckedForGenerateStatementPreamble {
+    type Syntax = ForGenerateStatementPreambleSyntax;
+    fn cast_unchecked(syntax: ForGenerateStatementPreambleSyntax) -> Self {
+        CheckedForGenerateStatementPreamble(syntax)
+    }
+    fn raw(&self) -> ForGenerateStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedForGenerateStatementPreamble {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn parameter_specification(&self) -> CheckedParameterSpecification {
+        CheckedParameterSpecification::cast_unchecked(self.0.parameter_specification().unwrap())
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedForGenerateStatementEpilogue(ForGenerateStatementEpilogueSyntax);
+impl CheckedNode for CheckedForGenerateStatementEpilogue {
+    type Syntax = ForGenerateStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: ForGenerateStatementEpilogueSyntax) -> Self {
+        CheckedForGenerateStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> ForGenerateStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedForGenerateStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenerateStatementBody(GenerateStatementBodySyntax);
+impl CheckedNode for CheckedGenerateStatementBody {
+    type Syntax = GenerateStatementBodySyntax;
+    fn cast_unchecked(syntax: GenerateStatementBodySyntax) -> Self {
+        CheckedGenerateStatementBody(syntax)
+    }
+    fn raw(&self) -> GenerateStatementBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenerateStatementBody {
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> Option<CheckedDeclarationStatementSeparator> {
+        self.0
+            .declaration_statement_separator()
+            .map(CheckedDeclarationStatementSeparator::cast_unchecked)
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn generate_statement_body_epilogue(&self) -> Option<CheckedGenerateStatementBodyEpilogue> {
+        self.0
+            .generate_statement_body_epilogue()
+            .map(CheckedGenerateStatementBodyEpilogue::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenerateStatementBodyEpilogue(GenerateStatementBodyEpilogueSyntax);
+impl CheckedNode for CheckedGenerateStatementBodyEpilogue {
+    type Syntax = GenerateStatementBodyEpilogueSyntax;
+    fn cast_unchecked(syntax: GenerateStatementBodyEpilogueSyntax) -> Self {
+        CheckedGenerateStatementBodyEpilogue(syntax)
+    }
+    fn raw(&self) -> GenerateStatementBodyEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenerateStatementBodyEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfGenerateElsif(IfGenerateElsifSyntax);
+impl CheckedNode for CheckedIfGenerateElsif {
+    type Syntax = IfGenerateElsifSyntax;
+    fn cast_unchecked(syntax: IfGenerateElsifSyntax) -> Self {
+        CheckedIfGenerateElsif(syntax)
+    }
+    fn raw(&self) -> IfGenerateElsifSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfGenerateElsif {
+    pub fn elsif_token(&self) -> SyntaxToken {
+        self.0.elsif_token().unwrap()
+    }
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+    pub fn generate_statement_body(&self) -> Option<CheckedGenerateStatementBody> {
+        self.0
+            .generate_statement_body()
+            .map(CheckedGenerateStatementBody::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfGenerateElse(IfGenerateElseSyntax);
+impl CheckedNode for CheckedIfGenerateElse {
+    type Syntax = IfGenerateElseSyntax;
+    fn cast_unchecked(syntax: IfGenerateElseSyntax) -> Self {
+        CheckedIfGenerateElse(syntax)
+    }
+    fn raw(&self) -> IfGenerateElseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfGenerateElse {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+    pub fn generate_statement_body(&self) -> Option<CheckedGenerateStatementBody> {
+        self.0
+            .generate_statement_body()
+            .map(CheckedGenerateStatementBody::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfGenerateStatement(IfGenerateStatementSyntax);
+impl CheckedNode for CheckedIfGenerateStatement {
+    type Syntax = IfGenerateStatementSyntax;
+    fn cast_unchecked(syntax: IfGenerateStatementSyntax) -> Self {
+        CheckedIfGenerateStatement(syntax)
+    }
+    fn raw(&self) -> IfGenerateStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfGenerateStatement {
+    pub fn if_generate_statement_preamble(&self) -> CheckedIfGenerateStatementPreamble {
+        CheckedIfGenerateStatementPreamble::cast_unchecked(
+            self.0.if_generate_statement_preamble().unwrap(),
+        )
+    }
+    pub fn generate_statement_body(&self) -> Option<CheckedGenerateStatementBody> {
+        self.0
+            .generate_statement_body()
+            .map(CheckedGenerateStatementBody::cast_unchecked)
+    }
+    pub fn if_generate_elsifs(&self) -> impl Iterator<Item = CheckedIfGenerateElsif> + use<'_> {
+        self.0
+            .if_generate_elsifs()
+            .map(CheckedIfGenerateElsif::cast_unchecked)
+    }
+    pub fn if_generate_else(&self) -> Option<CheckedIfGenerateElse> {
+        self.0
+            .if_generate_else()
+            .map(CheckedIfGenerateElse::cast_unchecked)
+    }
+    pub fn if_generate_statement_epilogue(&self) -> CheckedIfGenerateStatementEpilogue {
+        CheckedIfGenerateStatementEpilogue::cast_unchecked(
+            self.0.if_generate_statement_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfGenerateStatementPreamble(IfGenerateStatementPreambleSyntax);
+impl CheckedNode for CheckedIfGenerateStatementPreamble {
+    type Syntax = IfGenerateStatementPreambleSyntax;
+    fn cast_unchecked(syntax: IfGenerateStatementPreambleSyntax) -> Self {
+        CheckedIfGenerateStatementPreamble(syntax)
+    }
+    fn raw(&self) -> IfGenerateStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfGenerateStatementPreamble {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn if_token(&self) -> SyntaxToken {
+        self.0.if_token().unwrap()
+    }
+    pub fn alternative_label(&self) -> Option<CheckedLabel> {
+        self.0.alternative_label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn condition(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.condition().unwrap())
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfGenerateStatementEpilogue(IfGenerateStatementEpilogueSyntax);
+impl CheckedNode for CheckedIfGenerateStatementEpilogue {
+    type Syntax = IfGenerateStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: IfGenerateStatementEpilogueSyntax) -> Self {
+        CheckedIfGenerateStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> IfGenerateStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfGenerateStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn generate_token(&self) -> SyntaxToken {
+        self.0.generate_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInstantiatedUnit {
+    ComponentInstantiatedUnit(CheckedComponentInstantiatedUnit),
+    EntityInstantiatedUnit(CheckedEntityInstantiatedUnit),
+    ConfigurationInstantiatedUnit(CheckedConfigurationInstantiatedUnit),
+}
+impl CheckedNode for CheckedInstantiatedUnit {
+    type Syntax = InstantiatedUnitSyntax;
+    fn cast_unchecked(syntax: InstantiatedUnitSyntax) -> Self {
+        match syntax {
+            InstantiatedUnitSyntax::ComponentInstantiatedUnit(inner) => {
+                CheckedInstantiatedUnit::ComponentInstantiatedUnit(
+                    CheckedComponentInstantiatedUnit::cast_unchecked(inner),
+                )
+            }
+            InstantiatedUnitSyntax::EntityInstantiatedUnit(inner) => {
+                CheckedInstantiatedUnit::EntityInstantiatedUnit(
+                    CheckedEntityInstantiatedUnit::cast_unchecked(inner),
+                )
+            }
+            InstantiatedUnitSyntax::ConfigurationInstantiatedUnit(inner) => {
+                CheckedInstantiatedUnit::ConfigurationInstantiatedUnit(
+                    CheckedConfigurationInstantiatedUnit::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInstantiatedUnit::ComponentInstantiatedUnit(inner) => {
+                InstantiatedUnitSyntax::ComponentInstantiatedUnit(inner.raw())
+            }
+            CheckedInstantiatedUnit::EntityInstantiatedUnit(inner) => {
+                InstantiatedUnitSyntax::EntityInstantiatedUnit(inner.raw())
+            }
+            CheckedInstantiatedUnit::ConfigurationInstantiatedUnit(inner) => {
+                InstantiatedUnitSyntax::ConfigurationInstantiatedUnit(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentInstantiatedUnit(ComponentInstantiatedUnitSyntax);
+impl CheckedNode for CheckedComponentInstantiatedUnit {
+    type Syntax = ComponentInstantiatedUnitSyntax;
+    fn cast_unchecked(syntax: ComponentInstantiatedUnitSyntax) -> Self {
+        CheckedComponentInstantiatedUnit(syntax)
+    }
+    fn raw(&self) -> ComponentInstantiatedUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentInstantiatedUnit {
+    pub fn component_token(&self) -> Option<SyntaxToken> {
+        self.0.component_token()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityInstantiatedUnit(EntityInstantiatedUnitSyntax);
+impl CheckedNode for CheckedEntityInstantiatedUnit {
+    type Syntax = EntityInstantiatedUnitSyntax;
+    fn cast_unchecked(syntax: EntityInstantiatedUnitSyntax) -> Self {
+        CheckedEntityInstantiatedUnit(syntax)
+    }
+    fn raw(&self) -> EntityInstantiatedUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityInstantiatedUnit {
+    pub fn entity_token(&self) -> SyntaxToken {
+        self.0.entity_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn left_par_token(&self) -> Option<SyntaxToken> {
+        self.0.left_par_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn right_par_token(&self) -> Option<SyntaxToken> {
+        self.0.right_par_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConfigurationInstantiatedUnit(ConfigurationInstantiatedUnitSyntax);
+impl CheckedNode for CheckedConfigurationInstantiatedUnit {
+    type Syntax = ConfigurationInstantiatedUnitSyntax;
+    fn cast_unchecked(syntax: ConfigurationInstantiatedUnitSyntax) -> Self {
+        CheckedConfigurationInstantiatedUnit(syntax)
+    }
+    fn raw(&self) -> ConfigurationInstantiatedUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConfigurationInstantiatedUnit {
+    pub fn configuration_token(&self) -> SyntaxToken {
+        self.0.configuration_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAllSensitivityList(AllSensitivityListSyntax);
+impl CheckedNode for CheckedAllSensitivityList {
+    type Syntax = AllSensitivityListSyntax;
+    fn cast_unchecked(syntax: AllSensitivityListSyntax) -> Self {
+        CheckedAllSensitivityList(syntax)
+    }
+    fn raw(&self) -> AllSensitivityListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAllSensitivityList {
+    pub fn all_token(&self) -> SyntaxToken {
+        self.0.all_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSensitivityList(SensitivityListSyntax);
+impl CheckedNode for CheckedSensitivityList {
+    type Syntax = SensitivityListSyntax;
+    fn cast_unchecked(syntax: SensitivityListSyntax) -> Self {
+        CheckedSensitivityList(syntax)
+    }
+    fn raw(&self) -> SensitivityListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSensitivityList {
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedProcessSensitivityList {
+    AllSensitivityList(CheckedAllSensitivityList),
+    SensitivityList(CheckedSensitivityList),
+}
+impl CheckedNode for CheckedProcessSensitivityList {
+    type Syntax = ProcessSensitivityListSyntax;
+    fn cast_unchecked(syntax: ProcessSensitivityListSyntax) -> Self {
+        match syntax {
+            ProcessSensitivityListSyntax::AllSensitivityList(inner) => {
+                CheckedProcessSensitivityList::AllSensitivityList(
+                    CheckedAllSensitivityList::cast_unchecked(inner),
+                )
+            }
+            ProcessSensitivityListSyntax::SensitivityList(inner) => {
+                CheckedProcessSensitivityList::SensitivityList(
+                    CheckedSensitivityList::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedProcessSensitivityList::AllSensitivityList(inner) => {
+                ProcessSensitivityListSyntax::AllSensitivityList(inner.raw())
+            }
+            CheckedProcessSensitivityList::SensitivityList(inner) => {
+                ProcessSensitivityListSyntax::SensitivityList(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProcessStatement(ProcessStatementSyntax);
+impl CheckedNode for CheckedProcessStatement {
+    type Syntax = ProcessStatementSyntax;
+    fn cast_unchecked(syntax: ProcessStatementSyntax) -> Self {
+        CheckedProcessStatement(syntax)
+    }
+    fn raw(&self) -> ProcessStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProcessStatement {
+    pub fn process_statement_preamble(&self) -> CheckedProcessStatementPreamble {
+        CheckedProcessStatementPreamble::cast_unchecked(
+            self.0.process_statement_preamble().unwrap(),
+        )
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> CheckedDeclarationStatementSeparator {
+        CheckedDeclarationStatementSeparator::cast_unchecked(
+            self.0.declaration_statement_separator().unwrap(),
+        )
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn process_statement_epilogue(&self) -> CheckedProcessStatementEpilogue {
+        CheckedProcessStatementEpilogue::cast_unchecked(
+            self.0.process_statement_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedProcessSensitivityList(ParenthesizedProcessSensitivityListSyntax);
+impl CheckedNode for CheckedParenthesizedProcessSensitivityList {
+    type Syntax = ParenthesizedProcessSensitivityListSyntax;
+    fn cast_unchecked(syntax: ParenthesizedProcessSensitivityListSyntax) -> Self {
+        CheckedParenthesizedProcessSensitivityList(syntax)
+    }
+    fn raw(&self) -> ParenthesizedProcessSensitivityListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedProcessSensitivityList {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn process_sensitivity_list(&self) -> CheckedProcessSensitivityList {
+        CheckedProcessSensitivityList::cast_unchecked(self.0.process_sensitivity_list().unwrap())
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProcessStatementPreamble(ProcessStatementPreambleSyntax);
+impl CheckedNode for CheckedProcessStatementPreamble {
+    type Syntax = ProcessStatementPreambleSyntax;
+    fn cast_unchecked(syntax: ProcessStatementPreambleSyntax) -> Self {
+        CheckedProcessStatementPreamble(syntax)
+    }
+    fn raw(&self) -> ProcessStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProcessStatementPreamble {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn process_token(&self) -> SyntaxToken {
+        self.0.process_token().unwrap()
+    }
+    pub fn parenthesized_process_sensitivity_list(
+        &self,
+    ) -> Option<CheckedParenthesizedProcessSensitivityList> {
+        self.0
+            .parenthesized_process_sensitivity_list()
+            .map(CheckedParenthesizedProcessSensitivityList::cast_unchecked)
+    }
+    pub fn is_token(&self) -> Option<SyntaxToken> {
+        self.0.is_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProcessStatementEpilogue(ProcessStatementEpilogueSyntax);
+impl CheckedNode for CheckedProcessStatementEpilogue {
+    type Syntax = ProcessStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: ProcessStatementEpilogueSyntax) -> Self {
+        CheckedProcessStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> ProcessStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProcessStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn postponed_token(&self) -> Option<SyntaxToken> {
+        self.0.postponed_token()
+    }
+    pub fn process_token(&self) -> SyntaxToken {
+        self.0.process_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/declarations.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/declarations.rs
@@ -1,0 +1,2148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub enum CheckedDeclaration {
+    SubprogramDeclaration(CheckedSubprogramDeclaration),
+    SubprogramBody(CheckedSubprogramBody),
+    SubprogramInstantiationDeclaration(CheckedSubprogramInstantiationDeclaration),
+    PackageDeclaration(CheckedPackageDeclaration),
+    PackageBodyDeclaration(CheckedPackageBodyDeclaration),
+    PackageInstantiationDeclaration(CheckedPackageInstantiationDeclaration),
+    TypeDeclaration(CheckedTypeDeclaration),
+    SubtypeDeclaration(CheckedSubtypeDeclaration),
+    FileDeclaration(CheckedFileDeclaration),
+    AliasDeclaration(CheckedAliasDeclaration),
+    ComponentDeclaration(CheckedComponentDeclaration),
+    AttributeDeclaration(CheckedAttributeDeclaration),
+    AttributeSpecification(CheckedAttributeSpecification),
+    ConfigurationSpecification(CheckedConfigurationSpecification),
+    DisconnectionSpecification(CheckedDisconnectionSpecification),
+    UseClauseDeclaration(CheckedUseClauseDeclaration),
+    GroupTemplateDeclaration(CheckedGroupTemplateDeclaration),
+    GroupDeclaration(CheckedGroupDeclaration),
+    ConstantDeclaration(CheckedConstantDeclaration),
+    SignalDeclaration(CheckedSignalDeclaration),
+    VariableDeclaration(CheckedVariableDeclaration),
+    SharedVariableDeclaration(CheckedSharedVariableDeclaration),
+    PslPropertyDeclaration(CheckedPslPropertyDeclaration),
+    PslSequenceDeclaration(CheckedPslSequenceDeclaration),
+    PslClockDeclaration(CheckedPslClockDeclaration),
+}
+impl CheckedNode for CheckedDeclaration {
+    type Syntax = DeclarationSyntax;
+    fn cast_unchecked(syntax: DeclarationSyntax) -> Self {
+        match syntax {
+            DeclarationSyntax::SubprogramDeclaration(inner) => {
+                CheckedDeclaration::SubprogramDeclaration(
+                    CheckedSubprogramDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::SubprogramBody(inner) => {
+                CheckedDeclaration::SubprogramBody(CheckedSubprogramBody::cast_unchecked(inner))
+            }
+            DeclarationSyntax::SubprogramInstantiationDeclaration(inner) => {
+                CheckedDeclaration::SubprogramInstantiationDeclaration(
+                    CheckedSubprogramInstantiationDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::PackageDeclaration(inner) => CheckedDeclaration::PackageDeclaration(
+                CheckedPackageDeclaration::cast_unchecked(inner),
+            ),
+            DeclarationSyntax::PackageBodyDeclaration(inner) => {
+                CheckedDeclaration::PackageBodyDeclaration(
+                    CheckedPackageBodyDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::PackageInstantiationDeclaration(inner) => {
+                CheckedDeclaration::PackageInstantiationDeclaration(
+                    CheckedPackageInstantiationDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::TypeDeclaration(inner) => {
+                CheckedDeclaration::TypeDeclaration(CheckedTypeDeclaration::cast_unchecked(inner))
+            }
+            DeclarationSyntax::SubtypeDeclaration(inner) => CheckedDeclaration::SubtypeDeclaration(
+                CheckedSubtypeDeclaration::cast_unchecked(inner),
+            ),
+            DeclarationSyntax::FileDeclaration(inner) => {
+                CheckedDeclaration::FileDeclaration(CheckedFileDeclaration::cast_unchecked(inner))
+            }
+            DeclarationSyntax::AliasDeclaration(inner) => {
+                CheckedDeclaration::AliasDeclaration(CheckedAliasDeclaration::cast_unchecked(inner))
+            }
+            DeclarationSyntax::ComponentDeclaration(inner) => {
+                CheckedDeclaration::ComponentDeclaration(
+                    CheckedComponentDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::AttributeDeclaration(inner) => {
+                CheckedDeclaration::AttributeDeclaration(
+                    CheckedAttributeDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::AttributeSpecification(inner) => {
+                CheckedDeclaration::AttributeSpecification(
+                    CheckedAttributeSpecification::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::ConfigurationSpecification(inner) => {
+                CheckedDeclaration::ConfigurationSpecification(
+                    CheckedConfigurationSpecification::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::DisconnectionSpecification(inner) => {
+                CheckedDeclaration::DisconnectionSpecification(
+                    CheckedDisconnectionSpecification::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::UseClauseDeclaration(inner) => {
+                CheckedDeclaration::UseClauseDeclaration(
+                    CheckedUseClauseDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::GroupTemplateDeclaration(inner) => {
+                CheckedDeclaration::GroupTemplateDeclaration(
+                    CheckedGroupTemplateDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::GroupDeclaration(inner) => {
+                CheckedDeclaration::GroupDeclaration(CheckedGroupDeclaration::cast_unchecked(inner))
+            }
+            DeclarationSyntax::ConstantDeclaration(inner) => {
+                CheckedDeclaration::ConstantDeclaration(CheckedConstantDeclaration::cast_unchecked(
+                    inner,
+                ))
+            }
+            DeclarationSyntax::SignalDeclaration(inner) => CheckedDeclaration::SignalDeclaration(
+                CheckedSignalDeclaration::cast_unchecked(inner),
+            ),
+            DeclarationSyntax::VariableDeclaration(inner) => {
+                CheckedDeclaration::VariableDeclaration(CheckedVariableDeclaration::cast_unchecked(
+                    inner,
+                ))
+            }
+            DeclarationSyntax::SharedVariableDeclaration(inner) => {
+                CheckedDeclaration::SharedVariableDeclaration(
+                    CheckedSharedVariableDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::PslPropertyDeclaration(inner) => {
+                CheckedDeclaration::PslPropertyDeclaration(
+                    CheckedPslPropertyDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::PslSequenceDeclaration(inner) => {
+                CheckedDeclaration::PslSequenceDeclaration(
+                    CheckedPslSequenceDeclaration::cast_unchecked(inner),
+                )
+            }
+            DeclarationSyntax::PslClockDeclaration(inner) => {
+                CheckedDeclaration::PslClockDeclaration(CheckedPslClockDeclaration::cast_unchecked(
+                    inner,
+                ))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedDeclaration::SubprogramDeclaration(inner) => {
+                DeclarationSyntax::SubprogramDeclaration(inner.raw())
+            }
+            CheckedDeclaration::SubprogramBody(inner) => {
+                DeclarationSyntax::SubprogramBody(inner.raw())
+            }
+            CheckedDeclaration::SubprogramInstantiationDeclaration(inner) => {
+                DeclarationSyntax::SubprogramInstantiationDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PackageDeclaration(inner) => {
+                DeclarationSyntax::PackageDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PackageBodyDeclaration(inner) => {
+                DeclarationSyntax::PackageBodyDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PackageInstantiationDeclaration(inner) => {
+                DeclarationSyntax::PackageInstantiationDeclaration(inner.raw())
+            }
+            CheckedDeclaration::TypeDeclaration(inner) => {
+                DeclarationSyntax::TypeDeclaration(inner.raw())
+            }
+            CheckedDeclaration::SubtypeDeclaration(inner) => {
+                DeclarationSyntax::SubtypeDeclaration(inner.raw())
+            }
+            CheckedDeclaration::FileDeclaration(inner) => {
+                DeclarationSyntax::FileDeclaration(inner.raw())
+            }
+            CheckedDeclaration::AliasDeclaration(inner) => {
+                DeclarationSyntax::AliasDeclaration(inner.raw())
+            }
+            CheckedDeclaration::ComponentDeclaration(inner) => {
+                DeclarationSyntax::ComponentDeclaration(inner.raw())
+            }
+            CheckedDeclaration::AttributeDeclaration(inner) => {
+                DeclarationSyntax::AttributeDeclaration(inner.raw())
+            }
+            CheckedDeclaration::AttributeSpecification(inner) => {
+                DeclarationSyntax::AttributeSpecification(inner.raw())
+            }
+            CheckedDeclaration::ConfigurationSpecification(inner) => {
+                DeclarationSyntax::ConfigurationSpecification(inner.raw())
+            }
+            CheckedDeclaration::DisconnectionSpecification(inner) => {
+                DeclarationSyntax::DisconnectionSpecification(inner.raw())
+            }
+            CheckedDeclaration::UseClauseDeclaration(inner) => {
+                DeclarationSyntax::UseClauseDeclaration(inner.raw())
+            }
+            CheckedDeclaration::GroupTemplateDeclaration(inner) => {
+                DeclarationSyntax::GroupTemplateDeclaration(inner.raw())
+            }
+            CheckedDeclaration::GroupDeclaration(inner) => {
+                DeclarationSyntax::GroupDeclaration(inner.raw())
+            }
+            CheckedDeclaration::ConstantDeclaration(inner) => {
+                DeclarationSyntax::ConstantDeclaration(inner.raw())
+            }
+            CheckedDeclaration::SignalDeclaration(inner) => {
+                DeclarationSyntax::SignalDeclaration(inner.raw())
+            }
+            CheckedDeclaration::VariableDeclaration(inner) => {
+                DeclarationSyntax::VariableDeclaration(inner.raw())
+            }
+            CheckedDeclaration::SharedVariableDeclaration(inner) => {
+                DeclarationSyntax::SharedVariableDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PslPropertyDeclaration(inner) => {
+                DeclarationSyntax::PslPropertyDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PslSequenceDeclaration(inner) => {
+                DeclarationSyntax::PslSequenceDeclaration(inner.raw())
+            }
+            CheckedDeclaration::PslClockDeclaration(inner) => {
+                DeclarationSyntax::PslClockDeclaration(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageDeclaration(PackageDeclarationSyntax);
+impl CheckedNode for CheckedPackageDeclaration {
+    type Syntax = PackageDeclarationSyntax;
+    fn cast_unchecked(syntax: PackageDeclarationSyntax) -> Self {
+        CheckedPackageDeclaration(syntax)
+    }
+    fn raw(&self) -> PackageDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageDeclaration {
+    pub fn package(&self) -> CheckedPackage {
+        CheckedPackage::cast_unchecked(self.0.package().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageInstantiationDeclaration(PackageInstantiationDeclarationSyntax);
+impl CheckedNode for CheckedPackageInstantiationDeclaration {
+    type Syntax = PackageInstantiationDeclarationSyntax;
+    fn cast_unchecked(syntax: PackageInstantiationDeclarationSyntax) -> Self {
+        CheckedPackageInstantiationDeclaration(syntax)
+    }
+    fn raw(&self) -> PackageInstantiationDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageInstantiationDeclaration {
+    pub fn package_instantiation(&self) -> CheckedPackageInstantiation {
+        CheckedPackageInstantiation::cast_unchecked(self.0.package_instantiation().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageBodyDeclaration(PackageBodyDeclarationSyntax);
+impl CheckedNode for CheckedPackageBodyDeclaration {
+    type Syntax = PackageBodyDeclarationSyntax;
+    fn cast_unchecked(syntax: PackageBodyDeclarationSyntax) -> Self {
+        CheckedPackageBodyDeclaration(syntax)
+    }
+    fn raw(&self) -> PackageBodyDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageBodyDeclaration {
+    pub fn package_body(&self) -> CheckedPackageBody {
+        CheckedPackageBody::cast_unchecked(self.0.package_body().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUseClauseDeclaration(UseClauseDeclarationSyntax);
+impl CheckedNode for CheckedUseClauseDeclaration {
+    type Syntax = UseClauseDeclarationSyntax;
+    fn cast_unchecked(syntax: UseClauseDeclarationSyntax) -> Self {
+        CheckedUseClauseDeclaration(syntax)
+    }
+    fn raw(&self) -> UseClauseDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUseClauseDeclaration {
+    pub fn use_clause(&self) -> CheckedUseClause {
+        CheckedUseClause::cast_unchecked(self.0.use_clause().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedActualPart(ActualPartSyntax);
+impl CheckedNode for CheckedActualPart {
+    type Syntax = ActualPartSyntax;
+    fn cast_unchecked(syntax: ActualPartSyntax) -> Self {
+        CheckedActualPart(syntax)
+    }
+    fn raw(&self) -> ActualPartSyntax {
+        self.0.clone()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAliasDeclaration(AliasDeclarationSyntax);
+impl CheckedNode for CheckedAliasDeclaration {
+    type Syntax = AliasDeclarationSyntax;
+    fn cast_unchecked(syntax: AliasDeclarationSyntax) -> Self {
+        CheckedAliasDeclaration(syntax)
+    }
+    fn raw(&self) -> AliasDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAliasDeclaration {
+    pub fn alias_token(&self) -> SyntaxToken {
+        self.0.alias_token().unwrap()
+    }
+    pub fn alias_designator(&self) -> AliasDesignatorSyntax {
+        self.0.alias_designator().unwrap()
+    }
+    pub fn colon_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_token()
+    }
+    pub fn subtype_indication(&self) -> Option<CheckedSubtypeIndication> {
+        self.0
+            .subtype_indication()
+            .map(CheckedSubtypeIndication::cast_unchecked)
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn signature(&self) -> Option<CheckedSignature> {
+        self.0.signature().map(CheckedSignature::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAssociationElement(AssociationElementSyntax);
+impl CheckedNode for CheckedAssociationElement {
+    type Syntax = AssociationElementSyntax;
+    fn cast_unchecked(syntax: AssociationElementSyntax) -> Self {
+        CheckedAssociationElement(syntax)
+    }
+    fn raw(&self) -> AssociationElementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAssociationElement {
+    pub fn formal_part(&self) -> Option<CheckedFormalPart> {
+        self.0.formal_part().map(CheckedFormalPart::cast_unchecked)
+    }
+    pub fn right_arrow_token(&self) -> Option<SyntaxToken> {
+        self.0.right_arrow_token()
+    }
+    pub fn actual_part(&self) -> CheckedActualPart {
+        CheckedActualPart::cast_unchecked(self.0.actual_part().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAssociationList(AssociationListSyntax);
+impl CheckedNode for CheckedAssociationList {
+    type Syntax = AssociationListSyntax;
+    fn cast_unchecked(syntax: AssociationListSyntax) -> Self {
+        CheckedAssociationList(syntax)
+    }
+    fn raw(&self) -> AssociationListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAssociationList {
+    pub fn association_elements(
+        &self,
+    ) -> impl Iterator<Item = CheckedAssociationElement> + use<'_> {
+        self.0
+            .association_elements()
+            .map(CheckedAssociationElement::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAttributeDeclaration(AttributeDeclarationSyntax);
+impl CheckedNode for CheckedAttributeDeclaration {
+    type Syntax = AttributeDeclarationSyntax;
+    fn cast_unchecked(syntax: AttributeDeclarationSyntax) -> Self {
+        CheckedAttributeDeclaration(syntax)
+    }
+    fn raw(&self) -> AttributeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAttributeDeclaration {
+    pub fn attribute_token(&self) -> SyntaxToken {
+        self.0.attribute_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentDeclaration(ComponentDeclarationSyntax);
+impl CheckedNode for CheckedComponentDeclaration {
+    type Syntax = ComponentDeclarationSyntax;
+    fn cast_unchecked(syntax: ComponentDeclarationSyntax) -> Self {
+        CheckedComponentDeclaration(syntax)
+    }
+    fn raw(&self) -> ComponentDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentDeclaration {
+    pub fn component_declaration_preamble(&self) -> CheckedComponentDeclarationPreamble {
+        CheckedComponentDeclarationPreamble::cast_unchecked(
+            self.0.component_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn component_declaration_items(&self) -> Option<CheckedComponentDeclarationItems> {
+        self.0
+            .component_declaration_items()
+            .map(CheckedComponentDeclarationItems::cast_unchecked)
+    }
+    pub fn component_declaration_epilogue(&self) -> CheckedComponentDeclarationEpilogue {
+        CheckedComponentDeclarationEpilogue::cast_unchecked(
+            self.0.component_declaration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentDeclarationItems(ComponentDeclarationItemsSyntax);
+impl CheckedNode for CheckedComponentDeclarationItems {
+    type Syntax = ComponentDeclarationItemsSyntax;
+    fn cast_unchecked(syntax: ComponentDeclarationItemsSyntax) -> Self {
+        CheckedComponentDeclarationItems(syntax)
+    }
+    fn raw(&self) -> ComponentDeclarationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentDeclarationItems {
+    pub fn generic_clause(&self) -> Option<CheckedGenericClause> {
+        self.0
+            .generic_clause()
+            .map(CheckedGenericClause::cast_unchecked)
+    }
+    pub fn port_clause(&self) -> Option<CheckedPortClause> {
+        self.0.port_clause().map(CheckedPortClause::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentDeclarationPreamble(ComponentDeclarationPreambleSyntax);
+impl CheckedNode for CheckedComponentDeclarationPreamble {
+    type Syntax = ComponentDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: ComponentDeclarationPreambleSyntax) -> Self {
+        CheckedComponentDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> ComponentDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentDeclarationPreamble {
+    pub fn component_token(&self) -> SyntaxToken {
+        self.0.component_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> Option<SyntaxToken> {
+        self.0.is_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentDeclarationEpilogue(ComponentDeclarationEpilogueSyntax);
+impl CheckedNode for CheckedComponentDeclarationEpilogue {
+    type Syntax = ComponentDeclarationEpilogueSyntax;
+    fn cast_unchecked(syntax: ComponentDeclarationEpilogueSyntax) -> Self {
+        CheckedComponentDeclarationEpilogue(syntax)
+    }
+    fn raw(&self) -> ComponentDeclarationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentDeclarationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn component_token(&self) -> SyntaxToken {
+        self.0.component_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConstantDeclaration(ConstantDeclarationSyntax);
+impl CheckedNode for CheckedConstantDeclaration {
+    type Syntax = ConstantDeclarationSyntax;
+    fn cast_unchecked(syntax: ConstantDeclarationSyntax) -> Self {
+        CheckedConstantDeclaration(syntax)
+    }
+    fn raw(&self) -> ConstantDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConstantDeclaration {
+    pub fn constant_token(&self) -> SyntaxToken {
+        self.0.constant_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRangeConstraintConstraint(RangeConstraintConstraintSyntax);
+impl CheckedNode for CheckedRangeConstraintConstraint {
+    type Syntax = RangeConstraintConstraintSyntax;
+    fn cast_unchecked(syntax: RangeConstraintConstraintSyntax) -> Self {
+        CheckedRangeConstraintConstraint(syntax)
+    }
+    fn raw(&self) -> RangeConstraintConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRangeConstraintConstraint {
+    pub fn range_constraint(&self) -> CheckedRangeConstraint {
+        CheckedRangeConstraint::cast_unchecked(self.0.range_constraint().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedConstraint {
+    RangeConstraintConstraint(CheckedRangeConstraintConstraint),
+    ArrayConstraint(CheckedArrayConstraint),
+    RecordConstraint(CheckedRecordConstraint),
+}
+impl CheckedNode for CheckedConstraint {
+    type Syntax = ConstraintSyntax;
+    fn cast_unchecked(syntax: ConstraintSyntax) -> Self {
+        match syntax {
+            ConstraintSyntax::RangeConstraintConstraint(inner) => {
+                CheckedConstraint::RangeConstraintConstraint(
+                    CheckedRangeConstraintConstraint::cast_unchecked(inner),
+                )
+            }
+            ConstraintSyntax::ArrayConstraint(inner) => {
+                CheckedConstraint::ArrayConstraint(CheckedArrayConstraint::cast_unchecked(inner))
+            }
+            ConstraintSyntax::RecordConstraint(inner) => {
+                CheckedConstraint::RecordConstraint(CheckedRecordConstraint::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedConstraint::RangeConstraintConstraint(inner) => {
+                ConstraintSyntax::RangeConstraintConstraint(inner.raw())
+            }
+            CheckedConstraint::ArrayConstraint(inner) => {
+                ConstraintSyntax::ArrayConstraint(inner.raw())
+            }
+            CheckedConstraint::RecordConstraint(inner) => {
+                ConstraintSyntax::RecordConstraint(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedResolutionIndicationElementResolution(
+    ResolutionIndicationElementResolutionSyntax,
+);
+impl CheckedNode for CheckedResolutionIndicationElementResolution {
+    type Syntax = ResolutionIndicationElementResolutionSyntax;
+    fn cast_unchecked(syntax: ResolutionIndicationElementResolutionSyntax) -> Self {
+        CheckedResolutionIndicationElementResolution(syntax)
+    }
+    fn raw(&self) -> ResolutionIndicationElementResolutionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedResolutionIndicationElementResolution {
+    pub fn resolution_indication(&self) -> CheckedResolutionIndication {
+        CheckedResolutionIndication::cast_unchecked(self.0.resolution_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordResolutionElementResolution(RecordResolutionElementResolutionSyntax);
+impl CheckedNode for CheckedRecordResolutionElementResolution {
+    type Syntax = RecordResolutionElementResolutionSyntax;
+    fn cast_unchecked(syntax: RecordResolutionElementResolutionSyntax) -> Self {
+        CheckedRecordResolutionElementResolution(syntax)
+    }
+    fn raw(&self) -> RecordResolutionElementResolutionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordResolutionElementResolution {
+    pub fn record_resolution(&self) -> Option<CheckedRecordResolution> {
+        self.0
+            .record_resolution()
+            .map(CheckedRecordResolution::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedElementResolution {
+    ResolutionIndicationElementResolution(CheckedResolutionIndicationElementResolution),
+    RecordResolutionElementResolution(CheckedRecordResolutionElementResolution),
+}
+impl CheckedNode for CheckedElementResolution {
+    type Syntax = ElementResolutionSyntax;
+    fn cast_unchecked(syntax: ElementResolutionSyntax) -> Self {
+        match syntax {
+            ElementResolutionSyntax::ResolutionIndicationElementResolution(inner) => {
+                CheckedElementResolution::ResolutionIndicationElementResolution(
+                    CheckedResolutionIndicationElementResolution::cast_unchecked(inner),
+                )
+            }
+            ElementResolutionSyntax::RecordResolutionElementResolution(inner) => {
+                CheckedElementResolution::RecordResolutionElementResolution(
+                    CheckedRecordResolutionElementResolution::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedElementResolution::ResolutionIndicationElementResolution(inner) => {
+                ElementResolutionSyntax::ResolutionIndicationElementResolution(inner.raw())
+            }
+            CheckedElementResolution::RecordResolutionElementResolution(inner) => {
+                ElementResolutionSyntax::RecordResolutionElementResolution(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityClassEntry(EntityClassEntrySyntax);
+impl CheckedNode for CheckedEntityClassEntry {
+    type Syntax = EntityClassEntrySyntax;
+    fn cast_unchecked(syntax: EntityClassEntrySyntax) -> Self {
+        CheckedEntityClassEntry(syntax)
+    }
+    fn raw(&self) -> EntityClassEntrySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityClassEntry {
+    pub fn entity_class(&self) -> EntityClassSyntax {
+        self.0.entity_class().unwrap()
+    }
+    pub fn box_token(&self) -> Option<SyntaxToken> {
+        self.0.box_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityClassEntryList(EntityClassEntryListSyntax);
+impl CheckedNode for CheckedEntityClassEntryList {
+    type Syntax = EntityClassEntryListSyntax;
+    fn cast_unchecked(syntax: EntityClassEntryListSyntax) -> Self {
+        CheckedEntityClassEntryList(syntax)
+    }
+    fn raw(&self) -> EntityClassEntryListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityClassEntryList {
+    pub fn entity_class_entrys(&self) -> impl Iterator<Item = CheckedEntityClassEntry> + use<'_> {
+        self.0
+            .entity_class_entrys()
+            .map(CheckedEntityClassEntry::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFileDeclaration(FileDeclarationSyntax);
+impl CheckedNode for CheckedFileDeclaration {
+    type Syntax = FileDeclarationSyntax;
+    fn cast_unchecked(syntax: FileDeclarationSyntax) -> Self {
+        CheckedFileDeclaration(syntax)
+    }
+    fn raw(&self) -> FileDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFileDeclaration {
+    pub fn file_token(&self) -> SyntaxToken {
+        self.0.file_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn file_open_information(&self) -> CheckedFileOpenInformation {
+        CheckedFileOpenInformation::cast_unchecked(self.0.file_open_information().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFileOpenInformation(FileOpenInformationSyntax);
+impl CheckedNode for CheckedFileOpenInformation {
+    type Syntax = FileOpenInformationSyntax;
+    fn cast_unchecked(syntax: FileOpenInformationSyntax) -> Self {
+        CheckedFileOpenInformation(syntax)
+    }
+    fn raw(&self) -> FileOpenInformationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFileOpenInformation {
+    pub fn open_token(&self) -> SyntaxToken {
+        self.0.open_token().unwrap()
+    }
+    pub fn file_open_kind(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.file_open_kind().unwrap())
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn file_logical_name(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.file_logical_name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedName(ParenthesizedNameSyntax);
+impl CheckedNode for CheckedParenthesizedName {
+    type Syntax = ParenthesizedNameSyntax;
+    fn cast_unchecked(syntax: ParenthesizedNameSyntax) -> Self {
+        CheckedParenthesizedName(syntax)
+    }
+    fn raw(&self) -> ParenthesizedNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedName {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFormalPart(FormalPartSyntax);
+impl CheckedNode for CheckedFormalPart {
+    type Syntax = FormalPartSyntax;
+    fn cast_unchecked(syntax: FormalPartSyntax) -> Self {
+        CheckedFormalPart(syntax)
+    }
+    fn raw(&self) -> FormalPartSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFormalPart {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn parenthesized_name(&self) -> CheckedParenthesizedName {
+        CheckedParenthesizedName::cast_unchecked(self.0.parenthesized_name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFullTypeDeclaration(FullTypeDeclarationSyntax);
+impl CheckedNode for CheckedFullTypeDeclaration {
+    type Syntax = FullTypeDeclarationSyntax;
+    fn cast_unchecked(syntax: FullTypeDeclarationSyntax) -> Self {
+        CheckedFullTypeDeclaration(syntax)
+    }
+    fn raw(&self) -> FullTypeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFullTypeDeclaration {
+    pub fn type_token(&self) -> SyntaxToken {
+        self.0.type_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn type_definition(&self) -> CheckedTypeDefinition {
+        CheckedTypeDefinition::cast_unchecked(self.0.type_definition().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenericClause(GenericClauseSyntax);
+impl CheckedNode for CheckedGenericClause {
+    type Syntax = GenericClauseSyntax;
+    fn cast_unchecked(syntax: GenericClauseSyntax) -> Self {
+        CheckedGenericClause(syntax)
+    }
+    fn raw(&self) -> GenericClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenericClause {
+    pub fn generic_clause_preamble(&self) -> CheckedGenericClausePreamble {
+        CheckedGenericClausePreamble::cast_unchecked(self.0.generic_clause_preamble().unwrap())
+    }
+    pub fn interface_list(&self) -> Option<CheckedInterfaceList> {
+        self.0
+            .interface_list()
+            .map(CheckedInterfaceList::cast_unchecked)
+    }
+    pub fn generic_clause_epilogue(&self) -> CheckedGenericClauseEpilogue {
+        CheckedGenericClauseEpilogue::cast_unchecked(self.0.generic_clause_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenericClausePreamble(GenericClausePreambleSyntax);
+impl CheckedNode for CheckedGenericClausePreamble {
+    type Syntax = GenericClausePreambleSyntax;
+    fn cast_unchecked(syntax: GenericClausePreambleSyntax) -> Self {
+        CheckedGenericClausePreamble(syntax)
+    }
+    fn raw(&self) -> GenericClausePreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenericClausePreamble {
+    pub fn generic_token(&self) -> SyntaxToken {
+        self.0.generic_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenericClauseEpilogue(GenericClauseEpilogueSyntax);
+impl CheckedNode for CheckedGenericClauseEpilogue {
+    type Syntax = GenericClauseEpilogueSyntax;
+    fn cast_unchecked(syntax: GenericClauseEpilogueSyntax) -> Self {
+        CheckedGenericClauseEpilogue(syntax)
+    }
+    fn raw(&self) -> GenericClauseEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenericClauseEpilogue {
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGenericMapAspect(GenericMapAspectSyntax);
+impl CheckedNode for CheckedGenericMapAspect {
+    type Syntax = GenericMapAspectSyntax;
+    fn cast_unchecked(syntax: GenericMapAspectSyntax) -> Self {
+        CheckedGenericMapAspect(syntax)
+    }
+    fn raw(&self) -> GenericMapAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGenericMapAspect {
+    pub fn generic_token(&self) -> SyntaxToken {
+        self.0.generic_token().unwrap()
+    }
+    pub fn map_token(&self) -> SyntaxToken {
+        self.0.map_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn association_list(&self) -> Option<CheckedAssociationList> {
+        self.0
+            .association_list()
+            .map(CheckedAssociationList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGroupConstituentList(GroupConstituentListSyntax);
+impl CheckedNode for CheckedGroupConstituentList {
+    type Syntax = GroupConstituentListSyntax;
+    fn cast_unchecked(syntax: GroupConstituentListSyntax) -> Self {
+        CheckedGroupConstituentList(syntax)
+    }
+    fn raw(&self) -> GroupConstituentListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGroupConstituentList {
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGroupDeclaration(GroupDeclarationSyntax);
+impl CheckedNode for CheckedGroupDeclaration {
+    type Syntax = GroupDeclarationSyntax;
+    fn cast_unchecked(syntax: GroupDeclarationSyntax) -> Self {
+        CheckedGroupDeclaration(syntax)
+    }
+    fn raw(&self) -> GroupDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGroupDeclaration {
+    pub fn group_token(&self) -> SyntaxToken {
+        self.0.group_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn group_constituent_list(&self) -> Option<CheckedGroupConstituentList> {
+        self.0
+            .group_constituent_list()
+            .map(CheckedGroupConstituentList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGroupTemplateDeclaration(GroupTemplateDeclarationSyntax);
+impl CheckedNode for CheckedGroupTemplateDeclaration {
+    type Syntax = GroupTemplateDeclarationSyntax;
+    fn cast_unchecked(syntax: GroupTemplateDeclarationSyntax) -> Self {
+        CheckedGroupTemplateDeclaration(syntax)
+    }
+    fn raw(&self) -> GroupTemplateDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGroupTemplateDeclaration {
+    pub fn group_token(&self) -> SyntaxToken {
+        self.0.group_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn entity_class_entry_list(&self) -> Option<CheckedEntityClassEntryList> {
+        self.0
+            .entity_class_entry_list()
+            .map(CheckedEntityClassEntryList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceConstantDeclaration(InterfaceConstantDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceConstantDeclaration {
+    type Syntax = InterfaceConstantDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceConstantDeclarationSyntax) -> Self {
+        CheckedInterfaceConstantDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceConstantDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceConstantDeclaration {
+    pub fn constant_token(&self) -> SyntaxToken {
+        self.0.constant_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn in_token(&self) -> SyntaxToken {
+        self.0.in_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> SyntaxToken {
+        self.0.colon_eq_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInterfaceDeclaration {
+    InterfaceObjectDeclaration(CheckedInterfaceObjectDeclaration),
+    InterfaceIncompleteTypeDeclaration(CheckedInterfaceIncompleteTypeDeclaration),
+    InterfaceSubprogramDeclaration(CheckedInterfaceSubprogramDeclaration),
+    InterfacePackageDeclaration(CheckedInterfacePackageDeclaration),
+}
+impl CheckedNode for CheckedInterfaceDeclaration {
+    type Syntax = InterfaceDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceDeclarationSyntax) -> Self {
+        match syntax {
+            InterfaceDeclarationSyntax::InterfaceObjectDeclaration(inner) => {
+                CheckedInterfaceDeclaration::InterfaceObjectDeclaration(
+                    CheckedInterfaceObjectDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceDeclarationSyntax::InterfaceIncompleteTypeDeclaration(inner) => {
+                CheckedInterfaceDeclaration::InterfaceIncompleteTypeDeclaration(
+                    CheckedInterfaceIncompleteTypeDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceDeclarationSyntax::InterfaceSubprogramDeclaration(inner) => {
+                CheckedInterfaceDeclaration::InterfaceSubprogramDeclaration(
+                    CheckedInterfaceSubprogramDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceDeclarationSyntax::InterfacePackageDeclaration(inner) => {
+                CheckedInterfaceDeclaration::InterfacePackageDeclaration(
+                    CheckedInterfacePackageDeclaration::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInterfaceDeclaration::InterfaceObjectDeclaration(inner) => {
+                InterfaceDeclarationSyntax::InterfaceObjectDeclaration(inner.raw())
+            }
+            CheckedInterfaceDeclaration::InterfaceIncompleteTypeDeclaration(inner) => {
+                InterfaceDeclarationSyntax::InterfaceIncompleteTypeDeclaration(inner.raw())
+            }
+            CheckedInterfaceDeclaration::InterfaceSubprogramDeclaration(inner) => {
+                InterfaceDeclarationSyntax::InterfaceSubprogramDeclaration(inner.raw())
+            }
+            CheckedInterfaceDeclaration::InterfacePackageDeclaration(inner) => {
+                InterfaceDeclarationSyntax::InterfacePackageDeclaration(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceFileDeclaration(InterfaceFileDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceFileDeclaration {
+    type Syntax = InterfaceFileDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceFileDeclarationSyntax) -> Self {
+        CheckedInterfaceFileDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceFileDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceFileDeclaration {
+    pub fn file_token(&self) -> SyntaxToken {
+        self.0.file_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceFunctionSpecification(InterfaceFunctionSpecificationSyntax);
+impl CheckedNode for CheckedInterfaceFunctionSpecification {
+    type Syntax = InterfaceFunctionSpecificationSyntax;
+    fn cast_unchecked(syntax: InterfaceFunctionSpecificationSyntax) -> Self {
+        CheckedInterfaceFunctionSpecification(syntax)
+    }
+    fn raw(&self) -> InterfaceFunctionSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceFunctionSpecification {
+    pub fn function_purity(&self) -> Option<FunctionPuritySyntax> {
+        self.0.function_purity()
+    }
+    pub fn function_token(&self) -> SyntaxToken {
+        self.0.function_token().unwrap()
+    }
+    pub fn designator(&self) -> DesignatorSyntax {
+        self.0.designator().unwrap()
+    }
+    pub fn parameter_list(&self) -> Option<CheckedParameterList> {
+        self.0
+            .parameter_list()
+            .map(CheckedParameterList::cast_unchecked)
+    }
+    pub fn return_token(&self) -> SyntaxToken {
+        self.0.return_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceIncompleteTypeDeclaration(InterfaceIncompleteTypeDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceIncompleteTypeDeclaration {
+    type Syntax = InterfaceIncompleteTypeDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceIncompleteTypeDeclarationSyntax) -> Self {
+        CheckedInterfaceIncompleteTypeDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceIncompleteTypeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceIncompleteTypeDeclaration {
+    pub fn type_token(&self) -> SyntaxToken {
+        self.0.type_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceList(InterfaceListSyntax);
+impl CheckedNode for CheckedInterfaceList {
+    type Syntax = InterfaceListSyntax;
+    fn cast_unchecked(syntax: InterfaceListSyntax) -> Self {
+        CheckedInterfaceList(syntax)
+    }
+    fn raw(&self) -> InterfaceListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceList {
+    pub fn interface_declarations(
+        &self,
+    ) -> impl Iterator<Item = CheckedInterfaceDeclaration> + use<'_> {
+        self.0
+            .interface_declarations()
+            .map(CheckedInterfaceDeclaration::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.semi_colon_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInterfaceObjectDeclaration {
+    InterfaceConstantDeclaration(CheckedInterfaceConstantDeclaration),
+    InterfaceSignalDeclaration(CheckedInterfaceSignalDeclaration),
+    InterfaceVariableDeclaration(CheckedInterfaceVariableDeclaration),
+    InterfaceFileDeclaration(CheckedInterfaceFileDeclaration),
+}
+impl CheckedNode for CheckedInterfaceObjectDeclaration {
+    type Syntax = InterfaceObjectDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceObjectDeclarationSyntax) -> Self {
+        match syntax {
+            InterfaceObjectDeclarationSyntax::InterfaceConstantDeclaration(inner) => {
+                CheckedInterfaceObjectDeclaration::InterfaceConstantDeclaration(
+                    CheckedInterfaceConstantDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceObjectDeclarationSyntax::InterfaceSignalDeclaration(inner) => {
+                CheckedInterfaceObjectDeclaration::InterfaceSignalDeclaration(
+                    CheckedInterfaceSignalDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceObjectDeclarationSyntax::InterfaceVariableDeclaration(inner) => {
+                CheckedInterfaceObjectDeclaration::InterfaceVariableDeclaration(
+                    CheckedInterfaceVariableDeclaration::cast_unchecked(inner),
+                )
+            }
+            InterfaceObjectDeclarationSyntax::InterfaceFileDeclaration(inner) => {
+                CheckedInterfaceObjectDeclaration::InterfaceFileDeclaration(
+                    CheckedInterfaceFileDeclaration::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInterfaceObjectDeclaration::InterfaceConstantDeclaration(inner) => {
+                InterfaceObjectDeclarationSyntax::InterfaceConstantDeclaration(inner.raw())
+            }
+            CheckedInterfaceObjectDeclaration::InterfaceSignalDeclaration(inner) => {
+                InterfaceObjectDeclarationSyntax::InterfaceSignalDeclaration(inner.raw())
+            }
+            CheckedInterfaceObjectDeclaration::InterfaceVariableDeclaration(inner) => {
+                InterfaceObjectDeclarationSyntax::InterfaceVariableDeclaration(inner.raw())
+            }
+            CheckedInterfaceObjectDeclaration::InterfaceFileDeclaration(inner) => {
+                InterfaceObjectDeclarationSyntax::InterfaceFileDeclaration(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageDeclaration(InterfacePackageDeclarationSyntax);
+impl CheckedNode for CheckedInterfacePackageDeclaration {
+    type Syntax = InterfacePackageDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfacePackageDeclarationSyntax) -> Self {
+        CheckedInterfacePackageDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfacePackageDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageDeclaration {
+    pub fn interface_package_declaration_preamble(
+        &self,
+    ) -> CheckedInterfacePackageDeclarationPreamble {
+        CheckedInterfacePackageDeclarationPreamble::cast_unchecked(
+            self.0.interface_package_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn new_token(&self) -> SyntaxToken {
+        self.0.new_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn interface_package_generic_map_aspect(&self) -> CheckedInterfacePackageGenericMapAspect {
+        CheckedInterfacePackageGenericMapAspect::cast_unchecked(
+            self.0.interface_package_generic_map_aspect().unwrap(),
+        )
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageDeclarationPreamble(InterfacePackageDeclarationPreambleSyntax);
+impl CheckedNode for CheckedInterfacePackageDeclarationPreamble {
+    type Syntax = InterfacePackageDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: InterfacePackageDeclarationPreambleSyntax) -> Self {
+        CheckedInterfacePackageDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> InterfacePackageDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageDeclarationPreamble {
+    pub fn package_token(&self) -> SyntaxToken {
+        self.0.package_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageGenericMapAspect(InterfacePackageGenericMapAspectSyntax);
+impl CheckedNode for CheckedInterfacePackageGenericMapAspect {
+    type Syntax = InterfacePackageGenericMapAspectSyntax;
+    fn cast_unchecked(syntax: InterfacePackageGenericMapAspectSyntax) -> Self {
+        CheckedInterfacePackageGenericMapAspect(syntax)
+    }
+    fn raw(&self) -> InterfacePackageGenericMapAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageGenericMapAspect {
+    pub fn generic_token(&self) -> SyntaxToken {
+        self.0.generic_token().unwrap()
+    }
+    pub fn map_token(&self) -> SyntaxToken {
+        self.0.map_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn interface_package_generic_map_aspect_inner(
+        &self,
+    ) -> CheckedInterfacePackageGenericMapAspectInner {
+        CheckedInterfacePackageGenericMapAspectInner::cast_unchecked(
+            self.0.interface_package_generic_map_aspect_inner().unwrap(),
+        )
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageGenericMapAspectBox(InterfacePackageGenericMapAspectBoxSyntax);
+impl CheckedNode for CheckedInterfacePackageGenericMapAspectBox {
+    type Syntax = InterfacePackageGenericMapAspectBoxSyntax;
+    fn cast_unchecked(syntax: InterfacePackageGenericMapAspectBoxSyntax) -> Self {
+        CheckedInterfacePackageGenericMapAspectBox(syntax)
+    }
+    fn raw(&self) -> InterfacePackageGenericMapAspectBoxSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageGenericMapAspectBox {
+    pub fn box_token(&self) -> SyntaxToken {
+        self.0.box_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageGenericMapAspectDefault(
+    InterfacePackageGenericMapAspectDefaultSyntax,
+);
+impl CheckedNode for CheckedInterfacePackageGenericMapAspectDefault {
+    type Syntax = InterfacePackageGenericMapAspectDefaultSyntax;
+    fn cast_unchecked(syntax: InterfacePackageGenericMapAspectDefaultSyntax) -> Self {
+        CheckedInterfacePackageGenericMapAspectDefault(syntax)
+    }
+    fn raw(&self) -> InterfacePackageGenericMapAspectDefaultSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageGenericMapAspectDefault {
+    pub fn default_token(&self) -> SyntaxToken {
+        self.0.default_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfacePackageGenericMapAspectAssociations(
+    InterfacePackageGenericMapAspectAssociationsSyntax,
+);
+impl CheckedNode for CheckedInterfacePackageGenericMapAspectAssociations {
+    type Syntax = InterfacePackageGenericMapAspectAssociationsSyntax;
+    fn cast_unchecked(syntax: InterfacePackageGenericMapAspectAssociationsSyntax) -> Self {
+        CheckedInterfacePackageGenericMapAspectAssociations(syntax)
+    }
+    fn raw(&self) -> InterfacePackageGenericMapAspectAssociationsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfacePackageGenericMapAspectAssociations {
+    pub fn association_list(&self) -> Option<CheckedAssociationList> {
+        self.0
+            .association_list()
+            .map(CheckedAssociationList::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInterfacePackageGenericMapAspectInner {
+    InterfacePackageGenericMapAspectBox(CheckedInterfacePackageGenericMapAspectBox),
+    InterfacePackageGenericMapAspectDefault(CheckedInterfacePackageGenericMapAspectDefault),
+    InterfacePackageGenericMapAspectAssociations(
+        CheckedInterfacePackageGenericMapAspectAssociations,
+    ),
+}
+impl CheckedNode for CheckedInterfacePackageGenericMapAspectInner {
+    type Syntax = InterfacePackageGenericMapAspectInnerSyntax;
+    fn cast_unchecked(syntax: InterfacePackageGenericMapAspectInnerSyntax) -> Self {
+        match syntax { InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectBox (inner) => CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectBox (CheckedInterfacePackageGenericMapAspectBox :: cast_unchecked (inner)) , InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectDefault (inner) => CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectDefault (CheckedInterfacePackageGenericMapAspectDefault :: cast_unchecked (inner)) , InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectAssociations (inner) => CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectAssociations (CheckedInterfacePackageGenericMapAspectAssociations :: cast_unchecked (inner)) , }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self { CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectBox (inner) => InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectBox (inner . raw ()) , CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectDefault (inner) => InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectDefault (inner . raw ()) , CheckedInterfacePackageGenericMapAspectInner :: InterfacePackageGenericMapAspectAssociations (inner) => InterfacePackageGenericMapAspectInnerSyntax :: InterfacePackageGenericMapAspectAssociations (inner . raw ()) , }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceProcedureSpecification(InterfaceProcedureSpecificationSyntax);
+impl CheckedNode for CheckedInterfaceProcedureSpecification {
+    type Syntax = InterfaceProcedureSpecificationSyntax;
+    fn cast_unchecked(syntax: InterfaceProcedureSpecificationSyntax) -> Self {
+        CheckedInterfaceProcedureSpecification(syntax)
+    }
+    fn raw(&self) -> InterfaceProcedureSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceProcedureSpecification {
+    pub fn procedure_token(&self) -> SyntaxToken {
+        self.0.procedure_token().unwrap()
+    }
+    pub fn designator(&self) -> DesignatorSyntax {
+        self.0.designator().unwrap()
+    }
+    pub fn parameter_token(&self) -> SyntaxToken {
+        self.0.parameter_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn interface_list(&self) -> Option<CheckedInterfaceList> {
+        self.0
+            .interface_list()
+            .map(CheckedInterfaceList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceSignalDeclaration(InterfaceSignalDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceSignalDeclaration {
+    type Syntax = InterfaceSignalDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceSignalDeclarationSyntax) -> Self {
+        CheckedInterfaceSignalDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceSignalDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceSignalDeclaration {
+    pub fn signal_token(&self) -> Option<SyntaxToken> {
+        self.0.signal_token()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn mode(&self) -> Option<ModeSyntax> {
+        self.0.mode()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn bus_token(&self) -> Option<SyntaxToken> {
+        self.0.bus_token()
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceSubprogramDeclaration(InterfaceSubprogramDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceSubprogramDeclaration {
+    type Syntax = InterfaceSubprogramDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceSubprogramDeclarationSyntax) -> Self {
+        CheckedInterfaceSubprogramDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceSubprogramDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceSubprogramDeclaration {
+    pub fn interface_subprogram_specification(&self) -> CheckedInterfaceSubprogramSpecification {
+        CheckedInterfaceSubprogramSpecification::cast_unchecked(
+            self.0.interface_subprogram_specification().unwrap(),
+        )
+    }
+    pub fn is_token(&self) -> Option<SyntaxToken> {
+        self.0.is_token()
+    }
+    pub fn interface_subprogram_default(&self) -> Option<CheckedInterfaceSubprogramDefault> {
+        self.0
+            .interface_subprogram_default()
+            .map(CheckedInterfaceSubprogramDefault::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceSubprogramDefaultName(InterfaceSubprogramDefaultNameSyntax);
+impl CheckedNode for CheckedInterfaceSubprogramDefaultName {
+    type Syntax = InterfaceSubprogramDefaultNameSyntax;
+    fn cast_unchecked(syntax: InterfaceSubprogramDefaultNameSyntax) -> Self {
+        CheckedInterfaceSubprogramDefaultName(syntax)
+    }
+    fn raw(&self) -> InterfaceSubprogramDefaultNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceSubprogramDefaultName {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceSubprogramDefaultBox(InterfaceSubprogramDefaultBoxSyntax);
+impl CheckedNode for CheckedInterfaceSubprogramDefaultBox {
+    type Syntax = InterfaceSubprogramDefaultBoxSyntax;
+    fn cast_unchecked(syntax: InterfaceSubprogramDefaultBoxSyntax) -> Self {
+        CheckedInterfaceSubprogramDefaultBox(syntax)
+    }
+    fn raw(&self) -> InterfaceSubprogramDefaultBoxSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceSubprogramDefaultBox {
+    pub fn box_token(&self) -> SyntaxToken {
+        self.0.box_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInterfaceSubprogramDefault {
+    InterfaceSubprogramDefaultName(CheckedInterfaceSubprogramDefaultName),
+    InterfaceSubprogramDefaultBox(CheckedInterfaceSubprogramDefaultBox),
+}
+impl CheckedNode for CheckedInterfaceSubprogramDefault {
+    type Syntax = InterfaceSubprogramDefaultSyntax;
+    fn cast_unchecked(syntax: InterfaceSubprogramDefaultSyntax) -> Self {
+        match syntax {
+            InterfaceSubprogramDefaultSyntax::InterfaceSubprogramDefaultName(inner) => {
+                CheckedInterfaceSubprogramDefault::InterfaceSubprogramDefaultName(
+                    CheckedInterfaceSubprogramDefaultName::cast_unchecked(inner),
+                )
+            }
+            InterfaceSubprogramDefaultSyntax::InterfaceSubprogramDefaultBox(inner) => {
+                CheckedInterfaceSubprogramDefault::InterfaceSubprogramDefaultBox(
+                    CheckedInterfaceSubprogramDefaultBox::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInterfaceSubprogramDefault::InterfaceSubprogramDefaultName(inner) => {
+                InterfaceSubprogramDefaultSyntax::InterfaceSubprogramDefaultName(inner.raw())
+            }
+            CheckedInterfaceSubprogramDefault::InterfaceSubprogramDefaultBox(inner) => {
+                InterfaceSubprogramDefaultSyntax::InterfaceSubprogramDefaultBox(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInterfaceSubprogramSpecification {
+    InterfaceProcedureSpecification(CheckedInterfaceProcedureSpecification),
+    InterfaceFunctionSpecification(CheckedInterfaceFunctionSpecification),
+}
+impl CheckedNode for CheckedInterfaceSubprogramSpecification {
+    type Syntax = InterfaceSubprogramSpecificationSyntax;
+    fn cast_unchecked(syntax: InterfaceSubprogramSpecificationSyntax) -> Self {
+        match syntax {
+            InterfaceSubprogramSpecificationSyntax::InterfaceProcedureSpecification(inner) => {
+                CheckedInterfaceSubprogramSpecification::InterfaceProcedureSpecification(
+                    CheckedInterfaceProcedureSpecification::cast_unchecked(inner),
+                )
+            }
+            InterfaceSubprogramSpecificationSyntax::InterfaceFunctionSpecification(inner) => {
+                CheckedInterfaceSubprogramSpecification::InterfaceFunctionSpecification(
+                    CheckedInterfaceFunctionSpecification::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInterfaceSubprogramSpecification::InterfaceProcedureSpecification(inner) => {
+                InterfaceSubprogramSpecificationSyntax::InterfaceProcedureSpecification(inner.raw())
+            }
+            CheckedInterfaceSubprogramSpecification::InterfaceFunctionSpecification(inner) => {
+                InterfaceSubprogramSpecificationSyntax::InterfaceFunctionSpecification(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInterfaceVariableDeclaration(InterfaceVariableDeclarationSyntax);
+impl CheckedNode for CheckedInterfaceVariableDeclaration {
+    type Syntax = InterfaceVariableDeclarationSyntax;
+    fn cast_unchecked(syntax: InterfaceVariableDeclarationSyntax) -> Self {
+        CheckedInterfaceVariableDeclaration(syntax)
+    }
+    fn raw(&self) -> InterfaceVariableDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInterfaceVariableDeclaration {
+    pub fn variable_token(&self) -> Option<SyntaxToken> {
+        self.0.variable_token()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn mode(&self) -> Option<ModeSyntax> {
+        self.0.mode()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPortClause(PortClauseSyntax);
+impl CheckedNode for CheckedPortClause {
+    type Syntax = PortClauseSyntax;
+    fn cast_unchecked(syntax: PortClauseSyntax) -> Self {
+        CheckedPortClause(syntax)
+    }
+    fn raw(&self) -> PortClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPortClause {
+    pub fn port_clause_preamble(&self) -> CheckedPortClausePreamble {
+        CheckedPortClausePreamble::cast_unchecked(self.0.port_clause_preamble().unwrap())
+    }
+    pub fn interface_list(&self) -> Option<CheckedInterfaceList> {
+        self.0
+            .interface_list()
+            .map(CheckedInterfaceList::cast_unchecked)
+    }
+    pub fn port_clause_epilogue(&self) -> CheckedPortClauseEpilogue {
+        CheckedPortClauseEpilogue::cast_unchecked(self.0.port_clause_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPortClausePreamble(PortClausePreambleSyntax);
+impl CheckedNode for CheckedPortClausePreamble {
+    type Syntax = PortClausePreambleSyntax;
+    fn cast_unchecked(syntax: PortClausePreambleSyntax) -> Self {
+        CheckedPortClausePreamble(syntax)
+    }
+    fn raw(&self) -> PortClausePreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPortClausePreamble {
+    pub fn port_token(&self) -> SyntaxToken {
+        self.0.port_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPortClauseEpilogue(PortClauseEpilogueSyntax);
+impl CheckedNode for CheckedPortClauseEpilogue {
+    type Syntax = PortClauseEpilogueSyntax;
+    fn cast_unchecked(syntax: PortClauseEpilogueSyntax) -> Self {
+        CheckedPortClauseEpilogue(syntax)
+    }
+    fn raw(&self) -> PortClauseEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPortClauseEpilogue {
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPortMapAspect(PortMapAspectSyntax);
+impl CheckedNode for CheckedPortMapAspect {
+    type Syntax = PortMapAspectSyntax;
+    fn cast_unchecked(syntax: PortMapAspectSyntax) -> Self {
+        CheckedPortMapAspect(syntax)
+    }
+    fn raw(&self) -> PortMapAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPortMapAspect {
+    pub fn port_token(&self) -> SyntaxToken {
+        self.0.port_token().unwrap()
+    }
+    pub fn map_token(&self) -> SyntaxToken {
+        self.0.map_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn association_list(&self) -> Option<CheckedAssociationList> {
+        self.0
+            .association_list()
+            .map(CheckedAssociationList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordElementResolution(RecordElementResolutionSyntax);
+impl CheckedNode for CheckedRecordElementResolution {
+    type Syntax = RecordElementResolutionSyntax;
+    fn cast_unchecked(syntax: RecordElementResolutionSyntax) -> Self {
+        CheckedRecordElementResolution(syntax)
+    }
+    fn raw(&self) -> RecordElementResolutionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordElementResolution {
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn resolution_indication(&self) -> CheckedResolutionIndication {
+        CheckedResolutionIndication::cast_unchecked(self.0.resolution_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordResolution(RecordResolutionSyntax);
+impl CheckedNode for CheckedRecordResolution {
+    type Syntax = RecordResolutionSyntax;
+    fn cast_unchecked(syntax: RecordResolutionSyntax) -> Self {
+        CheckedRecordResolution(syntax)
+    }
+    fn raw(&self) -> RecordResolutionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordResolution {
+    pub fn record_element_resolutions(
+        &self,
+    ) -> impl Iterator<Item = CheckedRecordElementResolution> + use<'_> {
+        self.0
+            .record_element_resolutions()
+            .map(CheckedRecordElementResolution::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNameResolutionIndication(NameResolutionIndicationSyntax);
+impl CheckedNode for CheckedNameResolutionIndication {
+    type Syntax = NameResolutionIndicationSyntax;
+    fn cast_unchecked(syntax: NameResolutionIndicationSyntax) -> Self {
+        CheckedNameResolutionIndication(syntax)
+    }
+    fn raw(&self) -> NameResolutionIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNameResolutionIndication {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedElementResolutionResolutionIndication(
+    ElementResolutionResolutionIndicationSyntax,
+);
+impl CheckedNode for CheckedElementResolutionResolutionIndication {
+    type Syntax = ElementResolutionResolutionIndicationSyntax;
+    fn cast_unchecked(syntax: ElementResolutionResolutionIndicationSyntax) -> Self {
+        CheckedElementResolutionResolutionIndication(syntax)
+    }
+    fn raw(&self) -> ElementResolutionResolutionIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedElementResolutionResolutionIndication {
+    pub fn element_resolution(&self) -> CheckedElementResolution {
+        CheckedElementResolution::cast_unchecked(self.0.element_resolution().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedElementResolutionResolutionIndication(
+    ParenthesizedElementResolutionResolutionIndicationSyntax,
+);
+impl CheckedNode for CheckedParenthesizedElementResolutionResolutionIndication {
+    type Syntax = ParenthesizedElementResolutionResolutionIndicationSyntax;
+    fn cast_unchecked(syntax: ParenthesizedElementResolutionResolutionIndicationSyntax) -> Self {
+        CheckedParenthesizedElementResolutionResolutionIndication(syntax)
+    }
+    fn raw(&self) -> ParenthesizedElementResolutionResolutionIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedElementResolutionResolutionIndication {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn element_resolution_resolution_indication(
+        &self,
+    ) -> CheckedElementResolutionResolutionIndication {
+        CheckedElementResolutionResolutionIndication::cast_unchecked(
+            self.0.element_resolution_resolution_indication().unwrap(),
+        )
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedResolutionIndication {
+    NameResolutionIndication(CheckedNameResolutionIndication),
+    ParenthesizedElementResolutionResolutionIndication(
+        CheckedParenthesizedElementResolutionResolutionIndication,
+    ),
+}
+impl CheckedNode for CheckedResolutionIndication {
+    type Syntax = ResolutionIndicationSyntax;
+    fn cast_unchecked(syntax: ResolutionIndicationSyntax) -> Self {
+        match syntax {
+            ResolutionIndicationSyntax::NameResolutionIndication(inner) => {
+                CheckedResolutionIndication::NameResolutionIndication(
+                    CheckedNameResolutionIndication::cast_unchecked(inner),
+                )
+            }
+            ResolutionIndicationSyntax::ParenthesizedElementResolutionResolutionIndication(
+                inner,
+            ) => CheckedResolutionIndication::ParenthesizedElementResolutionResolutionIndication(
+                CheckedParenthesizedElementResolutionResolutionIndication::cast_unchecked(inner),
+            ),
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedResolutionIndication::NameResolutionIndication(inner) => {
+                ResolutionIndicationSyntax::NameResolutionIndication(inner.raw())
+            }
+            CheckedResolutionIndication::ParenthesizedElementResolutionResolutionIndication(
+                inner,
+            ) => ResolutionIndicationSyntax::ParenthesizedElementResolutionResolutionIndication(
+                inner.raw(),
+            ),
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSignalDeclaration(SignalDeclarationSyntax);
+impl CheckedNode for CheckedSignalDeclaration {
+    type Syntax = SignalDeclarationSyntax;
+    fn cast_unchecked(syntax: SignalDeclarationSyntax) -> Self {
+        CheckedSignalDeclaration(syntax)
+    }
+    fn raw(&self) -> SignalDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSignalDeclaration {
+    pub fn signal_token(&self) -> SyntaxToken {
+        self.0.signal_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn signal_kind(&self) -> Option<SignalKindSyntax> {
+        self.0.signal_kind()
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubtypeDeclaration(SubtypeDeclarationSyntax);
+impl CheckedNode for CheckedSubtypeDeclaration {
+    type Syntax = SubtypeDeclarationSyntax;
+    fn cast_unchecked(syntax: SubtypeDeclarationSyntax) -> Self {
+        CheckedSubtypeDeclaration(syntax)
+    }
+    fn raw(&self) -> SubtypeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubtypeDeclaration {
+    pub fn subtype_token(&self) -> SyntaxToken {
+        self.0.subtype_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubtypeIndication(SubtypeIndicationSyntax);
+impl CheckedNode for CheckedSubtypeIndication {
+    type Syntax = SubtypeIndicationSyntax;
+    fn cast_unchecked(syntax: SubtypeIndicationSyntax) -> Self {
+        CheckedSubtypeIndication(syntax)
+    }
+    fn raw(&self) -> SubtypeIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubtypeIndication {
+    pub fn resolution_indication(&self) -> CheckedResolutionIndication {
+        CheckedResolutionIndication::cast_unchecked(self.0.resolution_indication().unwrap())
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedTypeDeclaration {
+    FullTypeDeclaration(CheckedFullTypeDeclaration),
+    IncompleteTypeDeclaration(CheckedIncompleteTypeDeclaration),
+}
+impl CheckedNode for CheckedTypeDeclaration {
+    type Syntax = TypeDeclarationSyntax;
+    fn cast_unchecked(syntax: TypeDeclarationSyntax) -> Self {
+        match syntax {
+            TypeDeclarationSyntax::FullTypeDeclaration(inner) => {
+                CheckedTypeDeclaration::FullTypeDeclaration(
+                    CheckedFullTypeDeclaration::cast_unchecked(inner),
+                )
+            }
+            TypeDeclarationSyntax::IncompleteTypeDeclaration(inner) => {
+                CheckedTypeDeclaration::IncompleteTypeDeclaration(
+                    CheckedIncompleteTypeDeclaration::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedTypeDeclaration::FullTypeDeclaration(inner) => {
+                TypeDeclarationSyntax::FullTypeDeclaration(inner.raw())
+            }
+            CheckedTypeDeclaration::IncompleteTypeDeclaration(inner) => {
+                TypeDeclarationSyntax::IncompleteTypeDeclaration(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedTypeDefinition {
+    ScalarTypeDefinition(CheckedScalarTypeDefinition),
+    CompositeTypeDefinition(CheckedCompositeTypeDefinition),
+    AccessTypeDefinition(CheckedAccessTypeDefinition),
+    FileTypeDefinition(CheckedFileTypeDefinition),
+    ProtectedTypeDefinition(CheckedProtectedTypeDefinition),
+}
+impl CheckedNode for CheckedTypeDefinition {
+    type Syntax = TypeDefinitionSyntax;
+    fn cast_unchecked(syntax: TypeDefinitionSyntax) -> Self {
+        match syntax {
+            TypeDefinitionSyntax::ScalarTypeDefinition(inner) => {
+                CheckedTypeDefinition::ScalarTypeDefinition(
+                    CheckedScalarTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            TypeDefinitionSyntax::CompositeTypeDefinition(inner) => {
+                CheckedTypeDefinition::CompositeTypeDefinition(
+                    CheckedCompositeTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            TypeDefinitionSyntax::AccessTypeDefinition(inner) => {
+                CheckedTypeDefinition::AccessTypeDefinition(
+                    CheckedAccessTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            TypeDefinitionSyntax::FileTypeDefinition(inner) => {
+                CheckedTypeDefinition::FileTypeDefinition(
+                    CheckedFileTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            TypeDefinitionSyntax::ProtectedTypeDefinition(inner) => {
+                CheckedTypeDefinition::ProtectedTypeDefinition(
+                    CheckedProtectedTypeDefinition::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedTypeDefinition::ScalarTypeDefinition(inner) => {
+                TypeDefinitionSyntax::ScalarTypeDefinition(inner.raw())
+            }
+            CheckedTypeDefinition::CompositeTypeDefinition(inner) => {
+                TypeDefinitionSyntax::CompositeTypeDefinition(inner.raw())
+            }
+            CheckedTypeDefinition::AccessTypeDefinition(inner) => {
+                TypeDefinitionSyntax::AccessTypeDefinition(inner.raw())
+            }
+            CheckedTypeDefinition::FileTypeDefinition(inner) => {
+                TypeDefinitionSyntax::FileTypeDefinition(inner.raw())
+            }
+            CheckedTypeDefinition::ProtectedTypeDefinition(inner) => {
+                TypeDefinitionSyntax::ProtectedTypeDefinition(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedVariableDeclaration(VariableDeclarationSyntax);
+impl CheckedNode for CheckedVariableDeclaration {
+    type Syntax = VariableDeclarationSyntax;
+    fn cast_unchecked(syntax: VariableDeclarationSyntax) -> Self {
+        CheckedVariableDeclaration(syntax)
+    }
+    fn raw(&self) -> VariableDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedVariableDeclaration {
+    pub fn variable_token(&self) -> SyntaxToken {
+        self.0.variable_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSharedVariableDeclaration(SharedVariableDeclarationSyntax);
+impl CheckedNode for CheckedSharedVariableDeclaration {
+    type Syntax = SharedVariableDeclarationSyntax;
+    fn cast_unchecked(syntax: SharedVariableDeclarationSyntax) -> Self {
+        CheckedSharedVariableDeclaration(syntax)
+    }
+    fn raw(&self) -> SharedVariableDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSharedVariableDeclaration {
+    pub fn shared_token(&self) -> SyntaxToken {
+        self.0.shared_token().unwrap()
+    }
+    pub fn variable_token(&self) -> SyntaxToken {
+        self.0.variable_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_eq_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedDeclarations(DeclarationsSyntax);
+impl CheckedNode for CheckedDeclarations {
+    type Syntax = DeclarationsSyntax;
+    fn cast_unchecked(syntax: DeclarationsSyntax) -> Self {
+        CheckedDeclarations(syntax)
+    }
+    fn raw(&self) -> DeclarationsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDeclarations {
+    pub fn declarations(&self) -> impl Iterator<Item = CheckedDeclaration> + use<'_> {
+        self.0
+            .declarations()
+            .map(CheckedDeclaration::cast_unchecked)
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/design_entities.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/design_entities.rs
@@ -1,0 +1,601 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedArchitectureBody(ArchitectureBodySyntax);
+impl CheckedNode for CheckedArchitectureBody {
+    type Syntax = ArchitectureBodySyntax;
+    fn cast_unchecked(syntax: ArchitectureBodySyntax) -> Self {
+        CheckedArchitectureBody(syntax)
+    }
+    fn raw(&self) -> ArchitectureBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedArchitectureBody {
+    pub fn architecture_preamble(&self) -> CheckedArchitecturePreamble {
+        CheckedArchitecturePreamble::cast_unchecked(self.0.architecture_preamble().unwrap())
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> CheckedDeclarationStatementSeparator {
+        CheckedDeclarationStatementSeparator::cast_unchecked(
+            self.0.declaration_statement_separator().unwrap(),
+        )
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn architecture_epilogue(&self) -> CheckedArchitectureEpilogue {
+        CheckedArchitectureEpilogue::cast_unchecked(self.0.architecture_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedArchitecturePreamble(ArchitecturePreambleSyntax);
+impl CheckedNode for CheckedArchitecturePreamble {
+    type Syntax = ArchitecturePreambleSyntax;
+    fn cast_unchecked(syntax: ArchitecturePreambleSyntax) -> Self {
+        CheckedArchitecturePreamble(syntax)
+    }
+    fn raw(&self) -> ArchitecturePreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedArchitecturePreamble {
+    pub fn architecture_token(&self) -> SyntaxToken {
+        self.0.architecture_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn entity_name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.entity_name().unwrap())
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedArchitectureEpilogue(ArchitectureEpilogueSyntax);
+impl CheckedNode for CheckedArchitectureEpilogue {
+    type Syntax = ArchitectureEpilogueSyntax;
+    fn cast_unchecked(syntax: ArchitectureEpilogueSyntax) -> Self {
+        CheckedArchitectureEpilogue(syntax)
+    }
+    fn raw(&self) -> ArchitectureEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedArchitectureEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn architecture_token(&self) -> Option<SyntaxToken> {
+        self.0.architecture_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockConfigurationItem(BlockConfigurationItemSyntax);
+impl CheckedNode for CheckedBlockConfigurationItem {
+    type Syntax = BlockConfigurationItemSyntax;
+    fn cast_unchecked(syntax: BlockConfigurationItemSyntax) -> Self {
+        CheckedBlockConfigurationItem(syntax)
+    }
+    fn raw(&self) -> BlockConfigurationItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockConfigurationItem {
+    pub fn block_configuration(&self) -> CheckedBlockConfiguration {
+        CheckedBlockConfiguration::cast_unchecked(self.0.block_configuration().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedConfigurationItem {
+    BlockConfigurationItem(CheckedBlockConfigurationItem),
+    ComponentConfiguration(CheckedComponentConfiguration),
+}
+impl CheckedNode for CheckedConfigurationItem {
+    type Syntax = ConfigurationItemSyntax;
+    fn cast_unchecked(syntax: ConfigurationItemSyntax) -> Self {
+        match syntax {
+            ConfigurationItemSyntax::BlockConfigurationItem(inner) => {
+                CheckedConfigurationItem::BlockConfigurationItem(
+                    CheckedBlockConfigurationItem::cast_unchecked(inner),
+                )
+            }
+            ConfigurationItemSyntax::ComponentConfiguration(inner) => {
+                CheckedConfigurationItem::ComponentConfiguration(
+                    CheckedComponentConfiguration::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedConfigurationItem::BlockConfigurationItem(inner) => {
+                ConfigurationItemSyntax::BlockConfigurationItem(inner.raw())
+            }
+            CheckedConfigurationItem::ComponentConfiguration(inner) => {
+                ConfigurationItemSyntax::ComponentConfiguration(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockConfiguration(BlockConfigurationSyntax);
+impl CheckedNode for CheckedBlockConfiguration {
+    type Syntax = BlockConfigurationSyntax;
+    fn cast_unchecked(syntax: BlockConfigurationSyntax) -> Self {
+        CheckedBlockConfiguration(syntax)
+    }
+    fn raw(&self) -> BlockConfigurationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockConfiguration {
+    pub fn block_configuration_preamble(&self) -> CheckedBlockConfigurationPreamble {
+        CheckedBlockConfigurationPreamble::cast_unchecked(
+            self.0.block_configuration_preamble().unwrap(),
+        )
+    }
+    pub fn block_configuration_items(&self) -> Option<CheckedBlockConfigurationItems> {
+        self.0
+            .block_configuration_items()
+            .map(CheckedBlockConfigurationItems::cast_unchecked)
+    }
+    pub fn block_configuration_epilogue(&self) -> CheckedBlockConfigurationEpilogue {
+        CheckedBlockConfigurationEpilogue::cast_unchecked(
+            self.0.block_configuration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockConfigurationItems(BlockConfigurationItemsSyntax);
+impl CheckedNode for CheckedBlockConfigurationItems {
+    type Syntax = BlockConfigurationItemsSyntax;
+    fn cast_unchecked(syntax: BlockConfigurationItemsSyntax) -> Self {
+        CheckedBlockConfigurationItems(syntax)
+    }
+    fn raw(&self) -> BlockConfigurationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockConfigurationItems {
+    pub fn use_clauses(&self) -> impl Iterator<Item = CheckedUseClause> + use<'_> {
+        self.0.use_clauses().map(CheckedUseClause::cast_unchecked)
+    }
+    pub fn configuration_items(&self) -> impl Iterator<Item = CheckedConfigurationItem> + use<'_> {
+        self.0
+            .configuration_items()
+            .map(CheckedConfigurationItem::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockConfigurationPreamble(BlockConfigurationPreambleSyntax);
+impl CheckedNode for CheckedBlockConfigurationPreamble {
+    type Syntax = BlockConfigurationPreambleSyntax;
+    fn cast_unchecked(syntax: BlockConfigurationPreambleSyntax) -> Self {
+        CheckedBlockConfigurationPreamble(syntax)
+    }
+    fn raw(&self) -> BlockConfigurationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockConfigurationPreamble {
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBlockConfigurationEpilogue(BlockConfigurationEpilogueSyntax);
+impl CheckedNode for CheckedBlockConfigurationEpilogue {
+    type Syntax = BlockConfigurationEpilogueSyntax;
+    fn cast_unchecked(syntax: BlockConfigurationEpilogueSyntax) -> Self {
+        CheckedBlockConfigurationEpilogue(syntax)
+    }
+    fn raw(&self) -> BlockConfigurationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBlockConfigurationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentConfiguration(ComponentConfigurationSyntax);
+impl CheckedNode for CheckedComponentConfiguration {
+    type Syntax = ComponentConfigurationSyntax;
+    fn cast_unchecked(syntax: ComponentConfigurationSyntax) -> Self {
+        CheckedComponentConfiguration(syntax)
+    }
+    fn raw(&self) -> ComponentConfigurationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentConfiguration {
+    pub fn component_configuration_preamble(&self) -> CheckedComponentConfigurationPreamble {
+        CheckedComponentConfigurationPreamble::cast_unchecked(
+            self.0.component_configuration_preamble().unwrap(),
+        )
+    }
+    pub fn component_configuration_items(&self) -> Option<CheckedComponentConfigurationItems> {
+        self.0
+            .component_configuration_items()
+            .map(CheckedComponentConfigurationItems::cast_unchecked)
+    }
+    pub fn component_configuration_epilogue(&self) -> CheckedComponentConfigurationEpilogue {
+        CheckedComponentConfigurationEpilogue::cast_unchecked(
+            self.0.component_configuration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSemiColonTerminatedBindingIndication(SemiColonTerminatedBindingIndicationSyntax);
+impl CheckedNode for CheckedSemiColonTerminatedBindingIndication {
+    type Syntax = SemiColonTerminatedBindingIndicationSyntax;
+    fn cast_unchecked(syntax: SemiColonTerminatedBindingIndicationSyntax) -> Self {
+        CheckedSemiColonTerminatedBindingIndication(syntax)
+    }
+    fn raw(&self) -> SemiColonTerminatedBindingIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSemiColonTerminatedBindingIndication {
+    pub fn binding_indication(&self) -> Option<CheckedBindingIndication> {
+        self.0
+            .binding_indication()
+            .map(CheckedBindingIndication::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSemiColonTerminatedVerificationUnitBindingIndication(
+    SemiColonTerminatedVerificationUnitBindingIndicationSyntax,
+);
+impl CheckedNode for CheckedSemiColonTerminatedVerificationUnitBindingIndication {
+    type Syntax = SemiColonTerminatedVerificationUnitBindingIndicationSyntax;
+    fn cast_unchecked(syntax: SemiColonTerminatedVerificationUnitBindingIndicationSyntax) -> Self {
+        CheckedSemiColonTerminatedVerificationUnitBindingIndication(syntax)
+    }
+    fn raw(&self) -> SemiColonTerminatedVerificationUnitBindingIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSemiColonTerminatedVerificationUnitBindingIndication {
+    pub fn verification_unit_binding_indication(&self) -> CheckedVerificationUnitBindingIndication {
+        CheckedVerificationUnitBindingIndication::cast_unchecked(
+            self.0.verification_unit_binding_indication().unwrap(),
+        )
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentConfigurationItems(ComponentConfigurationItemsSyntax);
+impl CheckedNode for CheckedComponentConfigurationItems {
+    type Syntax = ComponentConfigurationItemsSyntax;
+    fn cast_unchecked(syntax: ComponentConfigurationItemsSyntax) -> Self {
+        CheckedComponentConfigurationItems(syntax)
+    }
+    fn raw(&self) -> ComponentConfigurationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentConfigurationItems {
+    pub fn semi_colon_terminated_binding_indication(
+        &self,
+    ) -> Option<CheckedSemiColonTerminatedBindingIndication> {
+        self.0
+            .semi_colon_terminated_binding_indication()
+            .map(CheckedSemiColonTerminatedBindingIndication::cast_unchecked)
+    }
+    pub fn semi_colon_terminated_verification_unit_binding_indications(
+        &self,
+    ) -> impl Iterator<Item = CheckedSemiColonTerminatedVerificationUnitBindingIndication> + use<'_>
+    {
+        self.0
+            .semi_colon_terminated_verification_unit_binding_indications()
+            .map(CheckedSemiColonTerminatedVerificationUnitBindingIndication::cast_unchecked)
+    }
+    pub fn block_configuration(&self) -> Option<CheckedBlockConfiguration> {
+        self.0
+            .block_configuration()
+            .map(CheckedBlockConfiguration::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentConfigurationPreamble(ComponentConfigurationPreambleSyntax);
+impl CheckedNode for CheckedComponentConfigurationPreamble {
+    type Syntax = ComponentConfigurationPreambleSyntax;
+    fn cast_unchecked(syntax: ComponentConfigurationPreambleSyntax) -> Self {
+        CheckedComponentConfigurationPreamble(syntax)
+    }
+    fn raw(&self) -> ComponentConfigurationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentConfigurationPreamble {
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn component_specification(&self) -> CheckedComponentSpecification {
+        CheckedComponentSpecification::cast_unchecked(self.0.component_specification().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentConfigurationEpilogue(ComponentConfigurationEpilogueSyntax);
+impl CheckedNode for CheckedComponentConfigurationEpilogue {
+    type Syntax = ComponentConfigurationEpilogueSyntax;
+    fn cast_unchecked(syntax: ComponentConfigurationEpilogueSyntax) -> Self {
+        CheckedComponentConfigurationEpilogue(syntax)
+    }
+    fn raw(&self) -> ComponentConfigurationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentConfigurationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConfigurationDeclaration(ConfigurationDeclarationSyntax);
+impl CheckedNode for CheckedConfigurationDeclaration {
+    type Syntax = ConfigurationDeclarationSyntax;
+    fn cast_unchecked(syntax: ConfigurationDeclarationSyntax) -> Self {
+        CheckedConfigurationDeclaration(syntax)
+    }
+    fn raw(&self) -> ConfigurationDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConfigurationDeclaration {
+    pub fn configuration_declaration_preamble(&self) -> CheckedConfigurationDeclarationPreamble {
+        CheckedConfigurationDeclarationPreamble::cast_unchecked(
+            self.0.configuration_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn configuration_declaration_items(&self) -> CheckedConfigurationDeclarationItems {
+        CheckedConfigurationDeclarationItems::cast_unchecked(
+            self.0.configuration_declaration_items().unwrap(),
+        )
+    }
+    pub fn configuration_declaration_epilogue(&self) -> CheckedConfigurationDeclarationEpilogue {
+        CheckedConfigurationDeclarationEpilogue::cast_unchecked(
+            self.0.configuration_declaration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConfigurationDeclarationItems(ConfigurationDeclarationItemsSyntax);
+impl CheckedNode for CheckedConfigurationDeclarationItems {
+    type Syntax = ConfigurationDeclarationItemsSyntax;
+    fn cast_unchecked(syntax: ConfigurationDeclarationItemsSyntax) -> Self {
+        CheckedConfigurationDeclarationItems(syntax)
+    }
+    fn raw(&self) -> ConfigurationDeclarationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConfigurationDeclarationItems {
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn semi_colon_terminated_verification_unit_binding_indications(
+        &self,
+    ) -> impl Iterator<Item = CheckedSemiColonTerminatedVerificationUnitBindingIndication> + use<'_>
+    {
+        self.0
+            .semi_colon_terminated_verification_unit_binding_indications()
+            .map(CheckedSemiColonTerminatedVerificationUnitBindingIndication::cast_unchecked)
+    }
+    pub fn block_configuration(&self) -> CheckedBlockConfiguration {
+        CheckedBlockConfiguration::cast_unchecked(self.0.block_configuration().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConfigurationDeclarationPreamble(ConfigurationDeclarationPreambleSyntax);
+impl CheckedNode for CheckedConfigurationDeclarationPreamble {
+    type Syntax = ConfigurationDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: ConfigurationDeclarationPreambleSyntax) -> Self {
+        CheckedConfigurationDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> ConfigurationDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConfigurationDeclarationPreamble {
+    pub fn configuration_token(&self) -> SyntaxToken {
+        self.0.configuration_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn entity_name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.entity_name().unwrap())
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConfigurationDeclarationEpilogue(ConfigurationDeclarationEpilogueSyntax);
+impl CheckedNode for CheckedConfigurationDeclarationEpilogue {
+    type Syntax = ConfigurationDeclarationEpilogueSyntax;
+    fn cast_unchecked(syntax: ConfigurationDeclarationEpilogueSyntax) -> Self {
+        CheckedConfigurationDeclarationEpilogue(syntax)
+    }
+    fn raw(&self) -> ConfigurationDeclarationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConfigurationDeclarationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn configuration_token(&self) -> Option<SyntaxToken> {
+        self.0.configuration_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityDeclaration(EntityDeclarationSyntax);
+impl CheckedNode for CheckedEntityDeclaration {
+    type Syntax = EntityDeclarationSyntax;
+    fn cast_unchecked(syntax: EntityDeclarationSyntax) -> Self {
+        CheckedEntityDeclaration(syntax)
+    }
+    fn raw(&self) -> EntityDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityDeclaration {
+    pub fn entity_declaration_preamble(&self) -> CheckedEntityDeclarationPreamble {
+        CheckedEntityDeclarationPreamble::cast_unchecked(
+            self.0.entity_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn entity_header(&self) -> Option<CheckedEntityHeader> {
+        self.0
+            .entity_header()
+            .map(CheckedEntityHeader::cast_unchecked)
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> Option<CheckedDeclarationStatementSeparator> {
+        self.0
+            .declaration_statement_separator()
+            .map(CheckedDeclarationStatementSeparator::cast_unchecked)
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn entity_declaration_epilogue(&self) -> CheckedEntityDeclarationEpilogue {
+        CheckedEntityDeclarationEpilogue::cast_unchecked(
+            self.0.entity_declaration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityDeclarationPreamble(EntityDeclarationPreambleSyntax);
+impl CheckedNode for CheckedEntityDeclarationPreamble {
+    type Syntax = EntityDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: EntityDeclarationPreambleSyntax) -> Self {
+        CheckedEntityDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> EntityDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityDeclarationPreamble {
+    pub fn entity_token(&self) -> SyntaxToken {
+        self.0.entity_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityDeclarationEpilogue(EntityDeclarationEpilogueSyntax);
+impl CheckedNode for CheckedEntityDeclarationEpilogue {
+    type Syntax = EntityDeclarationEpilogueSyntax;
+    fn cast_unchecked(syntax: EntityDeclarationEpilogueSyntax) -> Self {
+        CheckedEntityDeclarationEpilogue(syntax)
+    }
+    fn raw(&self) -> EntityDeclarationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityDeclarationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn entity_token(&self) -> Option<SyntaxToken> {
+        self.0.entity_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityHeader(EntityHeaderSyntax);
+impl CheckedNode for CheckedEntityHeader {
+    type Syntax = EntityHeaderSyntax;
+    fn cast_unchecked(syntax: EntityHeaderSyntax) -> Self {
+        CheckedEntityHeader(syntax)
+    }
+    fn raw(&self) -> EntityHeaderSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityHeader {
+    pub fn generic_clause(&self) -> Option<CheckedGenericClause> {
+        self.0
+            .generic_clause()
+            .map(CheckedGenericClause::cast_unchecked)
+    }
+    pub fn port_clause(&self) -> Option<CheckedPortClause> {
+        self.0.port_clause().map(CheckedPortClause::cast_unchecked)
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/design_units.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/design_units.rs
@@ -1,0 +1,409 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedContextClause(ContextClauseSyntax);
+impl CheckedNode for CheckedContextClause {
+    type Syntax = ContextClauseSyntax;
+    fn cast_unchecked(syntax: ContextClauseSyntax) -> Self {
+        CheckedContextClause(syntax)
+    }
+    fn raw(&self) -> ContextClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedContextClause {
+    pub fn context_items(&self) -> impl Iterator<Item = CheckedContextItem> + use<'_> {
+        self.0
+            .context_items()
+            .map(CheckedContextItem::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedContextDeclaration(ContextDeclarationSyntax);
+impl CheckedNode for CheckedContextDeclaration {
+    type Syntax = ContextDeclarationSyntax;
+    fn cast_unchecked(syntax: ContextDeclarationSyntax) -> Self {
+        CheckedContextDeclaration(syntax)
+    }
+    fn raw(&self) -> ContextDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedContextDeclaration {
+    pub fn context_declaration_preamble(&self) -> CheckedContextDeclarationPreamble {
+        CheckedContextDeclarationPreamble::cast_unchecked(
+            self.0.context_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn context_clause(&self) -> Option<CheckedContextClause> {
+        self.0
+            .context_clause()
+            .map(CheckedContextClause::cast_unchecked)
+    }
+    pub fn context_declaration_epilogue(&self) -> CheckedContextDeclarationEpilogue {
+        CheckedContextDeclarationEpilogue::cast_unchecked(
+            self.0.context_declaration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedContextDeclarationPreamble(ContextDeclarationPreambleSyntax);
+impl CheckedNode for CheckedContextDeclarationPreamble {
+    type Syntax = ContextDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: ContextDeclarationPreambleSyntax) -> Self {
+        CheckedContextDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> ContextDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedContextDeclarationPreamble {
+    pub fn context_token(&self) -> SyntaxToken {
+        self.0.context_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedContextDeclarationEpilogue(ContextDeclarationEpilogueSyntax);
+impl CheckedNode for CheckedContextDeclarationEpilogue {
+    type Syntax = ContextDeclarationEpilogueSyntax;
+    fn cast_unchecked(syntax: ContextDeclarationEpilogueSyntax) -> Self {
+        CheckedContextDeclarationEpilogue(syntax)
+    }
+    fn raw(&self) -> ContextDeclarationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedContextDeclarationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn context_token(&self) -> Option<SyntaxToken> {
+        self.0.context_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUseClauseContextItem(UseClauseContextItemSyntax);
+impl CheckedNode for CheckedUseClauseContextItem {
+    type Syntax = UseClauseContextItemSyntax;
+    fn cast_unchecked(syntax: UseClauseContextItemSyntax) -> Self {
+        CheckedUseClauseContextItem(syntax)
+    }
+    fn raw(&self) -> UseClauseContextItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUseClauseContextItem {
+    pub fn use_clause(&self) -> CheckedUseClause {
+        CheckedUseClause::cast_unchecked(self.0.use_clause().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedContextReference(ContextReferenceSyntax);
+impl CheckedNode for CheckedContextReference {
+    type Syntax = ContextReferenceSyntax;
+    fn cast_unchecked(syntax: ContextReferenceSyntax) -> Self {
+        CheckedContextReference(syntax)
+    }
+    fn raw(&self) -> ContextReferenceSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedContextReference {
+    pub fn context_token(&self) -> SyntaxToken {
+        self.0.context_token().unwrap()
+    }
+    pub fn name_list(&self) -> Option<CheckedNameList> {
+        self.0.name_list().map(CheckedNameList::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedContextItem {
+    LibraryClause(CheckedLibraryClause),
+    UseClauseContextItem(CheckedUseClauseContextItem),
+    ContextReference(CheckedContextReference),
+}
+impl CheckedNode for CheckedContextItem {
+    type Syntax = ContextItemSyntax;
+    fn cast_unchecked(syntax: ContextItemSyntax) -> Self {
+        match syntax {
+            ContextItemSyntax::LibraryClause(inner) => {
+                CheckedContextItem::LibraryClause(CheckedLibraryClause::cast_unchecked(inner))
+            }
+            ContextItemSyntax::UseClauseContextItem(inner) => {
+                CheckedContextItem::UseClauseContextItem(
+                    CheckedUseClauseContextItem::cast_unchecked(inner),
+                )
+            }
+            ContextItemSyntax::ContextReference(inner) => {
+                CheckedContextItem::ContextReference(CheckedContextReference::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedContextItem::LibraryClause(inner) => {
+                ContextItemSyntax::LibraryClause(inner.raw())
+            }
+            CheckedContextItem::UseClauseContextItem(inner) => {
+                ContextItemSyntax::UseClauseContextItem(inner.raw())
+            }
+            CheckedContextItem::ContextReference(inner) => {
+                ContextItemSyntax::ContextReference(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedDesignFile(DesignFileSyntax);
+impl CheckedNode for CheckedDesignFile {
+    type Syntax = DesignFileSyntax;
+    fn cast_unchecked(syntax: DesignFileSyntax) -> Self {
+        CheckedDesignFile(syntax)
+    }
+    fn raw(&self) -> DesignFileSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDesignFile {
+    pub fn design_units(&self) -> impl Iterator<Item = CheckedDesignUnit> + use<'_> {
+        self.0.design_units().map(CheckedDesignUnit::cast_unchecked)
+    }
+    pub fn eof_token(&self) -> SyntaxToken {
+        self.0.eof_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedDesignUnit(DesignUnitSyntax);
+impl CheckedNode for CheckedDesignUnit {
+    type Syntax = DesignUnitSyntax;
+    fn cast_unchecked(syntax: DesignUnitSyntax) -> Self {
+        CheckedDesignUnit(syntax)
+    }
+    fn raw(&self) -> DesignUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDesignUnit {
+    pub fn context_clause(&self) -> Option<CheckedContextClause> {
+        self.0
+            .context_clause()
+            .map(CheckedContextClause::cast_unchecked)
+    }
+    pub fn library_unit(&self) -> CheckedLibraryUnit {
+        CheckedLibraryUnit::cast_unchecked(self.0.library_unit().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLibraryClause(LibraryClauseSyntax);
+impl CheckedNode for CheckedLibraryClause {
+    type Syntax = LibraryClauseSyntax;
+    fn cast_unchecked(syntax: LibraryClauseSyntax) -> Self {
+        CheckedLibraryClause(syntax)
+    }
+    fn raw(&self) -> LibraryClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLibraryClause {
+    pub fn library_token(&self) -> SyntaxToken {
+        self.0.library_token().unwrap()
+    }
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedLibraryUnit {
+    PrimaryUnit(CheckedPrimaryUnit),
+    SecondaryUnit(CheckedSecondaryUnit),
+}
+impl CheckedNode for CheckedLibraryUnit {
+    type Syntax = LibraryUnitSyntax;
+    fn cast_unchecked(syntax: LibraryUnitSyntax) -> Self {
+        match syntax {
+            LibraryUnitSyntax::PrimaryUnit(inner) => {
+                CheckedLibraryUnit::PrimaryUnit(CheckedPrimaryUnit::cast_unchecked(inner))
+            }
+            LibraryUnitSyntax::SecondaryUnit(inner) => {
+                CheckedLibraryUnit::SecondaryUnit(CheckedSecondaryUnit::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedLibraryUnit::PrimaryUnit(inner) => LibraryUnitSyntax::PrimaryUnit(inner.raw()),
+            CheckedLibraryUnit::SecondaryUnit(inner) => {
+                LibraryUnitSyntax::SecondaryUnit(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPrimaryUnitPackageDeclaration(PrimaryUnitPackageDeclarationSyntax);
+impl CheckedNode for CheckedPrimaryUnitPackageDeclaration {
+    type Syntax = PrimaryUnitPackageDeclarationSyntax;
+    fn cast_unchecked(syntax: PrimaryUnitPackageDeclarationSyntax) -> Self {
+        CheckedPrimaryUnitPackageDeclaration(syntax)
+    }
+    fn raw(&self) -> PrimaryUnitPackageDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPrimaryUnitPackageDeclaration {
+    pub fn package(&self) -> CheckedPackage {
+        CheckedPackage::cast_unchecked(self.0.package().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageInstantiationDeclarationPrimaryUnit(
+    PackageInstantiationDeclarationPrimaryUnitSyntax,
+);
+impl CheckedNode for CheckedPackageInstantiationDeclarationPrimaryUnit {
+    type Syntax = PackageInstantiationDeclarationPrimaryUnitSyntax;
+    fn cast_unchecked(syntax: PackageInstantiationDeclarationPrimaryUnitSyntax) -> Self {
+        CheckedPackageInstantiationDeclarationPrimaryUnit(syntax)
+    }
+    fn raw(&self) -> PackageInstantiationDeclarationPrimaryUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageInstantiationDeclarationPrimaryUnit {
+    pub fn package_instantiation(&self) -> CheckedPackageInstantiation {
+        CheckedPackageInstantiation::cast_unchecked(self.0.package_instantiation().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedPrimaryUnit {
+    EntityDeclaration(CheckedEntityDeclaration),
+    ConfigurationDeclaration(CheckedConfigurationDeclaration),
+    PrimaryUnitPackageDeclaration(CheckedPrimaryUnitPackageDeclaration),
+    PackageInstantiationDeclarationPrimaryUnit(CheckedPackageInstantiationDeclarationPrimaryUnit),
+    ContextDeclaration(CheckedContextDeclaration),
+    PslVerificationUnit(CheckedPslVerificationUnit),
+}
+impl CheckedNode for CheckedPrimaryUnit {
+    type Syntax = PrimaryUnitSyntax;
+    fn cast_unchecked(syntax: PrimaryUnitSyntax) -> Self {
+        match syntax {
+            PrimaryUnitSyntax::EntityDeclaration(inner) => CheckedPrimaryUnit::EntityDeclaration(
+                CheckedEntityDeclaration::cast_unchecked(inner),
+            ),
+            PrimaryUnitSyntax::ConfigurationDeclaration(inner) => {
+                CheckedPrimaryUnit::ConfigurationDeclaration(
+                    CheckedConfigurationDeclaration::cast_unchecked(inner),
+                )
+            }
+            PrimaryUnitSyntax::PrimaryUnitPackageDeclaration(inner) => {
+                CheckedPrimaryUnit::PrimaryUnitPackageDeclaration(
+                    CheckedPrimaryUnitPackageDeclaration::cast_unchecked(inner),
+                )
+            }
+            PrimaryUnitSyntax::PackageInstantiationDeclarationPrimaryUnit(inner) => {
+                CheckedPrimaryUnit::PackageInstantiationDeclarationPrimaryUnit(
+                    CheckedPackageInstantiationDeclarationPrimaryUnit::cast_unchecked(inner),
+                )
+            }
+            PrimaryUnitSyntax::ContextDeclaration(inner) => CheckedPrimaryUnit::ContextDeclaration(
+                CheckedContextDeclaration::cast_unchecked(inner),
+            ),
+            PrimaryUnitSyntax::PslVerificationUnit(inner) => {
+                CheckedPrimaryUnit::PslVerificationUnit(CheckedPslVerificationUnit::cast_unchecked(
+                    inner,
+                ))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedPrimaryUnit::EntityDeclaration(inner) => {
+                PrimaryUnitSyntax::EntityDeclaration(inner.raw())
+            }
+            CheckedPrimaryUnit::ConfigurationDeclaration(inner) => {
+                PrimaryUnitSyntax::ConfigurationDeclaration(inner.raw())
+            }
+            CheckedPrimaryUnit::PrimaryUnitPackageDeclaration(inner) => {
+                PrimaryUnitSyntax::PrimaryUnitPackageDeclaration(inner.raw())
+            }
+            CheckedPrimaryUnit::PackageInstantiationDeclarationPrimaryUnit(inner) => {
+                PrimaryUnitSyntax::PackageInstantiationDeclarationPrimaryUnit(inner.raw())
+            }
+            CheckedPrimaryUnit::ContextDeclaration(inner) => {
+                PrimaryUnitSyntax::ContextDeclaration(inner.raw())
+            }
+            CheckedPrimaryUnit::PslVerificationUnit(inner) => {
+                PrimaryUnitSyntax::PslVerificationUnit(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSecondaryUnitPackageBody(SecondaryUnitPackageBodySyntax);
+impl CheckedNode for CheckedSecondaryUnitPackageBody {
+    type Syntax = SecondaryUnitPackageBodySyntax;
+    fn cast_unchecked(syntax: SecondaryUnitPackageBodySyntax) -> Self {
+        CheckedSecondaryUnitPackageBody(syntax)
+    }
+    fn raw(&self) -> SecondaryUnitPackageBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSecondaryUnitPackageBody {
+    pub fn package_body(&self) -> CheckedPackageBody {
+        CheckedPackageBody::cast_unchecked(self.0.package_body().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSecondaryUnit {
+    ArchitectureBody(CheckedArchitectureBody),
+    SecondaryUnitPackageBody(CheckedSecondaryUnitPackageBody),
+}
+impl CheckedNode for CheckedSecondaryUnit {
+    type Syntax = SecondaryUnitSyntax;
+    fn cast_unchecked(syntax: SecondaryUnitSyntax) -> Self {
+        match syntax {
+            SecondaryUnitSyntax::ArchitectureBody(inner) => CheckedSecondaryUnit::ArchitectureBody(
+                CheckedArchitectureBody::cast_unchecked(inner),
+            ),
+            SecondaryUnitSyntax::SecondaryUnitPackageBody(inner) => {
+                CheckedSecondaryUnit::SecondaryUnitPackageBody(
+                    CheckedSecondaryUnitPackageBody::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSecondaryUnit::ArchitectureBody(inner) => {
+                SecondaryUnitSyntax::ArchitectureBody(inner.raw())
+            }
+            CheckedSecondaryUnit::SecondaryUnitPackageBody(inner) => {
+                SecondaryUnitSyntax::SecondaryUnitPackageBody(inner.raw())
+            }
+        }
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/expression.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/expression.rs
@@ -1,0 +1,470 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedExpressionOrAggregate(ParenthesizedExpressionOrAggregateSyntax);
+impl CheckedNode for CheckedParenthesizedExpressionOrAggregate {
+    type Syntax = ParenthesizedExpressionOrAggregateSyntax;
+    fn cast_unchecked(syntax: ParenthesizedExpressionOrAggregateSyntax) -> Self {
+        CheckedParenthesizedExpressionOrAggregate(syntax)
+    }
+    fn raw(&self) -> ParenthesizedExpressionOrAggregateSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedExpressionOrAggregate {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn element_associations(
+        &self,
+    ) -> impl Iterator<Item = CheckedElementAssociation> + use<'_> {
+        self.0
+            .element_associations()
+            .map(CheckedElementAssociation::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUnaryExpression(UnaryExpressionSyntax);
+impl CheckedNode for CheckedUnaryExpression {
+    type Syntax = UnaryExpressionSyntax;
+    fn cast_unchecked(syntax: UnaryExpressionSyntax) -> Self {
+        CheckedUnaryExpression(syntax)
+    }
+    fn raw(&self) -> UnaryExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUnaryExpression {
+    pub fn op(&self) -> UnaryOperatorSyntax {
+        self.0.op().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBinaryExpression(BinaryExpressionSyntax);
+impl CheckedNode for CheckedBinaryExpression {
+    type Syntax = BinaryExpressionSyntax;
+    fn cast_unchecked(syntax: BinaryExpressionSyntax) -> Self {
+        CheckedBinaryExpression(syntax)
+    }
+    fn raw(&self) -> BinaryExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBinaryExpression {
+    pub fn lhs(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.lhs().unwrap())
+    }
+    pub fn op(&self) -> BinaryOperatorSyntax {
+        self.0.op().unwrap()
+    }
+    pub fn rhs(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.rhs().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLiteralExpression(LiteralExpressionSyntax);
+impl CheckedNode for CheckedLiteralExpression {
+    type Syntax = LiteralExpressionSyntax;
+    fn cast_unchecked(syntax: LiteralExpressionSyntax) -> Self {
+        CheckedLiteralExpression(syntax)
+    }
+    fn raw(&self) -> LiteralExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLiteralExpression {
+    pub fn literal(&self) -> LiteralSyntax {
+        self.0.literal().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPhysicalLiteralExpression(PhysicalLiteralExpressionSyntax);
+impl CheckedNode for CheckedPhysicalLiteralExpression {
+    type Syntax = PhysicalLiteralExpressionSyntax;
+    fn cast_unchecked(syntax: PhysicalLiteralExpressionSyntax) -> Self {
+        CheckedPhysicalLiteralExpression(syntax)
+    }
+    fn raw(&self) -> PhysicalLiteralExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPhysicalLiteralExpression {
+    pub fn physical_literal(&self) -> CheckedPhysicalLiteral {
+        CheckedPhysicalLiteral::cast_unchecked(self.0.physical_literal().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNameExpression(NameExpressionSyntax);
+impl CheckedNode for CheckedNameExpression {
+    type Syntax = NameExpressionSyntax;
+    fn cast_unchecked(syntax: NameExpressionSyntax) -> Self {
+        CheckedNameExpression(syntax)
+    }
+    fn raw(&self) -> NameExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNameExpression {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedExpression {
+    LiteralExpression(CheckedLiteralExpression),
+    PhysicalLiteralExpression(CheckedPhysicalLiteralExpression),
+    UnaryExpression(CheckedUnaryExpression),
+    BinaryExpression(CheckedBinaryExpression),
+    ParenthesizedExpressionOrAggregate(CheckedParenthesizedExpressionOrAggregate),
+    Allocator(CheckedAllocator),
+    QualifiedExpression(CheckedQualifiedExpression),
+    TypeConversion(CheckedTypeConversion),
+    NameExpression(CheckedNameExpression),
+}
+impl CheckedNode for CheckedExpression {
+    type Syntax = ExpressionSyntax;
+    fn cast_unchecked(syntax: ExpressionSyntax) -> Self {
+        match syntax {
+            ExpressionSyntax::LiteralExpression(inner) => CheckedExpression::LiteralExpression(
+                CheckedLiteralExpression::cast_unchecked(inner),
+            ),
+            ExpressionSyntax::PhysicalLiteralExpression(inner) => {
+                CheckedExpression::PhysicalLiteralExpression(
+                    CheckedPhysicalLiteralExpression::cast_unchecked(inner),
+                )
+            }
+            ExpressionSyntax::UnaryExpression(inner) => {
+                CheckedExpression::UnaryExpression(CheckedUnaryExpression::cast_unchecked(inner))
+            }
+            ExpressionSyntax::BinaryExpression(inner) => {
+                CheckedExpression::BinaryExpression(CheckedBinaryExpression::cast_unchecked(inner))
+            }
+            ExpressionSyntax::ParenthesizedExpressionOrAggregate(inner) => {
+                CheckedExpression::ParenthesizedExpressionOrAggregate(
+                    CheckedParenthesizedExpressionOrAggregate::cast_unchecked(inner),
+                )
+            }
+            ExpressionSyntax::Allocator(inner) => {
+                CheckedExpression::Allocator(CheckedAllocator::cast_unchecked(inner))
+            }
+            ExpressionSyntax::QualifiedExpression(inner) => CheckedExpression::QualifiedExpression(
+                CheckedQualifiedExpression::cast_unchecked(inner),
+            ),
+            ExpressionSyntax::TypeConversion(inner) => {
+                CheckedExpression::TypeConversion(CheckedTypeConversion::cast_unchecked(inner))
+            }
+            ExpressionSyntax::NameExpression(inner) => {
+                CheckedExpression::NameExpression(CheckedNameExpression::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedExpression::LiteralExpression(inner) => {
+                ExpressionSyntax::LiteralExpression(inner.raw())
+            }
+            CheckedExpression::PhysicalLiteralExpression(inner) => {
+                ExpressionSyntax::PhysicalLiteralExpression(inner.raw())
+            }
+            CheckedExpression::UnaryExpression(inner) => {
+                ExpressionSyntax::UnaryExpression(inner.raw())
+            }
+            CheckedExpression::BinaryExpression(inner) => {
+                ExpressionSyntax::BinaryExpression(inner.raw())
+            }
+            CheckedExpression::ParenthesizedExpressionOrAggregate(inner) => {
+                ExpressionSyntax::ParenthesizedExpressionOrAggregate(inner.raw())
+            }
+            CheckedExpression::Allocator(inner) => ExpressionSyntax::Allocator(inner.raw()),
+            CheckedExpression::QualifiedExpression(inner) => {
+                ExpressionSyntax::QualifiedExpression(inner.raw())
+            }
+            CheckedExpression::TypeConversion(inner) => {
+                ExpressionSyntax::TypeConversion(inner.raw())
+            }
+            CheckedExpression::NameExpression(inner) => {
+                ExpressionSyntax::NameExpression(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAggregate(AggregateSyntax);
+impl CheckedNode for CheckedAggregate {
+    type Syntax = AggregateSyntax;
+    fn cast_unchecked(syntax: AggregateSyntax) -> Self {
+        CheckedAggregate(syntax)
+    }
+    fn raw(&self) -> AggregateSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAggregate {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn element_associations(
+        &self,
+    ) -> impl Iterator<Item = CheckedElementAssociation> + use<'_> {
+        self.0
+            .element_associations()
+            .map(CheckedElementAssociation::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubtypeIndicationAllocator(SubtypeIndicationAllocatorSyntax);
+impl CheckedNode for CheckedSubtypeIndicationAllocator {
+    type Syntax = SubtypeIndicationAllocatorSyntax;
+    fn cast_unchecked(syntax: SubtypeIndicationAllocatorSyntax) -> Self {
+        CheckedSubtypeIndicationAllocator(syntax)
+    }
+    fn raw(&self) -> SubtypeIndicationAllocatorSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubtypeIndicationAllocator {
+    pub fn new_token(&self) -> SyntaxToken {
+        self.0.new_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExpressionAllocator(ExpressionAllocatorSyntax);
+impl CheckedNode for CheckedExpressionAllocator {
+    type Syntax = ExpressionAllocatorSyntax;
+    fn cast_unchecked(syntax: ExpressionAllocatorSyntax) -> Self {
+        CheckedExpressionAllocator(syntax)
+    }
+    fn raw(&self) -> ExpressionAllocatorSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExpressionAllocator {
+    pub fn new_token(&self) -> SyntaxToken {
+        self.0.new_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedAllocator {
+    SubtypeIndicationAllocator(CheckedSubtypeIndicationAllocator),
+    ExpressionAllocator(CheckedExpressionAllocator),
+}
+impl CheckedNode for CheckedAllocator {
+    type Syntax = AllocatorSyntax;
+    fn cast_unchecked(syntax: AllocatorSyntax) -> Self {
+        match syntax {
+            AllocatorSyntax::SubtypeIndicationAllocator(inner) => {
+                CheckedAllocator::SubtypeIndicationAllocator(
+                    CheckedSubtypeIndicationAllocator::cast_unchecked(inner),
+                )
+            }
+            AllocatorSyntax::ExpressionAllocator(inner) => CheckedAllocator::ExpressionAllocator(
+                CheckedExpressionAllocator::cast_unchecked(inner),
+            ),
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedAllocator::SubtypeIndicationAllocator(inner) => {
+                AllocatorSyntax::SubtypeIndicationAllocator(inner.raw())
+            }
+            CheckedAllocator::ExpressionAllocator(inner) => {
+                AllocatorSyntax::ExpressionAllocator(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedOthersChoice(OthersChoiceSyntax);
+impl CheckedNode for CheckedOthersChoice {
+    type Syntax = OthersChoiceSyntax;
+    fn cast_unchecked(syntax: OthersChoiceSyntax) -> Self {
+        CheckedOthersChoice(syntax)
+    }
+    fn raw(&self) -> OthersChoiceSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedOthersChoice {
+    pub fn others_token(&self) -> SyntaxToken {
+        self.0.others_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExpressionChoice(ExpressionChoiceSyntax);
+impl CheckedNode for CheckedExpressionChoice {
+    type Syntax = ExpressionChoiceSyntax;
+    fn cast_unchecked(syntax: ExpressionChoiceSyntax) -> Self {
+        CheckedExpressionChoice(syntax)
+    }
+    fn raw(&self) -> ExpressionChoiceSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExpressionChoice {
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedDiscreteRangeChoice(DiscreteRangeChoiceSyntax);
+impl CheckedNode for CheckedDiscreteRangeChoice {
+    type Syntax = DiscreteRangeChoiceSyntax;
+    fn cast_unchecked(syntax: DiscreteRangeChoiceSyntax) -> Self {
+        CheckedDiscreteRangeChoice(syntax)
+    }
+    fn raw(&self) -> DiscreteRangeChoiceSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDiscreteRangeChoice {
+    pub fn discrete_range(&self) -> CheckedDiscreteRange {
+        CheckedDiscreteRange::cast_unchecked(self.0.discrete_range().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedChoice {
+    ExpressionChoice(CheckedExpressionChoice),
+    OthersChoice(CheckedOthersChoice),
+    DiscreteRangeChoice(CheckedDiscreteRangeChoice),
+}
+impl CheckedNode for CheckedChoice {
+    type Syntax = ChoiceSyntax;
+    fn cast_unchecked(syntax: ChoiceSyntax) -> Self {
+        match syntax {
+            ChoiceSyntax::ExpressionChoice(inner) => {
+                CheckedChoice::ExpressionChoice(CheckedExpressionChoice::cast_unchecked(inner))
+            }
+            ChoiceSyntax::OthersChoice(inner) => {
+                CheckedChoice::OthersChoice(CheckedOthersChoice::cast_unchecked(inner))
+            }
+            ChoiceSyntax::DiscreteRangeChoice(inner) => CheckedChoice::DiscreteRangeChoice(
+                CheckedDiscreteRangeChoice::cast_unchecked(inner),
+            ),
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedChoice::ExpressionChoice(inner) => ChoiceSyntax::ExpressionChoice(inner.raw()),
+            CheckedChoice::OthersChoice(inner) => ChoiceSyntax::OthersChoice(inner.raw()),
+            CheckedChoice::DiscreteRangeChoice(inner) => {
+                ChoiceSyntax::DiscreteRangeChoice(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedChoices(ChoicesSyntax);
+impl CheckedNode for CheckedChoices {
+    type Syntax = ChoicesSyntax;
+    fn cast_unchecked(syntax: ChoicesSyntax) -> Self {
+        CheckedChoices(syntax)
+    }
+    fn raw(&self) -> ChoicesSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedChoices {
+    pub fn choices(&self) -> impl Iterator<Item = CheckedChoice> + use<'_> {
+        self.0.choices().map(CheckedChoice::cast_unchecked)
+    }
+    pub fn bar_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.bar_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedElementAssociation(ElementAssociationSyntax);
+impl CheckedNode for CheckedElementAssociation {
+    type Syntax = ElementAssociationSyntax;
+    fn cast_unchecked(syntax: ElementAssociationSyntax) -> Self {
+        CheckedElementAssociation(syntax)
+    }
+    fn raw(&self) -> ElementAssociationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedElementAssociation {
+    pub fn choice(&self) -> CheckedChoice {
+        CheckedChoice::cast_unchecked(self.0.choice().unwrap())
+    }
+    pub fn right_arrow_token(&self) -> SyntaxToken {
+        self.0.right_arrow_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedQualifiedExpression(QualifiedExpressionSyntax);
+impl CheckedNode for CheckedQualifiedExpression {
+    type Syntax = QualifiedExpressionSyntax;
+    fn cast_unchecked(syntax: QualifiedExpressionSyntax) -> Self {
+        CheckedQualifiedExpression(syntax)
+    }
+    fn raw(&self) -> QualifiedExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedQualifiedExpression {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn tick_token(&self) -> SyntaxToken {
+        self.0.tick_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedTypeConversion(TypeConversionSyntax);
+impl CheckedNode for CheckedTypeConversion {
+    type Syntax = TypeConversionSyntax;
+    fn cast_unchecked(syntax: TypeConversionSyntax) -> Self {
+        CheckedTypeConversion(syntax)
+    }
+    fn raw(&self) -> TypeConversionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedTypeConversion {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/mod.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/mod.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+pub mod concurrent_statements;
+pub use concurrent_statements::*;
+pub mod declarations;
+pub use declarations::*;
+pub mod design_entities;
+pub use design_entities::*;
+pub mod design_units;
+pub use design_units::*;
+pub mod expression;
+pub use expression::*;
+pub mod names;
+pub use names::*;
+pub mod psl;
+pub use psl::*;
+pub mod scope_and_visibility;
+pub use scope_and_visibility::*;
+pub mod sequential_statements;
+pub use sequential_statements::*;
+pub mod specifications;
+pub use specifications::*;
+pub mod subprograms_packages;
+pub use subprograms_packages::*;
+pub mod types;
+pub use types::*;

--- a/vhdl_syntax/src/syntax/checked/generated/names.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/names.rs
@@ -1,0 +1,467 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedAbsolutePathname(AbsolutePathnameSyntax);
+impl CheckedNode for CheckedAbsolutePathname {
+    type Syntax = AbsolutePathnameSyntax;
+    fn cast_unchecked(syntax: AbsolutePathnameSyntax) -> Self {
+        CheckedAbsolutePathname(syntax)
+    }
+    fn raw(&self) -> AbsolutePathnameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAbsolutePathname {
+    pub fn dot_token(&self) -> SyntaxToken {
+        self.0.dot_token().unwrap()
+    }
+    pub fn partial_pathname(&self) -> Option<CheckedPartialPathname> {
+        self.0
+            .partial_pathname()
+            .map(CheckedPartialPathname::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAttributeName(AttributeNameSyntax);
+impl CheckedNode for CheckedAttributeName {
+    type Syntax = AttributeNameSyntax;
+    fn cast_unchecked(syntax: AttributeNameSyntax) -> Self {
+        CheckedAttributeName(syntax)
+    }
+    fn raw(&self) -> AttributeNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAttributeName {
+    pub fn left_square_token(&self) -> SyntaxToken {
+        self.0.left_square_token().unwrap()
+    }
+    pub fn signature(&self) -> CheckedSignature {
+        CheckedSignature::cast_unchecked(self.0.signature().unwrap())
+    }
+    pub fn right_square_token(&self) -> SyntaxToken {
+        self.0.right_square_token().unwrap()
+    }
+    pub fn tick_token(&self) -> SyntaxToken {
+        self.0.tick_token().unwrap()
+    }
+    pub fn attribute_designator_token_token(&self) -> SyntaxToken {
+        self.0.attribute_designator_token_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedExternalName {
+    ExternalConstantName(CheckedExternalConstantName),
+    ExternalSignalName(CheckedExternalSignalName),
+    ExternalVariableName(CheckedExternalVariableName),
+}
+impl CheckedNode for CheckedExternalName {
+    type Syntax = ExternalNameSyntax;
+    fn cast_unchecked(syntax: ExternalNameSyntax) -> Self {
+        match syntax {
+            ExternalNameSyntax::ExternalConstantName(inner) => {
+                CheckedExternalName::ExternalConstantName(
+                    CheckedExternalConstantName::cast_unchecked(inner),
+                )
+            }
+            ExternalNameSyntax::ExternalSignalName(inner) => {
+                CheckedExternalName::ExternalSignalName(CheckedExternalSignalName::cast_unchecked(
+                    inner,
+                ))
+            }
+            ExternalNameSyntax::ExternalVariableName(inner) => {
+                CheckedExternalName::ExternalVariableName(
+                    CheckedExternalVariableName::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedExternalName::ExternalConstantName(inner) => {
+                ExternalNameSyntax::ExternalConstantName(inner.raw())
+            }
+            CheckedExternalName::ExternalSignalName(inner) => {
+                ExternalNameSyntax::ExternalSignalName(inner.raw())
+            }
+            CheckedExternalName::ExternalVariableName(inner) => {
+                ExternalNameSyntax::ExternalVariableName(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExternalConstantName(ExternalConstantNameSyntax);
+impl CheckedNode for CheckedExternalConstantName {
+    type Syntax = ExternalConstantNameSyntax;
+    fn cast_unchecked(syntax: ExternalConstantNameSyntax) -> Self {
+        CheckedExternalConstantName(syntax)
+    }
+    fn raw(&self) -> ExternalConstantNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExternalConstantName {
+    pub fn lt_lt_token(&self) -> SyntaxToken {
+        self.0.lt_lt_token().unwrap()
+    }
+    pub fn constant_token(&self) -> SyntaxToken {
+        self.0.constant_token().unwrap()
+    }
+    pub fn external_path_name(&self) -> CheckedExternalPathName {
+        CheckedExternalPathName::cast_unchecked(self.0.external_path_name().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn gt_gt_token(&self) -> SyntaxToken {
+        self.0.gt_gt_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExternalSignalName(ExternalSignalNameSyntax);
+impl CheckedNode for CheckedExternalSignalName {
+    type Syntax = ExternalSignalNameSyntax;
+    fn cast_unchecked(syntax: ExternalSignalNameSyntax) -> Self {
+        CheckedExternalSignalName(syntax)
+    }
+    fn raw(&self) -> ExternalSignalNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExternalSignalName {
+    pub fn lt_lt_token(&self) -> SyntaxToken {
+        self.0.lt_lt_token().unwrap()
+    }
+    pub fn signal_token(&self) -> SyntaxToken {
+        self.0.signal_token().unwrap()
+    }
+    pub fn external_path_name(&self) -> CheckedExternalPathName {
+        CheckedExternalPathName::cast_unchecked(self.0.external_path_name().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn gt_gt_token(&self) -> SyntaxToken {
+        self.0.gt_gt_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExternalVariableName(ExternalVariableNameSyntax);
+impl CheckedNode for CheckedExternalVariableName {
+    type Syntax = ExternalVariableNameSyntax;
+    fn cast_unchecked(syntax: ExternalVariableNameSyntax) -> Self {
+        CheckedExternalVariableName(syntax)
+    }
+    fn raw(&self) -> ExternalVariableNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExternalVariableName {
+    pub fn lt_lt_token(&self) -> SyntaxToken {
+        self.0.lt_lt_token().unwrap()
+    }
+    pub fn variable_token(&self) -> SyntaxToken {
+        self.0.variable_token().unwrap()
+    }
+    pub fn external_path_name(&self) -> CheckedExternalPathName {
+        CheckedExternalPathName::cast_unchecked(self.0.external_path_name().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn gt_gt_token(&self) -> SyntaxToken {
+        self.0.gt_gt_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedExternalPathName {
+    PackagePathname(CheckedPackagePathname),
+    AbsolutePathname(CheckedAbsolutePathname),
+    RelativePathname(CheckedRelativePathname),
+}
+impl CheckedNode for CheckedExternalPathName {
+    type Syntax = ExternalPathNameSyntax;
+    fn cast_unchecked(syntax: ExternalPathNameSyntax) -> Self {
+        match syntax {
+            ExternalPathNameSyntax::PackagePathname(inner) => {
+                CheckedExternalPathName::PackagePathname(CheckedPackagePathname::cast_unchecked(
+                    inner,
+                ))
+            }
+            ExternalPathNameSyntax::AbsolutePathname(inner) => {
+                CheckedExternalPathName::AbsolutePathname(CheckedAbsolutePathname::cast_unchecked(
+                    inner,
+                ))
+            }
+            ExternalPathNameSyntax::RelativePathname(inner) => {
+                CheckedExternalPathName::RelativePathname(CheckedRelativePathname::cast_unchecked(
+                    inner,
+                ))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedExternalPathName::PackagePathname(inner) => {
+                ExternalPathNameSyntax::PackagePathname(inner.raw())
+            }
+            CheckedExternalPathName::AbsolutePathname(inner) => {
+                ExternalPathNameSyntax::AbsolutePathname(inner.raw())
+            }
+            CheckedExternalPathName::RelativePathname(inner) => {
+                ExternalPathNameSyntax::RelativePathname(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackagePathname(PackagePathnameSyntax);
+impl CheckedNode for CheckedPackagePathname {
+    type Syntax = PackagePathnameSyntax;
+    fn cast_unchecked(syntax: PackagePathnameSyntax) -> Self {
+        CheckedPackagePathname(syntax)
+    }
+    fn raw(&self) -> PackagePathnameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackagePathname {
+    pub fn comm_at_token(&self) -> SyntaxToken {
+        self.0.comm_at_token().unwrap()
+    }
+    pub fn dot_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.dot_token()
+    }
+    pub fn simple_name_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.simple_name_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRelativePathname(RelativePathnameSyntax);
+impl CheckedNode for CheckedRelativePathname {
+    type Syntax = RelativePathnameSyntax;
+    fn cast_unchecked(syntax: RelativePathnameSyntax) -> Self {
+        CheckedRelativePathname(syntax)
+    }
+    fn raw(&self) -> RelativePathnameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRelativePathname {
+    pub fn circ_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.circ_token()
+    }
+    pub fn dot_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.dot_token()
+    }
+    pub fn partial_pathname(&self) -> Option<CheckedPartialPathname> {
+        self.0
+            .partial_pathname()
+            .map(CheckedPartialPathname::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPartialPathname(PartialPathnameSyntax);
+impl CheckedNode for CheckedPartialPathname {
+    type Syntax = PartialPathnameSyntax;
+    fn cast_unchecked(syntax: PartialPathnameSyntax) -> Self {
+        CheckedPartialPathname(syntax)
+    }
+    fn raw(&self) -> PartialPathnameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPartialPathname {
+    pub fn identifier_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.identifier_token()
+    }
+    pub fn dot_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.dot_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNameList(NameListSyntax);
+impl CheckedNode for CheckedNameList {
+    type Syntax = NameListSyntax;
+    fn cast_unchecked(syntax: NameListSyntax) -> Self {
+        CheckedNameList(syntax)
+    }
+    fn raw(&self) -> NameListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNameList {
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLabel(LabelSyntax);
+impl CheckedNode for CheckedLabel {
+    type Syntax = LabelSyntax;
+    fn cast_unchecked(syntax: LabelSyntax) -> Self {
+        CheckedLabel(syntax)
+    }
+    fn raw(&self) -> LabelSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLabel {
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedName(NameSyntax);
+impl CheckedNode for CheckedName {
+    type Syntax = NameSyntax;
+    fn cast_unchecked(syntax: NameSyntax) -> Self {
+        CheckedName(syntax)
+    }
+    fn raw(&self) -> NameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedName {
+    pub fn name_prefix(&self) -> CheckedNamePrefix {
+        CheckedNamePrefix::cast_unchecked(self.0.name_prefix().unwrap())
+    }
+    pub fn name_tails(&self) -> impl Iterator<Item = CheckedNameTail> + use<'_> {
+        self.0.name_tails().map(CheckedNameTail::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNameDesignatorPrefix(NameDesignatorPrefixSyntax);
+impl CheckedNode for CheckedNameDesignatorPrefix {
+    type Syntax = NameDesignatorPrefixSyntax;
+    fn cast_unchecked(syntax: NameDesignatorPrefixSyntax) -> Self {
+        CheckedNameDesignatorPrefix(syntax)
+    }
+    fn raw(&self) -> NameDesignatorPrefixSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNameDesignatorPrefix {
+    pub fn name_designator(&self) -> NameDesignatorSyntax {
+        self.0.name_designator().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedNamePrefix {
+    ExternalName(CheckedExternalName),
+    NameDesignatorPrefix(CheckedNameDesignatorPrefix),
+}
+impl CheckedNode for CheckedNamePrefix {
+    type Syntax = NamePrefixSyntax;
+    fn cast_unchecked(syntax: NamePrefixSyntax) -> Self {
+        match syntax {
+            NamePrefixSyntax::ExternalName(inner) => {
+                CheckedNamePrefix::ExternalName(CheckedExternalName::cast_unchecked(inner))
+            }
+            NamePrefixSyntax::NameDesignatorPrefix(inner) => {
+                CheckedNamePrefix::NameDesignatorPrefix(
+                    CheckedNameDesignatorPrefix::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedNamePrefix::ExternalName(inner) => NamePrefixSyntax::ExternalName(inner.raw()),
+            CheckedNamePrefix::NameDesignatorPrefix(inner) => {
+                NamePrefixSyntax::NameDesignatorPrefix(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedName(SelectedNameSyntax);
+impl CheckedNode for CheckedSelectedName {
+    type Syntax = SelectedNameSyntax;
+    fn cast_unchecked(syntax: SelectedNameSyntax) -> Self {
+        CheckedSelectedName(syntax)
+    }
+    fn raw(&self) -> SelectedNameSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedName {
+    pub fn dot_token(&self) -> SyntaxToken {
+        self.0.dot_token().unwrap()
+    }
+    pub fn suffix(&self) -> SuffixSyntax {
+        self.0.suffix().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedNameTail {
+    SelectedName(CheckedSelectedName),
+    RawTokens(CheckedRawTokens),
+    AttributeName(CheckedAttributeName),
+}
+impl CheckedNode for CheckedNameTail {
+    type Syntax = NameTailSyntax;
+    fn cast_unchecked(syntax: NameTailSyntax) -> Self {
+        match syntax {
+            NameTailSyntax::SelectedName(inner) => {
+                CheckedNameTail::SelectedName(CheckedSelectedName::cast_unchecked(inner))
+            }
+            NameTailSyntax::RawTokens(inner) => {
+                CheckedNameTail::RawTokens(CheckedRawTokens::cast_unchecked(inner))
+            }
+            NameTailSyntax::AttributeName(inner) => {
+                CheckedNameTail::AttributeName(CheckedAttributeName::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedNameTail::SelectedName(inner) => NameTailSyntax::SelectedName(inner.raw()),
+            CheckedNameTail::RawTokens(inner) => NameTailSyntax::RawTokens(inner.raw()),
+            CheckedNameTail::AttributeName(inner) => NameTailSyntax::AttributeName(inner.raw()),
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRawTokens(RawTokensSyntax);
+impl CheckedNode for CheckedRawTokens {
+    type Syntax = RawTokensSyntax;
+    fn cast_unchecked(syntax: RawTokensSyntax) -> Self {
+        CheckedRawTokens(syntax)
+    }
+    fn raw(&self) -> RawTokensSyntax {
+        self.0.clone()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/psl.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/psl.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedPslDirective(PslDirectiveSyntax);
+impl CheckedNode for CheckedPslDirective {
+    type Syntax = PslDirectiveSyntax;
+    fn cast_unchecked(syntax: PslDirectiveSyntax) -> Self {
+        CheckedPslDirective(syntax)
+    }
+    fn raw(&self) -> PslDirectiveSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPslDirective {}
+#[derive(Debug, Clone)]
+pub struct CheckedPslPropertyDeclaration(PslPropertyDeclarationSyntax);
+impl CheckedNode for CheckedPslPropertyDeclaration {
+    type Syntax = PslPropertyDeclarationSyntax;
+    fn cast_unchecked(syntax: PslPropertyDeclarationSyntax) -> Self {
+        CheckedPslPropertyDeclaration(syntax)
+    }
+    fn raw(&self) -> PslPropertyDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPslPropertyDeclaration {}
+#[derive(Debug, Clone)]
+pub struct CheckedPslSequenceDeclaration(PslSequenceDeclarationSyntax);
+impl CheckedNode for CheckedPslSequenceDeclaration {
+    type Syntax = PslSequenceDeclarationSyntax;
+    fn cast_unchecked(syntax: PslSequenceDeclarationSyntax) -> Self {
+        CheckedPslSequenceDeclaration(syntax)
+    }
+    fn raw(&self) -> PslSequenceDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPslSequenceDeclaration {}
+#[derive(Debug, Clone)]
+pub struct CheckedPslClockDeclaration(PslClockDeclarationSyntax);
+impl CheckedNode for CheckedPslClockDeclaration {
+    type Syntax = PslClockDeclarationSyntax;
+    fn cast_unchecked(syntax: PslClockDeclarationSyntax) -> Self {
+        CheckedPslClockDeclaration(syntax)
+    }
+    fn raw(&self) -> PslClockDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPslClockDeclaration {}
+#[derive(Debug, Clone)]
+pub struct CheckedPslVerificationUnit(PslVerificationUnitSyntax);
+impl CheckedNode for CheckedPslVerificationUnit {
+    type Syntax = PslVerificationUnitSyntax;
+    fn cast_unchecked(syntax: PslVerificationUnitSyntax) -> Self {
+        CheckedPslVerificationUnit(syntax)
+    }
+    fn raw(&self) -> PslVerificationUnitSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPslVerificationUnit {}

--- a/vhdl_syntax/src/syntax/checked/generated/scope_and_visibility.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/scope_and_visibility.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedUseClause(UseClauseSyntax);
+impl CheckedNode for CheckedUseClause {
+    type Syntax = UseClauseSyntax;
+    fn cast_unchecked(syntax: UseClauseSyntax) -> Self {
+        CheckedUseClause(syntax)
+    }
+    fn raw(&self) -> UseClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUseClause {
+    pub fn use_token(&self) -> SyntaxToken {
+        self.0.use_token().unwrap()
+    }
+    pub fn name_list(&self) -> Option<CheckedNameList> {
+        self.0.name_list().map(CheckedNameList::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/sequential_statements.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/sequential_statements.rs
@@ -1,0 +1,1915 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedAssertion(AssertionSyntax);
+impl CheckedNode for CheckedAssertion {
+    type Syntax = AssertionSyntax;
+    fn cast_unchecked(syntax: AssertionSyntax) -> Self {
+        CheckedAssertion(syntax)
+    }
+    fn raw(&self) -> AssertionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAssertion {
+    pub fn assert_token(&self) -> SyntaxToken {
+        self.0.assert_token().unwrap()
+    }
+    pub fn condition(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.condition().unwrap())
+    }
+    pub fn report_token(&self) -> Option<SyntaxToken> {
+        self.0.report_token()
+    }
+    pub fn report(&self) -> Option<CheckedExpression> {
+        self.0.report().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn severity_token(&self) -> Option<SyntaxToken> {
+        self.0.severity_token()
+    }
+    pub fn severity(&self) -> Option<CheckedExpression> {
+        self.0.severity().map(CheckedExpression::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAssertionStatement(AssertionStatementSyntax);
+impl CheckedNode for CheckedAssertionStatement {
+    type Syntax = AssertionStatementSyntax;
+    fn cast_unchecked(syntax: AssertionStatementSyntax) -> Self {
+        CheckedAssertionStatement(syntax)
+    }
+    fn raw(&self) -> AssertionStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAssertionStatement {
+    pub fn label_token(&self) -> Option<SyntaxToken> {
+        self.0.label_token()
+    }
+    pub fn colon_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_token()
+    }
+    pub fn assertion(&self) -> CheckedAssertion {
+        CheckedAssertion::cast_unchecked(self.0.assertion().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseStatementAlternative(CaseStatementAlternativeSyntax);
+impl CheckedNode for CheckedCaseStatementAlternative {
+    type Syntax = CaseStatementAlternativeSyntax;
+    fn cast_unchecked(syntax: CaseStatementAlternativeSyntax) -> Self {
+        CheckedCaseStatementAlternative(syntax)
+    }
+    fn raw(&self) -> CaseStatementAlternativeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseStatementAlternative {
+    pub fn case_statement_alternative_preamble(&self) -> CheckedCaseStatementAlternativePreamble {
+        CheckedCaseStatementAlternativePreamble::cast_unchecked(
+            self.0.case_statement_alternative_preamble().unwrap(),
+        )
+    }
+    pub fn sequential_statements(&self) -> Option<CheckedSequentialStatements> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatements::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseStatementAlternativePreamble(CaseStatementAlternativePreambleSyntax);
+impl CheckedNode for CheckedCaseStatementAlternativePreamble {
+    type Syntax = CaseStatementAlternativePreambleSyntax;
+    fn cast_unchecked(syntax: CaseStatementAlternativePreambleSyntax) -> Self {
+        CheckedCaseStatementAlternativePreamble(syntax)
+    }
+    fn raw(&self) -> CaseStatementAlternativePreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseStatementAlternativePreamble {
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn choices(&self) -> Option<CheckedChoices> {
+        self.0.choices().map(CheckedChoices::cast_unchecked)
+    }
+    pub fn right_arrow_token(&self) -> SyntaxToken {
+        self.0.right_arrow_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseStatement(CaseStatementSyntax);
+impl CheckedNode for CheckedCaseStatement {
+    type Syntax = CaseStatementSyntax;
+    fn cast_unchecked(syntax: CaseStatementSyntax) -> Self {
+        CheckedCaseStatement(syntax)
+    }
+    fn raw(&self) -> CaseStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseStatement {
+    pub fn case_statement_preamble(&self) -> CheckedCaseStatementPreamble {
+        CheckedCaseStatementPreamble::cast_unchecked(self.0.case_statement_preamble().unwrap())
+    }
+    pub fn case_statement_alternatives(
+        &self,
+    ) -> impl Iterator<Item = CheckedCaseStatementAlternative> + use<'_> {
+        self.0
+            .case_statement_alternatives()
+            .map(CheckedCaseStatementAlternative::cast_unchecked)
+    }
+    pub fn case_statement_epilogue(&self) -> CheckedCaseStatementEpilogue {
+        CheckedCaseStatementEpilogue::cast_unchecked(self.0.case_statement_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseStatementPreamble(CaseStatementPreambleSyntax);
+impl CheckedNode for CheckedCaseStatementPreamble {
+    type Syntax = CaseStatementPreambleSyntax;
+    fn cast_unchecked(syntax: CaseStatementPreambleSyntax) -> Self {
+        CheckedCaseStatementPreamble(syntax)
+    }
+    fn raw(&self) -> CaseStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseStatementPreamble {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn case_token(&self) -> SyntaxToken {
+        self.0.case_token().unwrap()
+    }
+    pub fn que_token(&self) -> Option<SyntaxToken> {
+        self.0.que_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCaseStatementEpilogue(CaseStatementEpilogueSyntax);
+impl CheckedNode for CheckedCaseStatementEpilogue {
+    type Syntax = CaseStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: CaseStatementEpilogueSyntax) -> Self {
+        CheckedCaseStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> CaseStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCaseStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn case_token(&self) -> SyntaxToken {
+        self.0.case_token().unwrap()
+    }
+    pub fn que_token(&self) -> Option<SyntaxToken> {
+        self.0.que_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionClause(ConditionClauseSyntax);
+impl CheckedNode for CheckedConditionClause {
+    type Syntax = ConditionClauseSyntax;
+    fn cast_unchecked(syntax: ConditionClauseSyntax) -> Self {
+        CheckedConditionClause(syntax)
+    }
+    fn raw(&self) -> ConditionClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionClause {
+    pub fn until_token(&self) -> SyntaxToken {
+        self.0.until_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalElseWhenExpression(ConditionalElseWhenExpressionSyntax);
+impl CheckedNode for CheckedConditionalElseWhenExpression {
+    type Syntax = ConditionalElseWhenExpressionSyntax;
+    fn cast_unchecked(syntax: ConditionalElseWhenExpressionSyntax) -> Self {
+        CheckedConditionalElseWhenExpression(syntax)
+    }
+    fn raw(&self) -> ConditionalElseWhenExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalElseWhenExpression {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn condition(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.condition().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalElseItem(ConditionalElseItemSyntax);
+impl CheckedNode for CheckedConditionalElseItem {
+    type Syntax = ConditionalElseItemSyntax;
+    fn cast_unchecked(syntax: ConditionalElseItemSyntax) -> Self {
+        CheckedConditionalElseItem(syntax)
+    }
+    fn raw(&self) -> ConditionalElseItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalElseItem {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalExpressions(ConditionalExpressionsSyntax);
+impl CheckedNode for CheckedConditionalExpressions {
+    type Syntax = ConditionalExpressionsSyntax;
+    fn cast_unchecked(syntax: ConditionalExpressionsSyntax) -> Self {
+        CheckedConditionalExpressions(syntax)
+    }
+    fn raw(&self) -> ConditionalExpressionsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalExpressions {
+    pub fn conditional_expression(&self) -> CheckedConditionalExpression {
+        CheckedConditionalExpression::cast_unchecked(self.0.conditional_expression().unwrap())
+    }
+    pub fn conditional_else_when_expressions(
+        &self,
+    ) -> impl Iterator<Item = CheckedConditionalElseWhenExpression> + use<'_> {
+        self.0
+            .conditional_else_when_expressions()
+            .map(CheckedConditionalElseWhenExpression::cast_unchecked)
+    }
+    pub fn conditional_else_item(&self) -> Option<CheckedConditionalElseItem> {
+        self.0
+            .conditional_else_item()
+            .map(CheckedConditionalElseItem::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalExpression(ConditionalExpressionSyntax);
+impl CheckedNode for CheckedConditionalExpression {
+    type Syntax = ConditionalExpressionSyntax;
+    fn cast_unchecked(syntax: ConditionalExpressionSyntax) -> Self {
+        CheckedConditionalExpression(syntax)
+    }
+    fn raw(&self) -> ConditionalExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalExpression {
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn condition(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.condition().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalForceAssignment(ConditionalForceAssignmentSyntax);
+impl CheckedNode for CheckedConditionalForceAssignment {
+    type Syntax = ConditionalForceAssignmentSyntax;
+    fn cast_unchecked(syntax: ConditionalForceAssignmentSyntax) -> Self {
+        CheckedConditionalForceAssignment(syntax)
+    }
+    fn raw(&self) -> ConditionalForceAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalForceAssignment {
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn force_token(&self) -> SyntaxToken {
+        self.0.force_token().unwrap()
+    }
+    pub fn force_mode(&self) -> Option<ForceModeSyntax> {
+        self.0.force_mode()
+    }
+    pub fn conditional_expressions(&self) -> CheckedConditionalExpressions {
+        CheckedConditionalExpressions::cast_unchecked(self.0.conditional_expressions().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedConditionalSignalAssignment {
+    ConditionalWaveformAssignment(CheckedConditionalWaveformAssignment),
+    ConditionalForceAssignment(CheckedConditionalForceAssignment),
+}
+impl CheckedNode for CheckedConditionalSignalAssignment {
+    type Syntax = ConditionalSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: ConditionalSignalAssignmentSyntax) -> Self {
+        match syntax {
+            ConditionalSignalAssignmentSyntax::ConditionalWaveformAssignment(inner) => {
+                CheckedConditionalSignalAssignment::ConditionalWaveformAssignment(
+                    CheckedConditionalWaveformAssignment::cast_unchecked(inner),
+                )
+            }
+            ConditionalSignalAssignmentSyntax::ConditionalForceAssignment(inner) => {
+                CheckedConditionalSignalAssignment::ConditionalForceAssignment(
+                    CheckedConditionalForceAssignment::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedConditionalSignalAssignment::ConditionalWaveformAssignment(inner) => {
+                ConditionalSignalAssignmentSyntax::ConditionalWaveformAssignment(inner.raw())
+            }
+            CheckedConditionalSignalAssignment::ConditionalForceAssignment(inner) => {
+                ConditionalSignalAssignmentSyntax::ConditionalForceAssignment(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalVariableAssignment(ConditionalVariableAssignmentSyntax);
+impl CheckedNode for CheckedConditionalVariableAssignment {
+    type Syntax = ConditionalVariableAssignmentSyntax;
+    fn cast_unchecked(syntax: ConditionalVariableAssignmentSyntax) -> Self {
+        CheckedConditionalVariableAssignment(syntax)
+    }
+    fn raw(&self) -> ConditionalVariableAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalVariableAssignment {
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> SyntaxToken {
+        self.0.colon_eq_token().unwrap()
+    }
+    pub fn conditional_expressions(&self) -> CheckedConditionalExpressions {
+        CheckedConditionalExpressions::cast_unchecked(self.0.conditional_expressions().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalWaveformAssignment(ConditionalWaveformAssignmentSyntax);
+impl CheckedNode for CheckedConditionalWaveformAssignment {
+    type Syntax = ConditionalWaveformAssignmentSyntax;
+    fn cast_unchecked(syntax: ConditionalWaveformAssignmentSyntax) -> Self {
+        CheckedConditionalWaveformAssignment(syntax)
+    }
+    fn raw(&self) -> ConditionalWaveformAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalWaveformAssignment {
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn conditional_waveforms(&self) -> CheckedConditionalWaveforms {
+        CheckedConditionalWaveforms::cast_unchecked(self.0.conditional_waveforms().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalWaveformElseWhenExpression(
+    ConditionalWaveformElseWhenExpressionSyntax,
+);
+impl CheckedNode for CheckedConditionalWaveformElseWhenExpression {
+    type Syntax = ConditionalWaveformElseWhenExpressionSyntax;
+    fn cast_unchecked(syntax: ConditionalWaveformElseWhenExpressionSyntax) -> Self {
+        CheckedConditionalWaveformElseWhenExpression(syntax)
+    }
+    fn raw(&self) -> ConditionalWaveformElseWhenExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalWaveformElseWhenExpression {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn condition(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.condition().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalWaveformElseItem(ConditionalWaveformElseItemSyntax);
+impl CheckedNode for CheckedConditionalWaveformElseItem {
+    type Syntax = ConditionalWaveformElseItemSyntax;
+    fn cast_unchecked(syntax: ConditionalWaveformElseItemSyntax) -> Self {
+        CheckedConditionalWaveformElseItem(syntax)
+    }
+    fn raw(&self) -> ConditionalWaveformElseItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalWaveformElseItem {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalWaveforms(ConditionalWaveformsSyntax);
+impl CheckedNode for CheckedConditionalWaveforms {
+    type Syntax = ConditionalWaveformsSyntax;
+    fn cast_unchecked(syntax: ConditionalWaveformsSyntax) -> Self {
+        CheckedConditionalWaveforms(syntax)
+    }
+    fn raw(&self) -> ConditionalWaveformsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalWaveforms {
+    pub fn conditional_waveform(&self) -> CheckedConditionalWaveform {
+        CheckedConditionalWaveform::cast_unchecked(self.0.conditional_waveform().unwrap())
+    }
+    pub fn conditional_waveform_else_when_expressions(
+        &self,
+    ) -> impl Iterator<Item = CheckedConditionalWaveformElseWhenExpression> + use<'_> {
+        self.0
+            .conditional_waveform_else_when_expressions()
+            .map(CheckedConditionalWaveformElseWhenExpression::cast_unchecked)
+    }
+    pub fn conditional_waveform_else_item(&self) -> Option<CheckedConditionalWaveformElseItem> {
+        self.0
+            .conditional_waveform_else_item()
+            .map(CheckedConditionalWaveformElseItem::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConditionalWaveform(ConditionalWaveformSyntax);
+impl CheckedNode for CheckedConditionalWaveform {
+    type Syntax = ConditionalWaveformSyntax;
+    fn cast_unchecked(syntax: ConditionalWaveformSyntax) -> Self {
+        CheckedConditionalWaveform(syntax)
+    }
+    fn raw(&self) -> ConditionalWaveformSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConditionalWaveform {
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedTransportDelayMechanism(TransportDelayMechanismSyntax);
+impl CheckedNode for CheckedTransportDelayMechanism {
+    type Syntax = TransportDelayMechanismSyntax;
+    fn cast_unchecked(syntax: TransportDelayMechanismSyntax) -> Self {
+        CheckedTransportDelayMechanism(syntax)
+    }
+    fn raw(&self) -> TransportDelayMechanismSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedTransportDelayMechanism {
+    pub fn transport_token(&self) -> SyntaxToken {
+        self.0.transport_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInertialDelayMechanism(InertialDelayMechanismSyntax);
+impl CheckedNode for CheckedInertialDelayMechanism {
+    type Syntax = InertialDelayMechanismSyntax;
+    fn cast_unchecked(syntax: InertialDelayMechanismSyntax) -> Self {
+        CheckedInertialDelayMechanism(syntax)
+    }
+    fn raw(&self) -> InertialDelayMechanismSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInertialDelayMechanism {
+    pub fn reject_token(&self) -> Option<SyntaxToken> {
+        self.0.reject_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn inertial_token(&self) -> SyntaxToken {
+        self.0.inertial_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedDelayMechanism {
+    TransportDelayMechanism(CheckedTransportDelayMechanism),
+    InertialDelayMechanism(CheckedInertialDelayMechanism),
+}
+impl CheckedNode for CheckedDelayMechanism {
+    type Syntax = DelayMechanismSyntax;
+    fn cast_unchecked(syntax: DelayMechanismSyntax) -> Self {
+        match syntax {
+            DelayMechanismSyntax::TransportDelayMechanism(inner) => {
+                CheckedDelayMechanism::TransportDelayMechanism(
+                    CheckedTransportDelayMechanism::cast_unchecked(inner),
+                )
+            }
+            DelayMechanismSyntax::InertialDelayMechanism(inner) => {
+                CheckedDelayMechanism::InertialDelayMechanism(
+                    CheckedInertialDelayMechanism::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedDelayMechanism::TransportDelayMechanism(inner) => {
+                DelayMechanismSyntax::TransportDelayMechanism(inner.raw())
+            }
+            CheckedDelayMechanism::InertialDelayMechanism(inner) => {
+                DelayMechanismSyntax::InertialDelayMechanism(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedExitStatement(ExitStatementSyntax);
+impl CheckedNode for CheckedExitStatement {
+    type Syntax = ExitStatementSyntax;
+    fn cast_unchecked(syntax: ExitStatementSyntax) -> Self {
+        CheckedExitStatement(syntax)
+    }
+    fn raw(&self) -> ExitStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedExitStatement {
+    pub fn label_token(&self) -> Option<SyntaxToken> {
+        self.0.label_token()
+    }
+    pub fn colon_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_token()
+    }
+    pub fn exit_token(&self) -> SyntaxToken {
+        self.0.exit_token().unwrap()
+    }
+    pub fn loop_label_token(&self) -> Option<SyntaxToken> {
+        self.0.loop_label_token()
+    }
+    pub fn when_token(&self) -> Option<SyntaxToken> {
+        self.0.when_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfStatementElsif(IfStatementElsifSyntax);
+impl CheckedNode for CheckedIfStatementElsif {
+    type Syntax = IfStatementElsifSyntax;
+    fn cast_unchecked(syntax: IfStatementElsifSyntax) -> Self {
+        CheckedIfStatementElsif(syntax)
+    }
+    fn raw(&self) -> IfStatementElsifSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfStatementElsif {
+    pub fn elsif_token(&self) -> SyntaxToken {
+        self.0.elsif_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn then_token(&self) -> SyntaxToken {
+        self.0.then_token().unwrap()
+    }
+    pub fn sequential_statements(&self) -> Option<CheckedSequentialStatements> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatements::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfStatementElse(IfStatementElseSyntax);
+impl CheckedNode for CheckedIfStatementElse {
+    type Syntax = IfStatementElseSyntax;
+    fn cast_unchecked(syntax: IfStatementElseSyntax) -> Self {
+        CheckedIfStatementElse(syntax)
+    }
+    fn raw(&self) -> IfStatementElseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfStatementElse {
+    pub fn else_token(&self) -> SyntaxToken {
+        self.0.else_token().unwrap()
+    }
+    pub fn sequential_statements(&self) -> Option<CheckedSequentialStatements> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatements::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfStatement(IfStatementSyntax);
+impl CheckedNode for CheckedIfStatement {
+    type Syntax = IfStatementSyntax;
+    fn cast_unchecked(syntax: IfStatementSyntax) -> Self {
+        CheckedIfStatement(syntax)
+    }
+    fn raw(&self) -> IfStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfStatement {
+    pub fn if_statement_preamble(&self) -> CheckedIfStatementPreamble {
+        CheckedIfStatementPreamble::cast_unchecked(self.0.if_statement_preamble().unwrap())
+    }
+    pub fn sequential_statements(&self) -> Option<CheckedSequentialStatements> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatements::cast_unchecked)
+    }
+    pub fn if_statement_elsifs(&self) -> impl Iterator<Item = CheckedIfStatementElsif> + use<'_> {
+        self.0
+            .if_statement_elsifs()
+            .map(CheckedIfStatementElsif::cast_unchecked)
+    }
+    pub fn if_statement_else(&self) -> Option<CheckedIfStatementElse> {
+        self.0
+            .if_statement_else()
+            .map(CheckedIfStatementElse::cast_unchecked)
+    }
+    pub fn if_statement_epilogue(&self) -> CheckedIfStatementEpilogue {
+        CheckedIfStatementEpilogue::cast_unchecked(self.0.if_statement_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfStatementPreamble(IfStatementPreambleSyntax);
+impl CheckedNode for CheckedIfStatementPreamble {
+    type Syntax = IfStatementPreambleSyntax;
+    fn cast_unchecked(syntax: IfStatementPreambleSyntax) -> Self {
+        CheckedIfStatementPreamble(syntax)
+    }
+    fn raw(&self) -> IfStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfStatementPreamble {
+    pub fn if_label_token(&self) -> Option<SyntaxToken> {
+        self.0.if_label_token()
+    }
+    pub fn colon_token(&self) -> Option<SyntaxToken> {
+        self.0.colon_token()
+    }
+    pub fn if_token(&self) -> SyntaxToken {
+        self.0.if_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn then_token(&self) -> SyntaxToken {
+        self.0.then_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIfStatementEpilogue(IfStatementEpilogueSyntax);
+impl CheckedNode for CheckedIfStatementEpilogue {
+    type Syntax = IfStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: IfStatementEpilogueSyntax) -> Self {
+        CheckedIfStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> IfStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIfStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn if_token(&self) -> SyntaxToken {
+        self.0.if_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedWhileIterationScheme(WhileIterationSchemeSyntax);
+impl CheckedNode for CheckedWhileIterationScheme {
+    type Syntax = WhileIterationSchemeSyntax;
+    fn cast_unchecked(syntax: WhileIterationSchemeSyntax) -> Self {
+        CheckedWhileIterationScheme(syntax)
+    }
+    fn raw(&self) -> WhileIterationSchemeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedWhileIterationScheme {
+    pub fn while_token(&self) -> SyntaxToken {
+        self.0.while_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedForIterationScheme(ForIterationSchemeSyntax);
+impl CheckedNode for CheckedForIterationScheme {
+    type Syntax = ForIterationSchemeSyntax;
+    fn cast_unchecked(syntax: ForIterationSchemeSyntax) -> Self {
+        CheckedForIterationScheme(syntax)
+    }
+    fn raw(&self) -> ForIterationSchemeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedForIterationScheme {
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn parameter_specification(&self) -> CheckedParameterSpecification {
+        CheckedParameterSpecification::cast_unchecked(self.0.parameter_specification().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedIterationScheme {
+    WhileIterationScheme(CheckedWhileIterationScheme),
+    ForIterationScheme(CheckedForIterationScheme),
+}
+impl CheckedNode for CheckedIterationScheme {
+    type Syntax = IterationSchemeSyntax;
+    fn cast_unchecked(syntax: IterationSchemeSyntax) -> Self {
+        match syntax {
+            IterationSchemeSyntax::WhileIterationScheme(inner) => {
+                CheckedIterationScheme::WhileIterationScheme(
+                    CheckedWhileIterationScheme::cast_unchecked(inner),
+                )
+            }
+            IterationSchemeSyntax::ForIterationScheme(inner) => {
+                CheckedIterationScheme::ForIterationScheme(
+                    CheckedForIterationScheme::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedIterationScheme::WhileIterationScheme(inner) => {
+                IterationSchemeSyntax::WhileIterationScheme(inner.raw())
+            }
+            CheckedIterationScheme::ForIterationScheme(inner) => {
+                IterationSchemeSyntax::ForIterationScheme(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLoopStatement(LoopStatementSyntax);
+impl CheckedNode for CheckedLoopStatement {
+    type Syntax = LoopStatementSyntax;
+    fn cast_unchecked(syntax: LoopStatementSyntax) -> Self {
+        CheckedLoopStatement(syntax)
+    }
+    fn raw(&self) -> LoopStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLoopStatement {
+    pub fn loop_statement_preamble(&self) -> CheckedLoopStatementPreamble {
+        CheckedLoopStatementPreamble::cast_unchecked(self.0.loop_statement_preamble().unwrap())
+    }
+    pub fn sequential_statements(&self) -> Option<CheckedSequentialStatements> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatements::cast_unchecked)
+    }
+    pub fn loop_statement_epilogue(&self) -> CheckedLoopStatementEpilogue {
+        CheckedLoopStatementEpilogue::cast_unchecked(self.0.loop_statement_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLoopStatementPreamble(LoopStatementPreambleSyntax);
+impl CheckedNode for CheckedLoopStatementPreamble {
+    type Syntax = LoopStatementPreambleSyntax;
+    fn cast_unchecked(syntax: LoopStatementPreambleSyntax) -> Self {
+        CheckedLoopStatementPreamble(syntax)
+    }
+    fn raw(&self) -> LoopStatementPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLoopStatementPreamble {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn iteration_scheme(&self) -> Option<CheckedIterationScheme> {
+        self.0
+            .iteration_scheme()
+            .map(CheckedIterationScheme::cast_unchecked)
+    }
+    pub fn loop_token(&self) -> SyntaxToken {
+        self.0.loop_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedLoopStatementEpilogue(LoopStatementEpilogueSyntax);
+impl CheckedNode for CheckedLoopStatementEpilogue {
+    type Syntax = LoopStatementEpilogueSyntax;
+    fn cast_unchecked(syntax: LoopStatementEpilogueSyntax) -> Self {
+        CheckedLoopStatementEpilogue(syntax)
+    }
+    fn raw(&self) -> LoopStatementEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedLoopStatementEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn loop_token(&self) -> SyntaxToken {
+        self.0.loop_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNextStatement(NextStatementSyntax);
+impl CheckedNode for CheckedNextStatement {
+    type Syntax = NextStatementSyntax;
+    fn cast_unchecked(syntax: NextStatementSyntax) -> Self {
+        CheckedNextStatement(syntax)
+    }
+    fn raw(&self) -> NextStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNextStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn next_token(&self) -> SyntaxToken {
+        self.0.next_token().unwrap()
+    }
+    pub fn loop_label_token(&self) -> Option<SyntaxToken> {
+        self.0.loop_label_token()
+    }
+    pub fn when_token(&self) -> Option<SyntaxToken> {
+        self.0.when_token()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNullStatement(NullStatementSyntax);
+impl CheckedNode for CheckedNullStatement {
+    type Syntax = NullStatementSyntax;
+    fn cast_unchecked(syntax: NullStatementSyntax) -> Self {
+        CheckedNullStatement(syntax)
+    }
+    fn raw(&self) -> NullStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNullStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn null_token(&self) -> SyntaxToken {
+        self.0.null_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParameterSpecification(ParameterSpecificationSyntax);
+impl CheckedNode for CheckedParameterSpecification {
+    type Syntax = ParameterSpecificationSyntax;
+    fn cast_unchecked(syntax: ParameterSpecificationSyntax) -> Self {
+        CheckedParameterSpecification(syntax)
+    }
+    fn raw(&self) -> ParameterSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParameterSpecification {
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn in_token(&self) -> SyntaxToken {
+        self.0.in_token().unwrap()
+    }
+    pub fn discrete_range(&self) -> CheckedDiscreteRange {
+        CheckedDiscreteRange::cast_unchecked(self.0.discrete_range().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProcedureCallStatement(ProcedureCallStatementSyntax);
+impl CheckedNode for CheckedProcedureCallStatement {
+    type Syntax = ProcedureCallStatementSyntax;
+    fn cast_unchecked(syntax: ProcedureCallStatementSyntax) -> Self {
+        CheckedProcedureCallStatement(syntax)
+    }
+    fn raw(&self) -> ProcedureCallStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProcedureCallStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedReportStatement(ReportStatementSyntax);
+impl CheckedNode for CheckedReportStatement {
+    type Syntax = ReportStatementSyntax;
+    fn cast_unchecked(syntax: ReportStatementSyntax) -> Self {
+        CheckedReportStatement(syntax)
+    }
+    fn raw(&self) -> ReportStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedReportStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn report_token(&self) -> SyntaxToken {
+        self.0.report_token().unwrap()
+    }
+    pub fn report(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.report().unwrap())
+    }
+    pub fn severity_token(&self) -> Option<SyntaxToken> {
+        self.0.severity_token()
+    }
+    pub fn severity(&self) -> Option<CheckedExpression> {
+        self.0.severity().map(CheckedExpression::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedReturnStatement(ReturnStatementSyntax);
+impl CheckedNode for CheckedReturnStatement {
+    type Syntax = ReturnStatementSyntax;
+    fn cast_unchecked(syntax: ReturnStatementSyntax) -> Self {
+        CheckedReturnStatement(syntax)
+    }
+    fn raw(&self) -> ReturnStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedReturnStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn return_token(&self) -> SyntaxToken {
+        self.0.return_token().unwrap()
+    }
+    pub fn expression(&self) -> Option<CheckedExpression> {
+        self.0.expression().map(CheckedExpression::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedExpressionItem(SelectedExpressionItemSyntax);
+impl CheckedNode for CheckedSelectedExpressionItem {
+    type Syntax = SelectedExpressionItemSyntax;
+    fn cast_unchecked(syntax: SelectedExpressionItemSyntax) -> Self {
+        CheckedSelectedExpressionItem(syntax)
+    }
+    fn raw(&self) -> SelectedExpressionItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedExpressionItem {
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn choices(&self) -> Option<CheckedChoices> {
+        self.0.choices().map(CheckedChoices::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedExpressions(SelectedExpressionsSyntax);
+impl CheckedNode for CheckedSelectedExpressions {
+    type Syntax = SelectedExpressionsSyntax;
+    fn cast_unchecked(syntax: SelectedExpressionsSyntax) -> Self {
+        CheckedSelectedExpressions(syntax)
+    }
+    fn raw(&self) -> SelectedExpressionsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedExpressions {
+    pub fn selected_expression_items(
+        &self,
+    ) -> impl Iterator<Item = CheckedSelectedExpressionItem> + use<'_> {
+        self.0
+            .selected_expression_items()
+            .map(CheckedSelectedExpressionItem::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedForceAssignment(SelectedForceAssignmentSyntax);
+impl CheckedNode for CheckedSelectedForceAssignment {
+    type Syntax = SelectedForceAssignmentSyntax;
+    fn cast_unchecked(syntax: SelectedForceAssignmentSyntax) -> Self {
+        CheckedSelectedForceAssignment(syntax)
+    }
+    fn raw(&self) -> SelectedForceAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedForceAssignment {
+    pub fn selected_assignment_preamble(&self) -> CheckedSelectedAssignmentPreamble {
+        CheckedSelectedAssignmentPreamble::cast_unchecked(
+            self.0.selected_assignment_preamble().unwrap(),
+        )
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn force_token(&self) -> SyntaxToken {
+        self.0.force_token().unwrap()
+    }
+    pub fn force_mode(&self) -> Option<ForceModeSyntax> {
+        self.0.force_mode()
+    }
+    pub fn selected_expressions(&self) -> Option<CheckedSelectedExpressions> {
+        self.0
+            .selected_expressions()
+            .map(CheckedSelectedExpressions::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedWaveformItem(SelectedWaveformItemSyntax);
+impl CheckedNode for CheckedSelectedWaveformItem {
+    type Syntax = SelectedWaveformItemSyntax;
+    fn cast_unchecked(syntax: SelectedWaveformItemSyntax) -> Self {
+        CheckedSelectedWaveformItem(syntax)
+    }
+    fn raw(&self) -> SelectedWaveformItemSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedWaveformItem {
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+    pub fn when_token(&self) -> SyntaxToken {
+        self.0.when_token().unwrap()
+    }
+    pub fn choices(&self) -> Option<CheckedChoices> {
+        self.0.choices().map(CheckedChoices::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedWaveforms(SelectedWaveformsSyntax);
+impl CheckedNode for CheckedSelectedWaveforms {
+    type Syntax = SelectedWaveformsSyntax;
+    fn cast_unchecked(syntax: SelectedWaveformsSyntax) -> Self {
+        CheckedSelectedWaveforms(syntax)
+    }
+    fn raw(&self) -> SelectedWaveformsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedWaveforms {
+    pub fn selected_waveform_items(
+        &self,
+    ) -> impl Iterator<Item = CheckedSelectedWaveformItem> + use<'_> {
+        self.0
+            .selected_waveform_items()
+            .map(CheckedSelectedWaveformItem::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSelectedSignalAssignment {
+    SelectedWaveformAssignment(CheckedSelectedWaveformAssignment),
+    SelectedForceAssignment(CheckedSelectedForceAssignment),
+}
+impl CheckedNode for CheckedSelectedSignalAssignment {
+    type Syntax = SelectedSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: SelectedSignalAssignmentSyntax) -> Self {
+        match syntax {
+            SelectedSignalAssignmentSyntax::SelectedWaveformAssignment(inner) => {
+                CheckedSelectedSignalAssignment::SelectedWaveformAssignment(
+                    CheckedSelectedWaveformAssignment::cast_unchecked(inner),
+                )
+            }
+            SelectedSignalAssignmentSyntax::SelectedForceAssignment(inner) => {
+                CheckedSelectedSignalAssignment::SelectedForceAssignment(
+                    CheckedSelectedForceAssignment::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSelectedSignalAssignment::SelectedWaveformAssignment(inner) => {
+                SelectedSignalAssignmentSyntax::SelectedWaveformAssignment(inner.raw())
+            }
+            CheckedSelectedSignalAssignment::SelectedForceAssignment(inner) => {
+                SelectedSignalAssignmentSyntax::SelectedForceAssignment(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedVariableAssignment(SelectedVariableAssignmentSyntax);
+impl CheckedNode for CheckedSelectedVariableAssignment {
+    type Syntax = SelectedVariableAssignmentSyntax;
+    fn cast_unchecked(syntax: SelectedVariableAssignmentSyntax) -> Self {
+        CheckedSelectedVariableAssignment(syntax)
+    }
+    fn raw(&self) -> SelectedVariableAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedVariableAssignment {
+    pub fn selected_assignment_preamble(&self) -> CheckedSelectedAssignmentPreamble {
+        CheckedSelectedAssignmentPreamble::cast_unchecked(
+            self.0.selected_assignment_preamble().unwrap(),
+        )
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> SyntaxToken {
+        self.0.colon_eq_token().unwrap()
+    }
+    pub fn selected_expressions(&self) -> Option<CheckedSelectedExpressions> {
+        self.0
+            .selected_expressions()
+            .map(CheckedSelectedExpressions::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedWaveformAssignment(SelectedWaveformAssignmentSyntax);
+impl CheckedNode for CheckedSelectedWaveformAssignment {
+    type Syntax = SelectedWaveformAssignmentSyntax;
+    fn cast_unchecked(syntax: SelectedWaveformAssignmentSyntax) -> Self {
+        CheckedSelectedWaveformAssignment(syntax)
+    }
+    fn raw(&self) -> SelectedWaveformAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedWaveformAssignment {
+    pub fn selected_assignment_preamble(&self) -> CheckedSelectedAssignmentPreamble {
+        CheckedSelectedAssignmentPreamble::cast_unchecked(
+            self.0.selected_assignment_preamble().unwrap(),
+        )
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn selected_waveforms(&self) -> Option<CheckedSelectedWaveforms> {
+        self.0
+            .selected_waveforms()
+            .map(CheckedSelectedWaveforms::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSelectedAssignmentPreamble(SelectedAssignmentPreambleSyntax);
+impl CheckedNode for CheckedSelectedAssignmentPreamble {
+    type Syntax = SelectedAssignmentPreambleSyntax;
+    fn cast_unchecked(syntax: SelectedAssignmentPreambleSyntax) -> Self {
+        CheckedSelectedAssignmentPreamble(syntax)
+    }
+    fn raw(&self) -> SelectedAssignmentPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSelectedAssignmentPreamble {
+    pub fn with_token(&self) -> SyntaxToken {
+        self.0.with_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn select_token(&self) -> SyntaxToken {
+        self.0.select_token().unwrap()
+    }
+    pub fn que_token(&self) -> Option<SyntaxToken> {
+        self.0.que_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSensitivityClause(SensitivityClauseSyntax);
+impl CheckedNode for CheckedSensitivityClause {
+    type Syntax = SensitivityClauseSyntax;
+    fn cast_unchecked(syntax: SensitivityClauseSyntax) -> Self {
+        CheckedSensitivityClause(syntax)
+    }
+    fn raw(&self) -> SensitivityClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSensitivityClause {
+    pub fn on_token(&self) -> SyntaxToken {
+        self.0.on_token().unwrap()
+    }
+    pub fn name_list(&self) -> Option<CheckedNameList> {
+        self.0.name_list().map(CheckedNameList::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSequentialStatement {
+    WaitStatement(CheckedWaitStatement),
+    AssertionStatement(CheckedAssertionStatement),
+    ReportStatement(CheckedReportStatement),
+    SignalAssignmentStatement(CheckedSignalAssignmentStatement),
+    VariableAssignmentStatement(CheckedVariableAssignmentStatement),
+    ProcedureCallStatement(CheckedProcedureCallStatement),
+    IfStatement(CheckedIfStatement),
+    CaseStatement(CheckedCaseStatement),
+    LoopStatement(CheckedLoopStatement),
+    NextStatement(CheckedNextStatement),
+    ExitStatement(CheckedExitStatement),
+    ReturnStatement(CheckedReturnStatement),
+    NullStatement(CheckedNullStatement),
+}
+impl CheckedNode for CheckedSequentialStatement {
+    type Syntax = SequentialStatementSyntax;
+    fn cast_unchecked(syntax: SequentialStatementSyntax) -> Self {
+        match syntax {
+            SequentialStatementSyntax::WaitStatement(inner) => {
+                CheckedSequentialStatement::WaitStatement(CheckedWaitStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::AssertionStatement(inner) => {
+                CheckedSequentialStatement::AssertionStatement(
+                    CheckedAssertionStatement::cast_unchecked(inner),
+                )
+            }
+            SequentialStatementSyntax::ReportStatement(inner) => {
+                CheckedSequentialStatement::ReportStatement(CheckedReportStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::SignalAssignmentStatement(inner) => {
+                CheckedSequentialStatement::SignalAssignmentStatement(
+                    CheckedSignalAssignmentStatement::cast_unchecked(inner),
+                )
+            }
+            SequentialStatementSyntax::VariableAssignmentStatement(inner) => {
+                CheckedSequentialStatement::VariableAssignmentStatement(
+                    CheckedVariableAssignmentStatement::cast_unchecked(inner),
+                )
+            }
+            SequentialStatementSyntax::ProcedureCallStatement(inner) => {
+                CheckedSequentialStatement::ProcedureCallStatement(
+                    CheckedProcedureCallStatement::cast_unchecked(inner),
+                )
+            }
+            SequentialStatementSyntax::IfStatement(inner) => {
+                CheckedSequentialStatement::IfStatement(CheckedIfStatement::cast_unchecked(inner))
+            }
+            SequentialStatementSyntax::CaseStatement(inner) => {
+                CheckedSequentialStatement::CaseStatement(CheckedCaseStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::LoopStatement(inner) => {
+                CheckedSequentialStatement::LoopStatement(CheckedLoopStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::NextStatement(inner) => {
+                CheckedSequentialStatement::NextStatement(CheckedNextStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::ExitStatement(inner) => {
+                CheckedSequentialStatement::ExitStatement(CheckedExitStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::ReturnStatement(inner) => {
+                CheckedSequentialStatement::ReturnStatement(CheckedReturnStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+            SequentialStatementSyntax::NullStatement(inner) => {
+                CheckedSequentialStatement::NullStatement(CheckedNullStatement::cast_unchecked(
+                    inner,
+                ))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSequentialStatement::WaitStatement(inner) => {
+                SequentialStatementSyntax::WaitStatement(inner.raw())
+            }
+            CheckedSequentialStatement::AssertionStatement(inner) => {
+                SequentialStatementSyntax::AssertionStatement(inner.raw())
+            }
+            CheckedSequentialStatement::ReportStatement(inner) => {
+                SequentialStatementSyntax::ReportStatement(inner.raw())
+            }
+            CheckedSequentialStatement::SignalAssignmentStatement(inner) => {
+                SequentialStatementSyntax::SignalAssignmentStatement(inner.raw())
+            }
+            CheckedSequentialStatement::VariableAssignmentStatement(inner) => {
+                SequentialStatementSyntax::VariableAssignmentStatement(inner.raw())
+            }
+            CheckedSequentialStatement::ProcedureCallStatement(inner) => {
+                SequentialStatementSyntax::ProcedureCallStatement(inner.raw())
+            }
+            CheckedSequentialStatement::IfStatement(inner) => {
+                SequentialStatementSyntax::IfStatement(inner.raw())
+            }
+            CheckedSequentialStatement::CaseStatement(inner) => {
+                SequentialStatementSyntax::CaseStatement(inner.raw())
+            }
+            CheckedSequentialStatement::LoopStatement(inner) => {
+                SequentialStatementSyntax::LoopStatement(inner.raw())
+            }
+            CheckedSequentialStatement::NextStatement(inner) => {
+                SequentialStatementSyntax::NextStatement(inner.raw())
+            }
+            CheckedSequentialStatement::ExitStatement(inner) => {
+                SequentialStatementSyntax::ExitStatement(inner.raw())
+            }
+            CheckedSequentialStatement::ReturnStatement(inner) => {
+                SequentialStatementSyntax::ReturnStatement(inner.raw())
+            }
+            CheckedSequentialStatement::NullStatement(inner) => {
+                SequentialStatementSyntax::NullStatement(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSignalAssignmentStatement {
+    SimpleSignalAssignment(CheckedSimpleSignalAssignment),
+    ConditionalSignalAssignment(CheckedConditionalSignalAssignment),
+    SelectedSignalAssignment(CheckedSelectedSignalAssignment),
+}
+impl CheckedNode for CheckedSignalAssignmentStatement {
+    type Syntax = SignalAssignmentStatementSyntax;
+    fn cast_unchecked(syntax: SignalAssignmentStatementSyntax) -> Self {
+        match syntax {
+            SignalAssignmentStatementSyntax::SimpleSignalAssignment(inner) => {
+                CheckedSignalAssignmentStatement::SimpleSignalAssignment(
+                    CheckedSimpleSignalAssignment::cast_unchecked(inner),
+                )
+            }
+            SignalAssignmentStatementSyntax::ConditionalSignalAssignment(inner) => {
+                CheckedSignalAssignmentStatement::ConditionalSignalAssignment(
+                    CheckedConditionalSignalAssignment::cast_unchecked(inner),
+                )
+            }
+            SignalAssignmentStatementSyntax::SelectedSignalAssignment(inner) => {
+                CheckedSignalAssignmentStatement::SelectedSignalAssignment(
+                    CheckedSelectedSignalAssignment::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSignalAssignmentStatement::SimpleSignalAssignment(inner) => {
+                SignalAssignmentStatementSyntax::SimpleSignalAssignment(inner.raw())
+            }
+            CheckedSignalAssignmentStatement::ConditionalSignalAssignment(inner) => {
+                SignalAssignmentStatementSyntax::ConditionalSignalAssignment(inner.raw())
+            }
+            CheckedSignalAssignmentStatement::SelectedSignalAssignment(inner) => {
+                SignalAssignmentStatementSyntax::SelectedSignalAssignment(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSimpleForceAssignment(SimpleForceAssignmentSyntax);
+impl CheckedNode for CheckedSimpleForceAssignment {
+    type Syntax = SimpleForceAssignmentSyntax;
+    fn cast_unchecked(syntax: SimpleForceAssignmentSyntax) -> Self {
+        CheckedSimpleForceAssignment(syntax)
+    }
+    fn raw(&self) -> SimpleForceAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSimpleForceAssignment {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn force_token(&self) -> SyntaxToken {
+        self.0.force_token().unwrap()
+    }
+    pub fn force_mode(&self) -> Option<ForceModeSyntax> {
+        self.0.force_mode()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSimpleReleaseAssignment(SimpleReleaseAssignmentSyntax);
+impl CheckedNode for CheckedSimpleReleaseAssignment {
+    type Syntax = SimpleReleaseAssignmentSyntax;
+    fn cast_unchecked(syntax: SimpleReleaseAssignmentSyntax) -> Self {
+        CheckedSimpleReleaseAssignment(syntax)
+    }
+    fn raw(&self) -> SimpleReleaseAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSimpleReleaseAssignment {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn release_token(&self) -> SyntaxToken {
+        self.0.release_token().unwrap()
+    }
+    pub fn force_mode(&self) -> Option<ForceModeSyntax> {
+        self.0.force_mode()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSimpleWaveformAssignment(SimpleWaveformAssignmentSyntax);
+impl CheckedNode for CheckedSimpleWaveformAssignment {
+    type Syntax = SimpleWaveformAssignmentSyntax;
+    fn cast_unchecked(syntax: SimpleWaveformAssignmentSyntax) -> Self {
+        CheckedSimpleWaveformAssignment(syntax)
+    }
+    fn raw(&self) -> SimpleWaveformAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSimpleWaveformAssignment {
+    pub fn label(&self) -> Option<CheckedLabel> {
+        self.0.label().map(CheckedLabel::cast_unchecked)
+    }
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn lte_token(&self) -> SyntaxToken {
+        self.0.lte_token().unwrap()
+    }
+    pub fn delay_mechanism(&self) -> Option<CheckedDelayMechanism> {
+        self.0
+            .delay_mechanism()
+            .map(CheckedDelayMechanism::cast_unchecked)
+    }
+    pub fn waveform(&self) -> CheckedWaveform {
+        CheckedWaveform::cast_unchecked(self.0.waveform().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSimpleSignalAssignment {
+    SimpleWaveformAssignment(CheckedSimpleWaveformAssignment),
+    SimpleForceAssignment(CheckedSimpleForceAssignment),
+    SimpleReleaseAssignment(CheckedSimpleReleaseAssignment),
+}
+impl CheckedNode for CheckedSimpleSignalAssignment {
+    type Syntax = SimpleSignalAssignmentSyntax;
+    fn cast_unchecked(syntax: SimpleSignalAssignmentSyntax) -> Self {
+        match syntax {
+            SimpleSignalAssignmentSyntax::SimpleWaveformAssignment(inner) => {
+                CheckedSimpleSignalAssignment::SimpleWaveformAssignment(
+                    CheckedSimpleWaveformAssignment::cast_unchecked(inner),
+                )
+            }
+            SimpleSignalAssignmentSyntax::SimpleForceAssignment(inner) => {
+                CheckedSimpleSignalAssignment::SimpleForceAssignment(
+                    CheckedSimpleForceAssignment::cast_unchecked(inner),
+                )
+            }
+            SimpleSignalAssignmentSyntax::SimpleReleaseAssignment(inner) => {
+                CheckedSimpleSignalAssignment::SimpleReleaseAssignment(
+                    CheckedSimpleReleaseAssignment::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSimpleSignalAssignment::SimpleWaveformAssignment(inner) => {
+                SimpleSignalAssignmentSyntax::SimpleWaveformAssignment(inner.raw())
+            }
+            CheckedSimpleSignalAssignment::SimpleForceAssignment(inner) => {
+                SimpleSignalAssignmentSyntax::SimpleForceAssignment(inner.raw())
+            }
+            CheckedSimpleSignalAssignment::SimpleReleaseAssignment(inner) => {
+                SimpleSignalAssignmentSyntax::SimpleReleaseAssignment(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSimpleVariableAssignment(SimpleVariableAssignmentSyntax);
+impl CheckedNode for CheckedSimpleVariableAssignment {
+    type Syntax = SimpleVariableAssignmentSyntax;
+    fn cast_unchecked(syntax: SimpleVariableAssignmentSyntax) -> Self {
+        CheckedSimpleVariableAssignment(syntax)
+    }
+    fn raw(&self) -> SimpleVariableAssignmentSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSimpleVariableAssignment {
+    pub fn target(&self) -> CheckedTarget {
+        CheckedTarget::cast_unchecked(self.0.target().unwrap())
+    }
+    pub fn colon_eq_token(&self) -> SyntaxToken {
+        self.0.colon_eq_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNameTarget(NameTargetSyntax);
+impl CheckedNode for CheckedNameTarget {
+    type Syntax = NameTargetSyntax;
+    fn cast_unchecked(syntax: NameTargetSyntax) -> Self {
+        CheckedNameTarget(syntax)
+    }
+    fn raw(&self) -> NameTargetSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNameTarget {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAggregateTarget(AggregateTargetSyntax);
+impl CheckedNode for CheckedAggregateTarget {
+    type Syntax = AggregateTargetSyntax;
+    fn cast_unchecked(syntax: AggregateTargetSyntax) -> Self {
+        CheckedAggregateTarget(syntax)
+    }
+    fn raw(&self) -> AggregateTargetSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAggregateTarget {
+    pub fn aggregate(&self) -> CheckedAggregate {
+        CheckedAggregate::cast_unchecked(self.0.aggregate().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedTarget {
+    NameTarget(CheckedNameTarget),
+    AggregateTarget(CheckedAggregateTarget),
+}
+impl CheckedNode for CheckedTarget {
+    type Syntax = TargetSyntax;
+    fn cast_unchecked(syntax: TargetSyntax) -> Self {
+        match syntax {
+            TargetSyntax::NameTarget(inner) => {
+                CheckedTarget::NameTarget(CheckedNameTarget::cast_unchecked(inner))
+            }
+            TargetSyntax::AggregateTarget(inner) => {
+                CheckedTarget::AggregateTarget(CheckedAggregateTarget::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedTarget::NameTarget(inner) => TargetSyntax::NameTarget(inner.raw()),
+            CheckedTarget::AggregateTarget(inner) => TargetSyntax::AggregateTarget(inner.raw()),
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedTimeoutClause(TimeoutClauseSyntax);
+impl CheckedNode for CheckedTimeoutClause {
+    type Syntax = TimeoutClauseSyntax;
+    fn cast_unchecked(syntax: TimeoutClauseSyntax) -> Self {
+        CheckedTimeoutClause(syntax)
+    }
+    fn raw(&self) -> TimeoutClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedTimeoutClause {
+    pub fn for_token(&self) -> SyntaxToken {
+        self.0.for_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedVariableAssignmentStatement {
+    SimpleVariableAssignment(CheckedSimpleVariableAssignment),
+    ConditionalVariableAssignment(CheckedConditionalVariableAssignment),
+    SelectedVariableAssignment(CheckedSelectedVariableAssignment),
+}
+impl CheckedNode for CheckedVariableAssignmentStatement {
+    type Syntax = VariableAssignmentStatementSyntax;
+    fn cast_unchecked(syntax: VariableAssignmentStatementSyntax) -> Self {
+        match syntax {
+            VariableAssignmentStatementSyntax::SimpleVariableAssignment(inner) => {
+                CheckedVariableAssignmentStatement::SimpleVariableAssignment(
+                    CheckedSimpleVariableAssignment::cast_unchecked(inner),
+                )
+            }
+            VariableAssignmentStatementSyntax::ConditionalVariableAssignment(inner) => {
+                CheckedVariableAssignmentStatement::ConditionalVariableAssignment(
+                    CheckedConditionalVariableAssignment::cast_unchecked(inner),
+                )
+            }
+            VariableAssignmentStatementSyntax::SelectedVariableAssignment(inner) => {
+                CheckedVariableAssignmentStatement::SelectedVariableAssignment(
+                    CheckedSelectedVariableAssignment::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedVariableAssignmentStatement::SimpleVariableAssignment(inner) => {
+                VariableAssignmentStatementSyntax::SimpleVariableAssignment(inner.raw())
+            }
+            CheckedVariableAssignmentStatement::ConditionalVariableAssignment(inner) => {
+                VariableAssignmentStatementSyntax::ConditionalVariableAssignment(inner.raw())
+            }
+            CheckedVariableAssignmentStatement::SelectedVariableAssignment(inner) => {
+                VariableAssignmentStatementSyntax::SelectedVariableAssignment(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedWaitStatement(WaitStatementSyntax);
+impl CheckedNode for CheckedWaitStatement {
+    type Syntax = WaitStatementSyntax;
+    fn cast_unchecked(syntax: WaitStatementSyntax) -> Self {
+        CheckedWaitStatement(syntax)
+    }
+    fn raw(&self) -> WaitStatementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedWaitStatement {
+    pub fn label(&self) -> CheckedLabel {
+        CheckedLabel::cast_unchecked(self.0.label().unwrap())
+    }
+    pub fn wait_token(&self) -> SyntaxToken {
+        self.0.wait_token().unwrap()
+    }
+    pub fn sensitivity_clause(&self) -> Option<CheckedSensitivityClause> {
+        self.0
+            .sensitivity_clause()
+            .map(CheckedSensitivityClause::cast_unchecked)
+    }
+    pub fn condition_clause(&self) -> Option<CheckedConditionClause> {
+        self.0
+            .condition_clause()
+            .map(CheckedConditionClause::cast_unchecked)
+    }
+    pub fn timeout_clause(&self) -> Option<CheckedTimeoutClause> {
+        self.0
+            .timeout_clause()
+            .map(CheckedTimeoutClause::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedWaveformElement(WaveformElementSyntax);
+impl CheckedNode for CheckedWaveformElement {
+    type Syntax = WaveformElementSyntax;
+    fn cast_unchecked(syntax: WaveformElementSyntax) -> Self {
+        CheckedWaveformElement(syntax)
+    }
+    fn raw(&self) -> WaveformElementSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedWaveformElement {
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn after_token(&self) -> SyntaxToken {
+        self.0.after_token().unwrap()
+    }
+    pub fn time_expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.time_expression().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedWaveformElements(WaveformElementsSyntax);
+impl CheckedNode for CheckedWaveformElements {
+    type Syntax = WaveformElementsSyntax;
+    fn cast_unchecked(syntax: WaveformElementsSyntax) -> Self {
+        CheckedWaveformElements(syntax)
+    }
+    fn raw(&self) -> WaveformElementsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedWaveformElements {
+    pub fn waveform_elements(&self) -> impl Iterator<Item = CheckedWaveformElement> + use<'_> {
+        self.0
+            .waveform_elements()
+            .map(CheckedWaveformElement::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUnaffectedWaveform(UnaffectedWaveformSyntax);
+impl CheckedNode for CheckedUnaffectedWaveform {
+    type Syntax = UnaffectedWaveformSyntax;
+    fn cast_unchecked(syntax: UnaffectedWaveformSyntax) -> Self {
+        CheckedUnaffectedWaveform(syntax)
+    }
+    fn raw(&self) -> UnaffectedWaveformSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUnaffectedWaveform {
+    pub fn unaffected_token(&self) -> SyntaxToken {
+        self.0.unaffected_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedWaveform {
+    WaveformElements(CheckedWaveformElements),
+    UnaffectedWaveform(CheckedUnaffectedWaveform),
+}
+impl CheckedNode for CheckedWaveform {
+    type Syntax = WaveformSyntax;
+    fn cast_unchecked(syntax: WaveformSyntax) -> Self {
+        match syntax {
+            WaveformSyntax::WaveformElements(inner) => {
+                CheckedWaveform::WaveformElements(CheckedWaveformElements::cast_unchecked(inner))
+            }
+            WaveformSyntax::UnaffectedWaveform(inner) => CheckedWaveform::UnaffectedWaveform(
+                CheckedUnaffectedWaveform::cast_unchecked(inner),
+            ),
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedWaveform::WaveformElements(inner) => {
+                WaveformSyntax::WaveformElements(inner.raw())
+            }
+            CheckedWaveform::UnaffectedWaveform(inner) => {
+                WaveformSyntax::UnaffectedWaveform(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSequentialStatements(SequentialStatementsSyntax);
+impl CheckedNode for CheckedSequentialStatements {
+    type Syntax = SequentialStatementsSyntax;
+    fn cast_unchecked(syntax: SequentialStatementsSyntax) -> Self {
+        CheckedSequentialStatements(syntax)
+    }
+    fn raw(&self) -> SequentialStatementsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSequentialStatements {
+    pub fn sequential_statements(
+        &self,
+    ) -> impl Iterator<Item = CheckedSequentialStatement> + use<'_> {
+        self.0
+            .sequential_statements()
+            .map(CheckedSequentialStatement::cast_unchecked)
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/specifications.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/specifications.rs
@@ -1,0 +1,721 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedAttributeSpecification(AttributeSpecificationSyntax);
+impl CheckedNode for CheckedAttributeSpecification {
+    type Syntax = AttributeSpecificationSyntax;
+    fn cast_unchecked(syntax: AttributeSpecificationSyntax) -> Self {
+        CheckedAttributeSpecification(syntax)
+    }
+    fn raw(&self) -> AttributeSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAttributeSpecification {
+    pub fn attribute_token(&self) -> SyntaxToken {
+        self.0.attribute_token().unwrap()
+    }
+    pub fn attribute_designator_token_token(&self) -> SyntaxToken {
+        self.0.attribute_designator_token_token().unwrap()
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn entity_specification(&self) -> CheckedEntitySpecification {
+        CheckedEntitySpecification::cast_unchecked(self.0.entity_specification().unwrap())
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedBindingIndication(BindingIndicationSyntax);
+impl CheckedNode for CheckedBindingIndication {
+    type Syntax = BindingIndicationSyntax;
+    fn cast_unchecked(syntax: BindingIndicationSyntax) -> Self {
+        CheckedBindingIndication(syntax)
+    }
+    fn raw(&self) -> BindingIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedBindingIndication {
+    pub fn use_token(&self) -> Option<SyntaxToken> {
+        self.0.use_token()
+    }
+    pub fn entity_aspect(&self) -> Option<CheckedEntityAspect> {
+        self.0
+            .entity_aspect()
+            .map(CheckedEntityAspect::cast_unchecked)
+    }
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+    pub fn port_map_aspect(&self) -> Option<CheckedPortMapAspect> {
+        self.0
+            .port_map_aspect()
+            .map(CheckedPortMapAspect::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedComponentSpecification(ComponentSpecificationSyntax);
+impl CheckedNode for CheckedComponentSpecification {
+    type Syntax = ComponentSpecificationSyntax;
+    fn cast_unchecked(syntax: ComponentSpecificationSyntax) -> Self {
+        CheckedComponentSpecification(syntax)
+    }
+    fn raw(&self) -> ComponentSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedComponentSpecification {
+    pub fn instantiation_list(&self) -> CheckedInstantiationList {
+        CheckedInstantiationList::cast_unchecked(self.0.instantiation_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCompoundConfigurationSpecification(CompoundConfigurationSpecificationSyntax);
+impl CheckedNode for CheckedCompoundConfigurationSpecification {
+    type Syntax = CompoundConfigurationSpecificationSyntax;
+    fn cast_unchecked(syntax: CompoundConfigurationSpecificationSyntax) -> Self {
+        CheckedCompoundConfigurationSpecification(syntax)
+    }
+    fn raw(&self) -> CompoundConfigurationSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCompoundConfigurationSpecification {
+    pub fn component_configuration_preamble(&self) -> CheckedComponentConfigurationPreamble {
+        CheckedComponentConfigurationPreamble::cast_unchecked(
+            self.0.component_configuration_preamble().unwrap(),
+        )
+    }
+    pub fn compound_configuration_specification_items(
+        &self,
+    ) -> CheckedCompoundConfigurationSpecificationItems {
+        CheckedCompoundConfigurationSpecificationItems::cast_unchecked(
+            self.0.compound_configuration_specification_items().unwrap(),
+        )
+    }
+    pub fn component_configuration_epilogue(&self) -> CheckedComponentConfigurationEpilogue {
+        CheckedComponentConfigurationEpilogue::cast_unchecked(
+            self.0.component_configuration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedCompoundConfigurationSpecificationItems(
+    CompoundConfigurationSpecificationItemsSyntax,
+);
+impl CheckedNode for CheckedCompoundConfigurationSpecificationItems {
+    type Syntax = CompoundConfigurationSpecificationItemsSyntax;
+    fn cast_unchecked(syntax: CompoundConfigurationSpecificationItemsSyntax) -> Self {
+        CheckedCompoundConfigurationSpecificationItems(syntax)
+    }
+    fn raw(&self) -> CompoundConfigurationSpecificationItemsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedCompoundConfigurationSpecificationItems {
+    pub fn semi_colon_terminated_binding_indication(
+        &self,
+    ) -> CheckedSemiColonTerminatedBindingIndication {
+        CheckedSemiColonTerminatedBindingIndication::cast_unchecked(
+            self.0.semi_colon_terminated_binding_indication().unwrap(),
+        )
+    }
+    pub fn verification_unit_binding_indications(
+        &self,
+    ) -> impl Iterator<Item = CheckedVerificationUnitBindingIndication> + use<'_> {
+        self.0
+            .verification_unit_binding_indications()
+            .map(CheckedVerificationUnitBindingIndication::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedConfigurationSpecification {
+    SimpleConfigurationSpecification(CheckedSimpleConfigurationSpecification),
+    CompoundConfigurationSpecification(CheckedCompoundConfigurationSpecification),
+}
+impl CheckedNode for CheckedConfigurationSpecification {
+    type Syntax = ConfigurationSpecificationSyntax;
+    fn cast_unchecked(syntax: ConfigurationSpecificationSyntax) -> Self {
+        match syntax {
+            ConfigurationSpecificationSyntax::SimpleConfigurationSpecification(inner) => {
+                CheckedConfigurationSpecification::SimpleConfigurationSpecification(
+                    CheckedSimpleConfigurationSpecification::cast_unchecked(inner),
+                )
+            }
+            ConfigurationSpecificationSyntax::CompoundConfigurationSpecification(inner) => {
+                CheckedConfigurationSpecification::CompoundConfigurationSpecification(
+                    CheckedCompoundConfigurationSpecification::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedConfigurationSpecification::SimpleConfigurationSpecification(inner) => {
+                ConfigurationSpecificationSyntax::SimpleConfigurationSpecification(inner.raw())
+            }
+            CheckedConfigurationSpecification::CompoundConfigurationSpecification(inner) => {
+                ConfigurationSpecificationSyntax::CompoundConfigurationSpecification(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedDisconnectionSpecification(DisconnectionSpecificationSyntax);
+impl CheckedNode for CheckedDisconnectionSpecification {
+    type Syntax = DisconnectionSpecificationSyntax;
+    fn cast_unchecked(syntax: DisconnectionSpecificationSyntax) -> Self {
+        CheckedDisconnectionSpecification(syntax)
+    }
+    fn raw(&self) -> DisconnectionSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedDisconnectionSpecification {
+    pub fn disconnect_token(&self) -> SyntaxToken {
+        self.0.disconnect_token().unwrap()
+    }
+    pub fn guarded_signal_specification(&self) -> CheckedGuardedSignalSpecification {
+        CheckedGuardedSignalSpecification::cast_unchecked(
+            self.0.guarded_signal_specification().unwrap(),
+        )
+    }
+    pub fn after_token(&self) -> SyntaxToken {
+        self.0.after_token().unwrap()
+    }
+    pub fn expression(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.expression().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityEntityAspect(EntityEntityAspectSyntax);
+impl CheckedNode for CheckedEntityEntityAspect {
+    type Syntax = EntityEntityAspectSyntax;
+    fn cast_unchecked(syntax: EntityEntityAspectSyntax) -> Self {
+        CheckedEntityEntityAspect(syntax)
+    }
+    fn raw(&self) -> EntityEntityAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityEntityAspect {
+    pub fn entity_token(&self) -> SyntaxToken {
+        self.0.entity_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityConfigurationAspect(EntityConfigurationAspectSyntax);
+impl CheckedNode for CheckedEntityConfigurationAspect {
+    type Syntax = EntityConfigurationAspectSyntax;
+    fn cast_unchecked(syntax: EntityConfigurationAspectSyntax) -> Self {
+        CheckedEntityConfigurationAspect(syntax)
+    }
+    fn raw(&self) -> EntityConfigurationAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityConfigurationAspect {
+    pub fn configuration_token(&self) -> SyntaxToken {
+        self.0.configuration_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityOpenAspect(EntityOpenAspectSyntax);
+impl CheckedNode for CheckedEntityOpenAspect {
+    type Syntax = EntityOpenAspectSyntax;
+    fn cast_unchecked(syntax: EntityOpenAspectSyntax) -> Self {
+        CheckedEntityOpenAspect(syntax)
+    }
+    fn raw(&self) -> EntityOpenAspectSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityOpenAspect {
+    pub fn open_token(&self) -> SyntaxToken {
+        self.0.open_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedEntityAspect {
+    EntityEntityAspect(CheckedEntityEntityAspect),
+    EntityConfigurationAspect(CheckedEntityConfigurationAspect),
+    EntityOpenAspect(CheckedEntityOpenAspect),
+}
+impl CheckedNode for CheckedEntityAspect {
+    type Syntax = EntityAspectSyntax;
+    fn cast_unchecked(syntax: EntityAspectSyntax) -> Self {
+        match syntax {
+            EntityAspectSyntax::EntityEntityAspect(inner) => {
+                CheckedEntityAspect::EntityEntityAspect(CheckedEntityEntityAspect::cast_unchecked(
+                    inner,
+                ))
+            }
+            EntityAspectSyntax::EntityConfigurationAspect(inner) => {
+                CheckedEntityAspect::EntityConfigurationAspect(
+                    CheckedEntityConfigurationAspect::cast_unchecked(inner),
+                )
+            }
+            EntityAspectSyntax::EntityOpenAspect(inner) => CheckedEntityAspect::EntityOpenAspect(
+                CheckedEntityOpenAspect::cast_unchecked(inner),
+            ),
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedEntityAspect::EntityEntityAspect(inner) => {
+                EntityAspectSyntax::EntityEntityAspect(inner.raw())
+            }
+            CheckedEntityAspect::EntityConfigurationAspect(inner) => {
+                EntityAspectSyntax::EntityConfigurationAspect(inner.raw())
+            }
+            CheckedEntityAspect::EntityOpenAspect(inner) => {
+                EntityAspectSyntax::EntityOpenAspect(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityDesignator(EntityDesignatorSyntax);
+impl CheckedNode for CheckedEntityDesignator {
+    type Syntax = EntityDesignatorSyntax;
+    fn cast_unchecked(syntax: EntityDesignatorSyntax) -> Self {
+        CheckedEntityDesignator(syntax)
+    }
+    fn raw(&self) -> EntityDesignatorSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityDesignator {
+    pub fn entity_tag(&self) -> EntityTagSyntax {
+        self.0.entity_tag().unwrap()
+    }
+    pub fn signature(&self) -> CheckedSignature {
+        CheckedSignature::cast_unchecked(self.0.signature().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityDesignatorList(EntityDesignatorListSyntax);
+impl CheckedNode for CheckedEntityDesignatorList {
+    type Syntax = EntityDesignatorListSyntax;
+    fn cast_unchecked(syntax: EntityDesignatorListSyntax) -> Self {
+        CheckedEntityDesignatorList(syntax)
+    }
+    fn raw(&self) -> EntityDesignatorListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityDesignatorList {
+    pub fn entity_designators(&self) -> impl Iterator<Item = CheckedEntityDesignator> + use<'_> {
+        self.0
+            .entity_designators()
+            .map(CheckedEntityDesignator::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityNameListAll(EntityNameListAllSyntax);
+impl CheckedNode for CheckedEntityNameListAll {
+    type Syntax = EntityNameListAllSyntax;
+    fn cast_unchecked(syntax: EntityNameListAllSyntax) -> Self {
+        CheckedEntityNameListAll(syntax)
+    }
+    fn raw(&self) -> EntityNameListAllSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityNameListAll {
+    pub fn all_token(&self) -> SyntaxToken {
+        self.0.all_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntityNameListOthers(EntityNameListOthersSyntax);
+impl CheckedNode for CheckedEntityNameListOthers {
+    type Syntax = EntityNameListOthersSyntax;
+    fn cast_unchecked(syntax: EntityNameListOthersSyntax) -> Self {
+        CheckedEntityNameListOthers(syntax)
+    }
+    fn raw(&self) -> EntityNameListOthersSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntityNameListOthers {
+    pub fn others_token(&self) -> SyntaxToken {
+        self.0.others_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedEntityNameList {
+    EntityDesignatorList(CheckedEntityDesignatorList),
+    EntityNameListAll(CheckedEntityNameListAll),
+    EntityNameListOthers(CheckedEntityNameListOthers),
+}
+impl CheckedNode for CheckedEntityNameList {
+    type Syntax = EntityNameListSyntax;
+    fn cast_unchecked(syntax: EntityNameListSyntax) -> Self {
+        match syntax {
+            EntityNameListSyntax::EntityDesignatorList(inner) => {
+                CheckedEntityNameList::EntityDesignatorList(
+                    CheckedEntityDesignatorList::cast_unchecked(inner),
+                )
+            }
+            EntityNameListSyntax::EntityNameListAll(inner) => {
+                CheckedEntityNameList::EntityNameListAll(CheckedEntityNameListAll::cast_unchecked(
+                    inner,
+                ))
+            }
+            EntityNameListSyntax::EntityNameListOthers(inner) => {
+                CheckedEntityNameList::EntityNameListOthers(
+                    CheckedEntityNameListOthers::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedEntityNameList::EntityDesignatorList(inner) => {
+                EntityNameListSyntax::EntityDesignatorList(inner.raw())
+            }
+            CheckedEntityNameList::EntityNameListAll(inner) => {
+                EntityNameListSyntax::EntityNameListAll(inner.raw())
+            }
+            CheckedEntityNameList::EntityNameListOthers(inner) => {
+                EntityNameListSyntax::EntityNameListOthers(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEntitySpecification(EntitySpecificationSyntax);
+impl CheckedNode for CheckedEntitySpecification {
+    type Syntax = EntitySpecificationSyntax;
+    fn cast_unchecked(syntax: EntitySpecificationSyntax) -> Self {
+        CheckedEntitySpecification(syntax)
+    }
+    fn raw(&self) -> EntitySpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEntitySpecification {
+    pub fn entity_name_list(&self) -> CheckedEntityNameList {
+        CheckedEntityNameList::cast_unchecked(self.0.entity_name_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn entity_class(&self) -> EntityClassSyntax {
+        self.0.entity_class().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedGuardedSignalSpecification(GuardedSignalSpecificationSyntax);
+impl CheckedNode for CheckedGuardedSignalSpecification {
+    type Syntax = GuardedSignalSpecificationSyntax;
+    fn cast_unchecked(syntax: GuardedSignalSpecificationSyntax) -> Self {
+        CheckedGuardedSignalSpecification(syntax)
+    }
+    fn raw(&self) -> GuardedSignalSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedGuardedSignalSpecification {
+    pub fn signal_list(&self) -> CheckedSignalList {
+        CheckedSignalList::cast_unchecked(self.0.signal_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInstantiationListList(InstantiationListListSyntax);
+impl CheckedNode for CheckedInstantiationListList {
+    type Syntax = InstantiationListListSyntax;
+    fn cast_unchecked(syntax: InstantiationListListSyntax) -> Self {
+        CheckedInstantiationListList(syntax)
+    }
+    fn raw(&self) -> InstantiationListListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInstantiationListList {
+    pub fn identifier_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.identifier_token()
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInstantiationListAll(InstantiationListAllSyntax);
+impl CheckedNode for CheckedInstantiationListAll {
+    type Syntax = InstantiationListAllSyntax;
+    fn cast_unchecked(syntax: InstantiationListAllSyntax) -> Self {
+        CheckedInstantiationListAll(syntax)
+    }
+    fn raw(&self) -> InstantiationListAllSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInstantiationListAll {
+    pub fn all_token(&self) -> SyntaxToken {
+        self.0.all_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedInstantiationListOthers(InstantiationListOthersSyntax);
+impl CheckedNode for CheckedInstantiationListOthers {
+    type Syntax = InstantiationListOthersSyntax;
+    fn cast_unchecked(syntax: InstantiationListOthersSyntax) -> Self {
+        CheckedInstantiationListOthers(syntax)
+    }
+    fn raw(&self) -> InstantiationListOthersSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedInstantiationListOthers {
+    pub fn others_token(&self) -> SyntaxToken {
+        self.0.others_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedInstantiationList {
+    InstantiationListList(CheckedInstantiationListList),
+    InstantiationListAll(CheckedInstantiationListAll),
+    InstantiationListOthers(CheckedInstantiationListOthers),
+}
+impl CheckedNode for CheckedInstantiationList {
+    type Syntax = InstantiationListSyntax;
+    fn cast_unchecked(syntax: InstantiationListSyntax) -> Self {
+        match syntax {
+            InstantiationListSyntax::InstantiationListList(inner) => {
+                CheckedInstantiationList::InstantiationListList(
+                    CheckedInstantiationListList::cast_unchecked(inner),
+                )
+            }
+            InstantiationListSyntax::InstantiationListAll(inner) => {
+                CheckedInstantiationList::InstantiationListAll(
+                    CheckedInstantiationListAll::cast_unchecked(inner),
+                )
+            }
+            InstantiationListSyntax::InstantiationListOthers(inner) => {
+                CheckedInstantiationList::InstantiationListOthers(
+                    CheckedInstantiationListOthers::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedInstantiationList::InstantiationListList(inner) => {
+                InstantiationListSyntax::InstantiationListList(inner.raw())
+            }
+            CheckedInstantiationList::InstantiationListAll(inner) => {
+                InstantiationListSyntax::InstantiationListAll(inner.raw())
+            }
+            CheckedInstantiationList::InstantiationListOthers(inner) => {
+                InstantiationListSyntax::InstantiationListOthers(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSignalListList(SignalListListSyntax);
+impl CheckedNode for CheckedSignalListList {
+    type Syntax = SignalListListSyntax;
+    fn cast_unchecked(syntax: SignalListListSyntax) -> Self {
+        CheckedSignalListList(syntax)
+    }
+    fn raw(&self) -> SignalListListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSignalListList {
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSignalListAll(SignalListAllSyntax);
+impl CheckedNode for CheckedSignalListAll {
+    type Syntax = SignalListAllSyntax;
+    fn cast_unchecked(syntax: SignalListAllSyntax) -> Self {
+        CheckedSignalListAll(syntax)
+    }
+    fn raw(&self) -> SignalListAllSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSignalListAll {
+    pub fn all_token(&self) -> SyntaxToken {
+        self.0.all_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSignalListOthers(SignalListOthersSyntax);
+impl CheckedNode for CheckedSignalListOthers {
+    type Syntax = SignalListOthersSyntax;
+    fn cast_unchecked(syntax: SignalListOthersSyntax) -> Self {
+        CheckedSignalListOthers(syntax)
+    }
+    fn raw(&self) -> SignalListOthersSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSignalListOthers {
+    pub fn others_token(&self) -> SyntaxToken {
+        self.0.others_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSignalList {
+    SignalListList(CheckedSignalListList),
+    SignalListAll(CheckedSignalListAll),
+    SignalListOthers(CheckedSignalListOthers),
+}
+impl CheckedNode for CheckedSignalList {
+    type Syntax = SignalListSyntax;
+    fn cast_unchecked(syntax: SignalListSyntax) -> Self {
+        match syntax {
+            SignalListSyntax::SignalListList(inner) => {
+                CheckedSignalList::SignalListList(CheckedSignalListList::cast_unchecked(inner))
+            }
+            SignalListSyntax::SignalListAll(inner) => {
+                CheckedSignalList::SignalListAll(CheckedSignalListAll::cast_unchecked(inner))
+            }
+            SignalListSyntax::SignalListOthers(inner) => {
+                CheckedSignalList::SignalListOthers(CheckedSignalListOthers::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSignalList::SignalListList(inner) => {
+                SignalListSyntax::SignalListList(inner.raw())
+            }
+            CheckedSignalList::SignalListAll(inner) => SignalListSyntax::SignalListAll(inner.raw()),
+            CheckedSignalList::SignalListOthers(inner) => {
+                SignalListSyntax::SignalListOthers(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSimpleConfigurationSpecification(SimpleConfigurationSpecificationSyntax);
+impl CheckedNode for CheckedSimpleConfigurationSpecification {
+    type Syntax = SimpleConfigurationSpecificationSyntax;
+    fn cast_unchecked(syntax: SimpleConfigurationSpecificationSyntax) -> Self {
+        CheckedSimpleConfigurationSpecification(syntax)
+    }
+    fn raw(&self) -> SimpleConfigurationSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSimpleConfigurationSpecification {
+    pub fn component_configuration_preamble(&self) -> CheckedComponentConfigurationPreamble {
+        CheckedComponentConfigurationPreamble::cast_unchecked(
+            self.0.component_configuration_preamble().unwrap(),
+        )
+    }
+    pub fn semi_colon_terminated_binding_indication(
+        &self,
+    ) -> CheckedSemiColonTerminatedBindingIndication {
+        CheckedSemiColonTerminatedBindingIndication::cast_unchecked(
+            self.0.semi_colon_terminated_binding_indication().unwrap(),
+        )
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+    pub fn component_configuration_epilogue(
+        &self,
+    ) -> Option<CheckedComponentConfigurationEpilogue> {
+        self.0
+            .component_configuration_epilogue()
+            .map(CheckedComponentConfigurationEpilogue::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedVerificationUnitBindingIndication(VerificationUnitBindingIndicationSyntax);
+impl CheckedNode for CheckedVerificationUnitBindingIndication {
+    type Syntax = VerificationUnitBindingIndicationSyntax;
+    fn cast_unchecked(syntax: VerificationUnitBindingIndicationSyntax) -> Self {
+        CheckedVerificationUnitBindingIndication(syntax)
+    }
+    fn raw(&self) -> VerificationUnitBindingIndicationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedVerificationUnitBindingIndication {
+    pub fn use_token(&self) -> SyntaxToken {
+        self.0.use_token().unwrap()
+    }
+    pub fn vunit_token(&self) -> SyntaxToken {
+        self.0.vunit_token().unwrap()
+    }
+    pub fn verification_unit_list(&self) -> Option<CheckedVerificationUnitList> {
+        self.0
+            .verification_unit_list()
+            .map(CheckedVerificationUnitList::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedVerificationUnitList(VerificationUnitListSyntax);
+impl CheckedNode for CheckedVerificationUnitList {
+    type Syntax = VerificationUnitListSyntax;
+    fn cast_unchecked(syntax: VerificationUnitListSyntax) -> Self {
+        CheckedVerificationUnitList(syntax)
+    }
+    fn raw(&self) -> VerificationUnitListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedVerificationUnitList {
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/subprograms_packages.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/subprograms_packages.rs
@@ -1,0 +1,624 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramDeclaration(SubprogramDeclarationSyntax);
+impl CheckedNode for CheckedSubprogramDeclaration {
+    type Syntax = SubprogramDeclarationSyntax;
+    fn cast_unchecked(syntax: SubprogramDeclarationSyntax) -> Self {
+        CheckedSubprogramDeclaration(syntax)
+    }
+    fn raw(&self) -> SubprogramDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramDeclaration {
+    pub fn subprogram_specification(&self) -> CheckedSubprogramSpecification {
+        CheckedSubprogramSpecification::cast_unchecked(self.0.subprogram_specification().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedSubprogramSpecification {
+    ProcedureSpecification(CheckedProcedureSpecification),
+    FunctionSpecification(CheckedFunctionSpecification),
+}
+impl CheckedNode for CheckedSubprogramSpecification {
+    type Syntax = SubprogramSpecificationSyntax;
+    fn cast_unchecked(syntax: SubprogramSpecificationSyntax) -> Self {
+        match syntax {
+            SubprogramSpecificationSyntax::ProcedureSpecification(inner) => {
+                CheckedSubprogramSpecification::ProcedureSpecification(
+                    CheckedProcedureSpecification::cast_unchecked(inner),
+                )
+            }
+            SubprogramSpecificationSyntax::FunctionSpecification(inner) => {
+                CheckedSubprogramSpecification::FunctionSpecification(
+                    CheckedFunctionSpecification::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedSubprogramSpecification::ProcedureSpecification(inner) => {
+                SubprogramSpecificationSyntax::ProcedureSpecification(inner.raw())
+            }
+            CheckedSubprogramSpecification::FunctionSpecification(inner) => {
+                SubprogramSpecificationSyntax::FunctionSpecification(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProcedureSpecification(ProcedureSpecificationSyntax);
+impl CheckedNode for CheckedProcedureSpecification {
+    type Syntax = ProcedureSpecificationSyntax;
+    fn cast_unchecked(syntax: ProcedureSpecificationSyntax) -> Self {
+        CheckedProcedureSpecification(syntax)
+    }
+    fn raw(&self) -> ProcedureSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProcedureSpecification {
+    pub fn procedure_token(&self) -> SyntaxToken {
+        self.0.procedure_token().unwrap()
+    }
+    pub fn designator(&self) -> DesignatorSyntax {
+        self.0.designator().unwrap()
+    }
+    pub fn subprogram_header(&self) -> Option<CheckedSubprogramHeader> {
+        self.0
+            .subprogram_header()
+            .map(CheckedSubprogramHeader::cast_unchecked)
+    }
+    pub fn parameter_list(&self) -> Option<CheckedParameterList> {
+        self.0
+            .parameter_list()
+            .map(CheckedParameterList::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFunctionSpecification(FunctionSpecificationSyntax);
+impl CheckedNode for CheckedFunctionSpecification {
+    type Syntax = FunctionSpecificationSyntax;
+    fn cast_unchecked(syntax: FunctionSpecificationSyntax) -> Self {
+        CheckedFunctionSpecification(syntax)
+    }
+    fn raw(&self) -> FunctionSpecificationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFunctionSpecification {
+    pub fn function_purity(&self) -> Option<FunctionPuritySyntax> {
+        self.0.function_purity()
+    }
+    pub fn function_token(&self) -> SyntaxToken {
+        self.0.function_token().unwrap()
+    }
+    pub fn designator(&self) -> DesignatorSyntax {
+        self.0.designator().unwrap()
+    }
+    pub fn subprogram_header(&self) -> Option<CheckedSubprogramHeader> {
+        self.0
+            .subprogram_header()
+            .map(CheckedSubprogramHeader::cast_unchecked)
+    }
+    pub fn parameter_list(&self) -> Option<CheckedParameterList> {
+        self.0
+            .parameter_list()
+            .map(CheckedParameterList::cast_unchecked)
+    }
+    pub fn return_token(&self) -> SyntaxToken {
+        self.0.return_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParenthesizedInterfaceList(ParenthesizedInterfaceListSyntax);
+impl CheckedNode for CheckedParenthesizedInterfaceList {
+    type Syntax = ParenthesizedInterfaceListSyntax;
+    fn cast_unchecked(syntax: ParenthesizedInterfaceListSyntax) -> Self {
+        CheckedParenthesizedInterfaceList(syntax)
+    }
+    fn raw(&self) -> ParenthesizedInterfaceListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParenthesizedInterfaceList {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn interface_list(&self) -> Option<CheckedInterfaceList> {
+        self.0
+            .interface_list()
+            .map(CheckedInterfaceList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedParameterList(ParameterListSyntax);
+impl CheckedNode for CheckedParameterList {
+    type Syntax = ParameterListSyntax;
+    fn cast_unchecked(syntax: ParameterListSyntax) -> Self {
+        CheckedParameterList(syntax)
+    }
+    fn raw(&self) -> ParameterListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedParameterList {
+    pub fn parameter_token(&self) -> Option<SyntaxToken> {
+        self.0.parameter_token()
+    }
+    pub fn parenthesized_interface_list(&self) -> Option<CheckedParenthesizedInterfaceList> {
+        self.0
+            .parenthesized_interface_list()
+            .map(CheckedParenthesizedInterfaceList::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramHeader(SubprogramHeaderSyntax);
+impl CheckedNode for CheckedSubprogramHeader {
+    type Syntax = SubprogramHeaderSyntax;
+    fn cast_unchecked(syntax: SubprogramHeaderSyntax) -> Self {
+        CheckedSubprogramHeader(syntax)
+    }
+    fn raw(&self) -> SubprogramHeaderSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramHeader {
+    pub fn subprogram_header_generic_clause(&self) -> Option<CheckedSubprogramHeaderGenericClause> {
+        self.0
+            .subprogram_header_generic_clause()
+            .map(CheckedSubprogramHeaderGenericClause::cast_unchecked)
+    }
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramHeaderGenericClause(SubprogramHeaderGenericClauseSyntax);
+impl CheckedNode for CheckedSubprogramHeaderGenericClause {
+    type Syntax = SubprogramHeaderGenericClauseSyntax;
+    fn cast_unchecked(syntax: SubprogramHeaderGenericClauseSyntax) -> Self {
+        CheckedSubprogramHeaderGenericClause(syntax)
+    }
+    fn raw(&self) -> SubprogramHeaderGenericClauseSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramHeaderGenericClause {
+    pub fn generic_token(&self) -> SyntaxToken {
+        self.0.generic_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn interface_list(&self) -> Option<CheckedInterfaceList> {
+        self.0
+            .interface_list()
+            .map(CheckedInterfaceList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramBody(SubprogramBodySyntax);
+impl CheckedNode for CheckedSubprogramBody {
+    type Syntax = SubprogramBodySyntax;
+    fn cast_unchecked(syntax: SubprogramBodySyntax) -> Self {
+        CheckedSubprogramBody(syntax)
+    }
+    fn raw(&self) -> SubprogramBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramBody {
+    pub fn subprogram_body_preamble(&self) -> CheckedSubprogramBodyPreamble {
+        CheckedSubprogramBodyPreamble::cast_unchecked(self.0.subprogram_body_preamble().unwrap())
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn declaration_statement_separator(&self) -> CheckedDeclarationStatementSeparator {
+        CheckedDeclarationStatementSeparator::cast_unchecked(
+            self.0.declaration_statement_separator().unwrap(),
+        )
+    }
+    pub fn concurrent_statements(&self) -> Option<CheckedConcurrentStatements> {
+        self.0
+            .concurrent_statements()
+            .map(CheckedConcurrentStatements::cast_unchecked)
+    }
+    pub fn subprogram_body_epilogue(&self) -> CheckedSubprogramBodyEpilogue {
+        CheckedSubprogramBodyEpilogue::cast_unchecked(self.0.subprogram_body_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramBodyPreamble(SubprogramBodyPreambleSyntax);
+impl CheckedNode for CheckedSubprogramBodyPreamble {
+    type Syntax = SubprogramBodyPreambleSyntax;
+    fn cast_unchecked(syntax: SubprogramBodyPreambleSyntax) -> Self {
+        CheckedSubprogramBodyPreamble(syntax)
+    }
+    fn raw(&self) -> SubprogramBodyPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramBodyPreamble {
+    pub fn subprogram_specification(&self) -> CheckedSubprogramSpecification {
+        CheckedSubprogramSpecification::cast_unchecked(self.0.subprogram_specification().unwrap())
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramBodyEpilogue(SubprogramBodyEpilogueSyntax);
+impl CheckedNode for CheckedSubprogramBodyEpilogue {
+    type Syntax = SubprogramBodyEpilogueSyntax;
+    fn cast_unchecked(syntax: SubprogramBodyEpilogueSyntax) -> Self {
+        CheckedSubprogramBodyEpilogue(syntax)
+    }
+    fn raw(&self) -> SubprogramBodyEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramBodyEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn subprogram_kind(&self) -> Option<SubprogramKindSyntax> {
+        self.0.subprogram_kind()
+    }
+    pub fn designator(&self) -> Option<DesignatorSyntax> {
+        self.0.designator()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramInstantiationDeclaration(SubprogramInstantiationDeclarationSyntax);
+impl CheckedNode for CheckedSubprogramInstantiationDeclaration {
+    type Syntax = SubprogramInstantiationDeclarationSyntax;
+    fn cast_unchecked(syntax: SubprogramInstantiationDeclarationSyntax) -> Self {
+        CheckedSubprogramInstantiationDeclaration(syntax)
+    }
+    fn raw(&self) -> SubprogramInstantiationDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramInstantiationDeclaration {
+    pub fn subprogram_instantiation_declaration_preamble(
+        &self,
+    ) -> CheckedSubprogramInstantiationDeclarationPreamble {
+        CheckedSubprogramInstantiationDeclarationPreamble::cast_unchecked(
+            self.0
+                .subprogram_instantiation_declaration_preamble()
+                .unwrap(),
+        )
+    }
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubprogramInstantiationDeclarationPreamble(
+    SubprogramInstantiationDeclarationPreambleSyntax,
+);
+impl CheckedNode for CheckedSubprogramInstantiationDeclarationPreamble {
+    type Syntax = SubprogramInstantiationDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: SubprogramInstantiationDeclarationPreambleSyntax) -> Self {
+        CheckedSubprogramInstantiationDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> SubprogramInstantiationDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubprogramInstantiationDeclarationPreamble {
+    pub fn subprogram_kind(&self) -> SubprogramKindSyntax {
+        self.0.subprogram_kind().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn new_token(&self) -> SyntaxToken {
+        self.0.new_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn signature(&self) -> Option<CheckedSignature> {
+        self.0.signature().map(CheckedSignature::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackage(PackageSyntax);
+impl CheckedNode for CheckedPackage {
+    type Syntax = PackageSyntax;
+    fn cast_unchecked(syntax: PackageSyntax) -> Self {
+        CheckedPackage(syntax)
+    }
+    fn raw(&self) -> PackageSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackage {
+    pub fn package_preamble(&self) -> CheckedPackagePreamble {
+        CheckedPackagePreamble::cast_unchecked(self.0.package_preamble().unwrap())
+    }
+    pub fn package_header(&self) -> Option<CheckedPackageHeader> {
+        self.0
+            .package_header()
+            .map(CheckedPackageHeader::cast_unchecked)
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn package_epilogue(&self) -> CheckedPackageEpilogue {
+        CheckedPackageEpilogue::cast_unchecked(self.0.package_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackagePreamble(PackagePreambleSyntax);
+impl CheckedNode for CheckedPackagePreamble {
+    type Syntax = PackagePreambleSyntax;
+    fn cast_unchecked(syntax: PackagePreambleSyntax) -> Self {
+        CheckedPackagePreamble(syntax)
+    }
+    fn raw(&self) -> PackagePreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackagePreamble {
+    pub fn package_token(&self) -> SyntaxToken {
+        self.0.package_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageEpilogue(PackageEpilogueSyntax);
+impl CheckedNode for CheckedPackageEpilogue {
+    type Syntax = PackageEpilogueSyntax;
+    fn cast_unchecked(syntax: PackageEpilogueSyntax) -> Self {
+        CheckedPackageEpilogue(syntax)
+    }
+    fn raw(&self) -> PackageEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn package_token(&self) -> Option<SyntaxToken> {
+        self.0.package_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageHeader(PackageHeaderSyntax);
+impl CheckedNode for CheckedPackageHeader {
+    type Syntax = PackageHeaderSyntax;
+    fn cast_unchecked(syntax: PackageHeaderSyntax) -> Self {
+        CheckedPackageHeader(syntax)
+    }
+    fn raw(&self) -> PackageHeaderSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageHeader {
+    pub fn generic_clause(&self) -> Option<CheckedGenericClause> {
+        self.0
+            .generic_clause()
+            .map(CheckedGenericClause::cast_unchecked)
+    }
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> Option<SyntaxToken> {
+        self.0.semi_colon_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageBody(PackageBodySyntax);
+impl CheckedNode for CheckedPackageBody {
+    type Syntax = PackageBodySyntax;
+    fn cast_unchecked(syntax: PackageBodySyntax) -> Self {
+        CheckedPackageBody(syntax)
+    }
+    fn raw(&self) -> PackageBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageBody {
+    pub fn package_body_preamble(&self) -> CheckedPackageBodyPreamble {
+        CheckedPackageBodyPreamble::cast_unchecked(self.0.package_body_preamble().unwrap())
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn package_body_epilogue(&self) -> CheckedPackageBodyEpilogue {
+        CheckedPackageBodyEpilogue::cast_unchecked(self.0.package_body_epilogue().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageBodyPreamble(PackageBodyPreambleSyntax);
+impl CheckedNode for CheckedPackageBodyPreamble {
+    type Syntax = PackageBodyPreambleSyntax;
+    fn cast_unchecked(syntax: PackageBodyPreambleSyntax) -> Self {
+        CheckedPackageBodyPreamble(syntax)
+    }
+    fn raw(&self) -> PackageBodyPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageBodyPreamble {
+    pub fn package_token(&self) -> SyntaxToken {
+        self.0.package_token().unwrap()
+    }
+    pub fn body_token(&self) -> SyntaxToken {
+        self.0.body_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageBodyEpilogue(PackageBodyEpilogueSyntax);
+impl CheckedNode for CheckedPackageBodyEpilogue {
+    type Syntax = PackageBodyEpilogueSyntax;
+    fn cast_unchecked(syntax: PackageBodyEpilogueSyntax) -> Self {
+        CheckedPackageBodyEpilogue(syntax)
+    }
+    fn raw(&self) -> PackageBodyEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageBodyEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn package_token(&self) -> Option<SyntaxToken> {
+        self.0.package_token()
+    }
+    pub fn body_token(&self) -> Option<SyntaxToken> {
+        self.0.body_token()
+    }
+    pub fn identifier_token(&self) -> Option<SyntaxToken> {
+        self.0.identifier_token()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageInstantiation(PackageInstantiationSyntax);
+impl CheckedNode for CheckedPackageInstantiation {
+    type Syntax = PackageInstantiationSyntax;
+    fn cast_unchecked(syntax: PackageInstantiationSyntax) -> Self {
+        CheckedPackageInstantiation(syntax)
+    }
+    fn raw(&self) -> PackageInstantiationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageInstantiation {
+    pub fn package_instantiation_preamble(&self) -> CheckedPackageInstantiationPreamble {
+        CheckedPackageInstantiationPreamble::cast_unchecked(
+            self.0.package_instantiation_preamble().unwrap(),
+        )
+    }
+    pub fn generic_map_aspect(&self) -> Option<CheckedGenericMapAspect> {
+        self.0
+            .generic_map_aspect()
+            .map(CheckedGenericMapAspect::cast_unchecked)
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPackageInstantiationPreamble(PackageInstantiationPreambleSyntax);
+impl CheckedNode for CheckedPackageInstantiationPreamble {
+    type Syntax = PackageInstantiationPreambleSyntax;
+    fn cast_unchecked(syntax: PackageInstantiationPreambleSyntax) -> Self {
+        CheckedPackageInstantiationPreamble(syntax)
+    }
+    fn raw(&self) -> PackageInstantiationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPackageInstantiationPreamble {
+    pub fn package_token(&self) -> SyntaxToken {
+        self.0.package_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+    pub fn is_token(&self) -> SyntaxToken {
+        self.0.is_token().unwrap()
+    }
+    pub fn new_token(&self) -> SyntaxToken {
+        self.0.new_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSignature(SignatureSyntax);
+impl CheckedNode for CheckedSignature {
+    type Syntax = SignatureSyntax;
+    fn cast_unchecked(syntax: SignatureSyntax) -> Self {
+        CheckedSignature(syntax)
+    }
+    fn raw(&self) -> SignatureSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSignature {
+    pub fn left_square_token(&self) -> SyntaxToken {
+        self.0.left_square_token().unwrap()
+    }
+    pub fn names(&self) -> impl Iterator<Item = CheckedName> + use<'_> {
+        self.0.names().map(CheckedName::cast_unchecked)
+    }
+    pub fn return_token(&self) -> SyntaxToken {
+        self.0.return_token().unwrap()
+    }
+    pub fn return_type(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.return_type().unwrap())
+    }
+    pub fn right_square_token(&self) -> SyntaxToken {
+        self.0.right_square_token().unwrap()
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/generated/types.rs
+++ b/vhdl_syntax/src/syntax/checked/generated/types.rs
@@ -1,0 +1,1024 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026, Lukas Scheller lukasscheller@icloud.com
+use super::*;
+use crate::syntax::checked::CheckedNode;
+use crate::syntax::node::SyntaxToken;
+use crate::syntax::*;
+#[derive(Debug, Clone)]
+pub struct CheckedAccessTypeDefinition(AccessTypeDefinitionSyntax);
+impl CheckedNode for CheckedAccessTypeDefinition {
+    type Syntax = AccessTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: AccessTypeDefinitionSyntax) -> Self {
+        CheckedAccessTypeDefinition(syntax)
+    }
+    fn raw(&self) -> AccessTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAccessTypeDefinition {
+    pub fn access_token(&self) -> SyntaxToken {
+        self.0.access_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedArrayConstraint(ArrayConstraintSyntax);
+impl CheckedNode for CheckedArrayConstraint {
+    type Syntax = ArrayConstraintSyntax;
+    fn cast_unchecked(syntax: ArrayConstraintSyntax) -> Self {
+        CheckedArrayConstraint(syntax)
+    }
+    fn raw(&self) -> ArrayConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedArrayConstraint {
+    pub fn index_constraint(&self) -> CheckedIndexConstraint {
+        CheckedIndexConstraint::cast_unchecked(self.0.index_constraint().unwrap())
+    }
+    pub fn constraint(&self) -> CheckedConstraint {
+        CheckedConstraint::cast_unchecked(self.0.constraint().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedArrayTypeDefinition {
+    UnboundedArrayDefinition(CheckedUnboundedArrayDefinition),
+    ConstrainedArrayDefinition(CheckedConstrainedArrayDefinition),
+}
+impl CheckedNode for CheckedArrayTypeDefinition {
+    type Syntax = ArrayTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: ArrayTypeDefinitionSyntax) -> Self {
+        match syntax {
+            ArrayTypeDefinitionSyntax::UnboundedArrayDefinition(inner) => {
+                CheckedArrayTypeDefinition::UnboundedArrayDefinition(
+                    CheckedUnboundedArrayDefinition::cast_unchecked(inner),
+                )
+            }
+            ArrayTypeDefinitionSyntax::ConstrainedArrayDefinition(inner) => {
+                CheckedArrayTypeDefinition::ConstrainedArrayDefinition(
+                    CheckedConstrainedArrayDefinition::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedArrayTypeDefinition::UnboundedArrayDefinition(inner) => {
+                ArrayTypeDefinitionSyntax::UnboundedArrayDefinition(inner.raw())
+            }
+            CheckedArrayTypeDefinition::ConstrainedArrayDefinition(inner) => {
+                ArrayTypeDefinitionSyntax::ConstrainedArrayDefinition(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedCompositeTypeDefinition {
+    ArrayTypeDefinition(CheckedArrayTypeDefinition),
+    RecordTypeDefinition(CheckedRecordTypeDefinition),
+}
+impl CheckedNode for CheckedCompositeTypeDefinition {
+    type Syntax = CompositeTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: CompositeTypeDefinitionSyntax) -> Self {
+        match syntax {
+            CompositeTypeDefinitionSyntax::ArrayTypeDefinition(inner) => {
+                CheckedCompositeTypeDefinition::ArrayTypeDefinition(
+                    CheckedArrayTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            CompositeTypeDefinitionSyntax::RecordTypeDefinition(inner) => {
+                CheckedCompositeTypeDefinition::RecordTypeDefinition(
+                    CheckedRecordTypeDefinition::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedCompositeTypeDefinition::ArrayTypeDefinition(inner) => {
+                CompositeTypeDefinitionSyntax::ArrayTypeDefinition(inner.raw())
+            }
+            CheckedCompositeTypeDefinition::RecordTypeDefinition(inner) => {
+                CompositeTypeDefinitionSyntax::RecordTypeDefinition(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedConstrainedArrayDefinition(ConstrainedArrayDefinitionSyntax);
+impl CheckedNode for CheckedConstrainedArrayDefinition {
+    type Syntax = ConstrainedArrayDefinitionSyntax;
+    fn cast_unchecked(syntax: ConstrainedArrayDefinitionSyntax) -> Self {
+        CheckedConstrainedArrayDefinition(syntax)
+    }
+    fn raw(&self) -> ConstrainedArrayDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedConstrainedArrayDefinition {
+    pub fn array_token(&self) -> SyntaxToken {
+        self.0.array_token().unwrap()
+    }
+    pub fn index_constraint(&self) -> CheckedIndexConstraint {
+        CheckedIndexConstraint::cast_unchecked(self.0.index_constraint().unwrap())
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubtypeIndicationDiscreteDiscreteRange(
+    SubtypeIndicationDiscreteDiscreteRangeSyntax,
+);
+impl CheckedNode for CheckedSubtypeIndicationDiscreteDiscreteRange {
+    type Syntax = SubtypeIndicationDiscreteDiscreteRangeSyntax;
+    fn cast_unchecked(syntax: SubtypeIndicationDiscreteDiscreteRangeSyntax) -> Self {
+        CheckedSubtypeIndicationDiscreteDiscreteRange(syntax)
+    }
+    fn raw(&self) -> SubtypeIndicationDiscreteDiscreteRangeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubtypeIndicationDiscreteDiscreteRange {
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSubtypeIndicationDiscreteRange(SubtypeIndicationDiscreteRangeSyntax);
+impl CheckedNode for CheckedSubtypeIndicationDiscreteRange {
+    type Syntax = SubtypeIndicationDiscreteRangeSyntax;
+    fn cast_unchecked(syntax: SubtypeIndicationDiscreteRangeSyntax) -> Self {
+        CheckedSubtypeIndicationDiscreteRange(syntax)
+    }
+    fn raw(&self) -> SubtypeIndicationDiscreteRangeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSubtypeIndicationDiscreteRange {
+    pub fn range(&self) -> CheckedRange {
+        CheckedRange::cast_unchecked(self.0.range().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedOpenDiscreteRange(OpenDiscreteRangeSyntax);
+impl CheckedNode for CheckedOpenDiscreteRange {
+    type Syntax = OpenDiscreteRangeSyntax;
+    fn cast_unchecked(syntax: OpenDiscreteRangeSyntax) -> Self {
+        CheckedOpenDiscreteRange(syntax)
+    }
+    fn raw(&self) -> OpenDiscreteRangeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedOpenDiscreteRange {
+    pub fn open_token(&self) -> SyntaxToken {
+        self.0.open_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedDiscreteRange {
+    SubtypeIndicationDiscreteDiscreteRange(CheckedSubtypeIndicationDiscreteDiscreteRange),
+    SubtypeIndicationDiscreteRange(CheckedSubtypeIndicationDiscreteRange),
+    OpenDiscreteRange(CheckedOpenDiscreteRange),
+}
+impl CheckedNode for CheckedDiscreteRange {
+    type Syntax = DiscreteRangeSyntax;
+    fn cast_unchecked(syntax: DiscreteRangeSyntax) -> Self {
+        match syntax {
+            DiscreteRangeSyntax::SubtypeIndicationDiscreteDiscreteRange(inner) => {
+                CheckedDiscreteRange::SubtypeIndicationDiscreteDiscreteRange(
+                    CheckedSubtypeIndicationDiscreteDiscreteRange::cast_unchecked(inner),
+                )
+            }
+            DiscreteRangeSyntax::SubtypeIndicationDiscreteRange(inner) => {
+                CheckedDiscreteRange::SubtypeIndicationDiscreteRange(
+                    CheckedSubtypeIndicationDiscreteRange::cast_unchecked(inner),
+                )
+            }
+            DiscreteRangeSyntax::OpenDiscreteRange(inner) => {
+                CheckedDiscreteRange::OpenDiscreteRange(CheckedOpenDiscreteRange::cast_unchecked(
+                    inner,
+                ))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedDiscreteRange::SubtypeIndicationDiscreteDiscreteRange(inner) => {
+                DiscreteRangeSyntax::SubtypeIndicationDiscreteDiscreteRange(inner.raw())
+            }
+            CheckedDiscreteRange::SubtypeIndicationDiscreteRange(inner) => {
+                DiscreteRangeSyntax::SubtypeIndicationDiscreteRange(inner.raw())
+            }
+            CheckedDiscreteRange::OpenDiscreteRange(inner) => {
+                DiscreteRangeSyntax::OpenDiscreteRange(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedElementDeclaration(ElementDeclarationSyntax);
+impl CheckedNode for CheckedElementDeclaration {
+    type Syntax = ElementDeclarationSyntax;
+    fn cast_unchecked(syntax: ElementDeclarationSyntax) -> Self {
+        CheckedElementDeclaration(syntax)
+    }
+    fn raw(&self) -> ElementDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedElementDeclaration {
+    pub fn identifier_list(&self) -> CheckedIdentifierList {
+        CheckedIdentifierList::cast_unchecked(self.0.identifier_list().unwrap())
+    }
+    pub fn colon_token(&self) -> SyntaxToken {
+        self.0.colon_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedEnumerationTypeDefinition(EnumerationTypeDefinitionSyntax);
+impl CheckedNode for CheckedEnumerationTypeDefinition {
+    type Syntax = EnumerationTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: EnumerationTypeDefinitionSyntax) -> Self {
+        CheckedEnumerationTypeDefinition(syntax)
+    }
+    fn raw(&self) -> EnumerationTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedEnumerationTypeDefinition {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn discrete_ranges(&self) -> impl Iterator<Item = CheckedDiscreteRange> + use<'_> {
+        self.0
+            .discrete_ranges()
+            .map(CheckedDiscreteRange::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedFileTypeDefinition(FileTypeDefinitionSyntax);
+impl CheckedNode for CheckedFileTypeDefinition {
+    type Syntax = FileTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: FileTypeDefinitionSyntax) -> Self {
+        CheckedFileTypeDefinition(syntax)
+    }
+    fn raw(&self) -> FileTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedFileTypeDefinition {
+    pub fn file_token(&self) -> SyntaxToken {
+        self.0.file_token().unwrap()
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIdentifierList(IdentifierListSyntax);
+impl CheckedNode for CheckedIdentifierList {
+    type Syntax = IdentifierListSyntax;
+    fn cast_unchecked(syntax: IdentifierListSyntax) -> Self {
+        CheckedIdentifierList(syntax)
+    }
+    fn raw(&self) -> IdentifierListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIdentifierList {
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn comma_token(&self) -> SyntaxToken {
+        self.0.comma_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIncompleteTypeDeclaration(IncompleteTypeDeclarationSyntax);
+impl CheckedNode for CheckedIncompleteTypeDeclaration {
+    type Syntax = IncompleteTypeDeclarationSyntax;
+    fn cast_unchecked(syntax: IncompleteTypeDeclarationSyntax) -> Self {
+        CheckedIncompleteTypeDeclaration(syntax)
+    }
+    fn raw(&self) -> IncompleteTypeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIncompleteTypeDeclaration {
+    pub fn type_token(&self) -> SyntaxToken {
+        self.0.type_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIndexSubtypeDefinition(IndexSubtypeDefinitionSyntax);
+impl CheckedNode for CheckedIndexSubtypeDefinition {
+    type Syntax = IndexSubtypeDefinitionSyntax;
+    fn cast_unchecked(syntax: IndexSubtypeDefinitionSyntax) -> Self {
+        CheckedIndexSubtypeDefinition(syntax)
+    }
+    fn raw(&self) -> IndexSubtypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIndexSubtypeDefinition {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn range_token(&self) -> SyntaxToken {
+        self.0.range_token().unwrap()
+    }
+    pub fn box_token(&self) -> SyntaxToken {
+        self.0.box_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPhysicalLiteral(PhysicalLiteralSyntax);
+impl CheckedNode for CheckedPhysicalLiteral {
+    type Syntax = PhysicalLiteralSyntax;
+    fn cast_unchecked(syntax: PhysicalLiteralSyntax) -> Self {
+        CheckedPhysicalLiteral(syntax)
+    }
+    fn raw(&self) -> PhysicalLiteralSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPhysicalLiteral {
+    pub fn abstract_literal_token(&self) -> SyntaxToken {
+        self.0.abstract_literal_token().unwrap()
+    }
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPhysicalTypeDefinition(PhysicalTypeDefinitionSyntax);
+impl CheckedNode for CheckedPhysicalTypeDefinition {
+    type Syntax = PhysicalTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: PhysicalTypeDefinitionSyntax) -> Self {
+        CheckedPhysicalTypeDefinition(syntax)
+    }
+    fn raw(&self) -> PhysicalTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPhysicalTypeDefinition {
+    pub fn range_constraint(&self) -> CheckedRangeConstraint {
+        CheckedRangeConstraint::cast_unchecked(self.0.range_constraint().unwrap())
+    }
+    pub fn unit_declarations(&self) -> CheckedUnitDeclarations {
+        CheckedUnitDeclarations::cast_unchecked(self.0.unit_declarations().unwrap())
+    }
+    pub fn physical_type_definition_epilogue(&self) -> CheckedPhysicalTypeDefinitionEpilogue {
+        CheckedPhysicalTypeDefinitionEpilogue::cast_unchecked(
+            self.0.physical_type_definition_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUnitDeclarations(UnitDeclarationsSyntax);
+impl CheckedNode for CheckedUnitDeclarations {
+    type Syntax = UnitDeclarationsSyntax;
+    fn cast_unchecked(syntax: UnitDeclarationsSyntax) -> Self {
+        CheckedUnitDeclarations(syntax)
+    }
+    fn raw(&self) -> UnitDeclarationsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUnitDeclarations {
+    pub fn units_token(&self) -> SyntaxToken {
+        self.0.units_token().unwrap()
+    }
+    pub fn primary_unit_declaration(&self) -> CheckedPrimaryUnitDeclaration {
+        CheckedPrimaryUnitDeclaration::cast_unchecked(self.0.primary_unit_declaration().unwrap())
+    }
+    pub fn secondary_unit_declarations(
+        &self,
+    ) -> impl Iterator<Item = CheckedSecondaryUnitDeclaration> + use<'_> {
+        self.0
+            .secondary_unit_declarations()
+            .map(CheckedSecondaryUnitDeclaration::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPhysicalTypeDefinitionEpilogue(PhysicalTypeDefinitionEpilogueSyntax);
+impl CheckedNode for CheckedPhysicalTypeDefinitionEpilogue {
+    type Syntax = PhysicalTypeDefinitionEpilogueSyntax;
+    fn cast_unchecked(syntax: PhysicalTypeDefinitionEpilogueSyntax) -> Self {
+        CheckedPhysicalTypeDefinitionEpilogue(syntax)
+    }
+    fn raw(&self) -> PhysicalTypeDefinitionEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPhysicalTypeDefinitionEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn units_token(&self) -> SyntaxToken {
+        self.0.units_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedPrimaryUnitDeclaration(PrimaryUnitDeclarationSyntax);
+impl CheckedNode for CheckedPrimaryUnitDeclaration {
+    type Syntax = PrimaryUnitDeclarationSyntax;
+    fn cast_unchecked(syntax: PrimaryUnitDeclarationSyntax) -> Self {
+        CheckedPrimaryUnitDeclaration(syntax)
+    }
+    fn raw(&self) -> PrimaryUnitDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedPrimaryUnitDeclaration {
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeBody(ProtectedTypeBodySyntax);
+impl CheckedNode for CheckedProtectedTypeBody {
+    type Syntax = ProtectedTypeBodySyntax;
+    fn cast_unchecked(syntax: ProtectedTypeBodySyntax) -> Self {
+        CheckedProtectedTypeBody(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeBodySyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeBody {
+    pub fn protected_type_body_preamble(&self) -> CheckedProtectedTypeBodyPreamble {
+        CheckedProtectedTypeBodyPreamble::cast_unchecked(
+            self.0.protected_type_body_preamble().unwrap(),
+        )
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn protected_type_body_epilogue(&self) -> CheckedProtectedTypeBodyEpilogue {
+        CheckedProtectedTypeBodyEpilogue::cast_unchecked(
+            self.0.protected_type_body_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeBodyPreamble(ProtectedTypeBodyPreambleSyntax);
+impl CheckedNode for CheckedProtectedTypeBodyPreamble {
+    type Syntax = ProtectedTypeBodyPreambleSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeBodyPreambleSyntax) -> Self {
+        CheckedProtectedTypeBodyPreamble(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeBodyPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeBodyPreamble {
+    pub fn protected_token(&self) -> SyntaxToken {
+        self.0.protected_token().unwrap()
+    }
+    pub fn body_token(&self) -> SyntaxToken {
+        self.0.body_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeBodyEpilogue(ProtectedTypeBodyEpilogueSyntax);
+impl CheckedNode for CheckedProtectedTypeBodyEpilogue {
+    type Syntax = ProtectedTypeBodyEpilogueSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeBodyEpilogueSyntax) -> Self {
+        CheckedProtectedTypeBodyEpilogue(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeBodyEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeBodyEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn protected_token(&self) -> SyntaxToken {
+        self.0.protected_token().unwrap()
+    }
+    pub fn body_token(&self) -> SyntaxToken {
+        self.0.body_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeDeclaration(ProtectedTypeDeclarationSyntax);
+impl CheckedNode for CheckedProtectedTypeDeclaration {
+    type Syntax = ProtectedTypeDeclarationSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeDeclarationSyntax) -> Self {
+        CheckedProtectedTypeDeclaration(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeDeclaration {
+    pub fn protected_type_declaration_preamble(&self) -> CheckedProtectedTypeDeclarationPreamble {
+        CheckedProtectedTypeDeclarationPreamble::cast_unchecked(
+            self.0.protected_type_declaration_preamble().unwrap(),
+        )
+    }
+    pub fn declarations(&self) -> Option<CheckedDeclarations> {
+        self.0
+            .declarations()
+            .map(CheckedDeclarations::cast_unchecked)
+    }
+    pub fn protected_type_declaration_epilogue(&self) -> CheckedProtectedTypeDeclarationEpilogue {
+        CheckedProtectedTypeDeclarationEpilogue::cast_unchecked(
+            self.0.protected_type_declaration_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeDeclarationPreamble(ProtectedTypeDeclarationPreambleSyntax);
+impl CheckedNode for CheckedProtectedTypeDeclarationPreamble {
+    type Syntax = ProtectedTypeDeclarationPreambleSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeDeclarationPreambleSyntax) -> Self {
+        CheckedProtectedTypeDeclarationPreamble(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeDeclarationPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeDeclarationPreamble {
+    pub fn protected_token(&self) -> SyntaxToken {
+        self.0.protected_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedProtectedTypeDeclarationEpilogue(ProtectedTypeDeclarationEpilogueSyntax);
+impl CheckedNode for CheckedProtectedTypeDeclarationEpilogue {
+    type Syntax = ProtectedTypeDeclarationEpilogueSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeDeclarationEpilogueSyntax) -> Self {
+        CheckedProtectedTypeDeclarationEpilogue(syntax)
+    }
+    fn raw(&self) -> ProtectedTypeDeclarationEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedProtectedTypeDeclarationEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn protected_token(&self) -> SyntaxToken {
+        self.0.protected_token().unwrap()
+    }
+    pub fn name_token(&self) -> SyntaxToken {
+        self.0.name_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedProtectedTypeDefinition {
+    ProtectedTypeDeclaration(CheckedProtectedTypeDeclaration),
+    ProtectedTypeBody(CheckedProtectedTypeBody),
+}
+impl CheckedNode for CheckedProtectedTypeDefinition {
+    type Syntax = ProtectedTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: ProtectedTypeDefinitionSyntax) -> Self {
+        match syntax {
+            ProtectedTypeDefinitionSyntax::ProtectedTypeDeclaration(inner) => {
+                CheckedProtectedTypeDefinition::ProtectedTypeDeclaration(
+                    CheckedProtectedTypeDeclaration::cast_unchecked(inner),
+                )
+            }
+            ProtectedTypeDefinitionSyntax::ProtectedTypeBody(inner) => {
+                CheckedProtectedTypeDefinition::ProtectedTypeBody(
+                    CheckedProtectedTypeBody::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedProtectedTypeDefinition::ProtectedTypeDeclaration(inner) => {
+                ProtectedTypeDefinitionSyntax::ProtectedTypeDeclaration(inner.raw())
+            }
+            CheckedProtectedTypeDefinition::ProtectedTypeBody(inner) => {
+                ProtectedTypeDefinitionSyntax::ProtectedTypeBody(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRangeExpression(RangeExpressionSyntax);
+impl CheckedNode for CheckedRangeExpression {
+    type Syntax = RangeExpressionSyntax;
+    fn cast_unchecked(syntax: RangeExpressionSyntax) -> Self {
+        CheckedRangeExpression(syntax)
+    }
+    fn raw(&self) -> RangeExpressionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRangeExpression {
+    pub fn lhs(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.lhs().unwrap())
+    }
+    pub fn direction(&self) -> DirectionSyntax {
+        self.0.direction().unwrap()
+    }
+    pub fn rhs(&self) -> CheckedExpression {
+        CheckedExpression::cast_unchecked(self.0.rhs().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedAttributeRange(AttributeRangeSyntax);
+impl CheckedNode for CheckedAttributeRange {
+    type Syntax = AttributeRangeSyntax;
+    fn cast_unchecked(syntax: AttributeRangeSyntax) -> Self {
+        CheckedAttributeRange(syntax)
+    }
+    fn raw(&self) -> AttributeRangeSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedAttributeRange {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedRange {
+    AttributeRange(CheckedAttributeRange),
+    RangeExpression(CheckedRangeExpression),
+}
+impl CheckedNode for CheckedRange {
+    type Syntax = RangeSyntax;
+    fn cast_unchecked(syntax: RangeSyntax) -> Self {
+        match syntax {
+            RangeSyntax::AttributeRange(inner) => {
+                CheckedRange::AttributeRange(CheckedAttributeRange::cast_unchecked(inner))
+            }
+            RangeSyntax::RangeExpression(inner) => {
+                CheckedRange::RangeExpression(CheckedRangeExpression::cast_unchecked(inner))
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedRange::AttributeRange(inner) => RangeSyntax::AttributeRange(inner.raw()),
+            CheckedRange::RangeExpression(inner) => RangeSyntax::RangeExpression(inner.raw()),
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRangeConstraint(RangeConstraintSyntax);
+impl CheckedNode for CheckedRangeConstraint {
+    type Syntax = RangeConstraintSyntax;
+    fn cast_unchecked(syntax: RangeConstraintSyntax) -> Self {
+        CheckedRangeConstraint(syntax)
+    }
+    fn raw(&self) -> RangeConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRangeConstraint {
+    pub fn range_token(&self) -> SyntaxToken {
+        self.0.range_token().unwrap()
+    }
+    pub fn range(&self) -> CheckedRange {
+        CheckedRange::cast_unchecked(self.0.range().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordConstraint(RecordConstraintSyntax);
+impl CheckedNode for CheckedRecordConstraint {
+    type Syntax = RecordConstraintSyntax;
+    fn cast_unchecked(syntax: RecordConstraintSyntax) -> Self {
+        CheckedRecordConstraint(syntax)
+    }
+    fn raw(&self) -> RecordConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordConstraint {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn record_element_constraints(
+        &self,
+    ) -> impl Iterator<Item = CheckedRecordElementConstraint> + use<'_> {
+        self.0
+            .record_element_constraints()
+            .map(CheckedRecordElementConstraint::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordElementConstraint(RecordElementConstraintSyntax);
+impl CheckedNode for CheckedRecordElementConstraint {
+    type Syntax = RecordElementConstraintSyntax;
+    fn cast_unchecked(syntax: RecordElementConstraintSyntax) -> Self {
+        CheckedRecordElementConstraint(syntax)
+    }
+    fn raw(&self) -> RecordElementConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordElementConstraint {
+    pub fn name(&self) -> CheckedName {
+        CheckedName::cast_unchecked(self.0.name().unwrap())
+    }
+    pub fn constraint(&self) -> CheckedConstraint {
+        CheckedConstraint::cast_unchecked(self.0.constraint().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordTypeDefinition(RecordTypeDefinitionSyntax);
+impl CheckedNode for CheckedRecordTypeDefinition {
+    type Syntax = RecordTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: RecordTypeDefinitionSyntax) -> Self {
+        CheckedRecordTypeDefinition(syntax)
+    }
+    fn raw(&self) -> RecordTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordTypeDefinition {
+    pub fn record_type_definition_preamble(&self) -> CheckedRecordTypeDefinitionPreamble {
+        CheckedRecordTypeDefinitionPreamble::cast_unchecked(
+            self.0.record_type_definition_preamble().unwrap(),
+        )
+    }
+    pub fn record_element_declarations(&self) -> Option<CheckedRecordElementDeclarations> {
+        self.0
+            .record_element_declarations()
+            .map(CheckedRecordElementDeclarations::cast_unchecked)
+    }
+    pub fn record_type_definition_epilogue(&self) -> CheckedRecordTypeDefinitionEpilogue {
+        CheckedRecordTypeDefinitionEpilogue::cast_unchecked(
+            self.0.record_type_definition_epilogue().unwrap(),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordElementDeclarations(RecordElementDeclarationsSyntax);
+impl CheckedNode for CheckedRecordElementDeclarations {
+    type Syntax = RecordElementDeclarationsSyntax;
+    fn cast_unchecked(syntax: RecordElementDeclarationsSyntax) -> Self {
+        CheckedRecordElementDeclarations(syntax)
+    }
+    fn raw(&self) -> RecordElementDeclarationsSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordElementDeclarations {
+    pub fn element_declarations(
+        &self,
+    ) -> impl Iterator<Item = CheckedElementDeclaration> + use<'_> {
+        self.0
+            .element_declarations()
+            .map(CheckedElementDeclaration::cast_unchecked)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordTypeDefinitionPreamble(RecordTypeDefinitionPreambleSyntax);
+impl CheckedNode for CheckedRecordTypeDefinitionPreamble {
+    type Syntax = RecordTypeDefinitionPreambleSyntax;
+    fn cast_unchecked(syntax: RecordTypeDefinitionPreambleSyntax) -> Self {
+        CheckedRecordTypeDefinitionPreamble(syntax)
+    }
+    fn raw(&self) -> RecordTypeDefinitionPreambleSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordTypeDefinitionPreamble {
+    pub fn record_token(&self) -> SyntaxToken {
+        self.0.record_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedRecordTypeDefinitionEpilogue(RecordTypeDefinitionEpilogueSyntax);
+impl CheckedNode for CheckedRecordTypeDefinitionEpilogue {
+    type Syntax = RecordTypeDefinitionEpilogueSyntax;
+    fn cast_unchecked(syntax: RecordTypeDefinitionEpilogueSyntax) -> Self {
+        CheckedRecordTypeDefinitionEpilogue(syntax)
+    }
+    fn raw(&self) -> RecordTypeDefinitionEpilogueSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedRecordTypeDefinitionEpilogue {
+    pub fn end_token(&self) -> SyntaxToken {
+        self.0.end_token().unwrap()
+    }
+    pub fn record_token(&self) -> SyntaxToken {
+        self.0.record_token().unwrap()
+    }
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedNumericTypeDefinition(NumericTypeDefinitionSyntax);
+impl CheckedNode for CheckedNumericTypeDefinition {
+    type Syntax = NumericTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: NumericTypeDefinitionSyntax) -> Self {
+        CheckedNumericTypeDefinition(syntax)
+    }
+    fn raw(&self) -> NumericTypeDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedNumericTypeDefinition {
+    pub fn range_constraint(&self) -> CheckedRangeConstraint {
+        CheckedRangeConstraint::cast_unchecked(self.0.range_constraint().unwrap())
+    }
+}
+#[derive(Debug, Clone)]
+pub enum CheckedScalarTypeDefinition {
+    EnumerationTypeDefinition(CheckedEnumerationTypeDefinition),
+    NumericTypeDefinition(CheckedNumericTypeDefinition),
+    PhysicalTypeDefinition(CheckedPhysicalTypeDefinition),
+}
+impl CheckedNode for CheckedScalarTypeDefinition {
+    type Syntax = ScalarTypeDefinitionSyntax;
+    fn cast_unchecked(syntax: ScalarTypeDefinitionSyntax) -> Self {
+        match syntax {
+            ScalarTypeDefinitionSyntax::EnumerationTypeDefinition(inner) => {
+                CheckedScalarTypeDefinition::EnumerationTypeDefinition(
+                    CheckedEnumerationTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            ScalarTypeDefinitionSyntax::NumericTypeDefinition(inner) => {
+                CheckedScalarTypeDefinition::NumericTypeDefinition(
+                    CheckedNumericTypeDefinition::cast_unchecked(inner),
+                )
+            }
+            ScalarTypeDefinitionSyntax::PhysicalTypeDefinition(inner) => {
+                CheckedScalarTypeDefinition::PhysicalTypeDefinition(
+                    CheckedPhysicalTypeDefinition::cast_unchecked(inner),
+                )
+            }
+        }
+    }
+    fn raw(&self) -> Self::Syntax {
+        match self {
+            CheckedScalarTypeDefinition::EnumerationTypeDefinition(inner) => {
+                ScalarTypeDefinitionSyntax::EnumerationTypeDefinition(inner.raw())
+            }
+            CheckedScalarTypeDefinition::NumericTypeDefinition(inner) => {
+                ScalarTypeDefinitionSyntax::NumericTypeDefinition(inner.raw())
+            }
+            CheckedScalarTypeDefinition::PhysicalTypeDefinition(inner) => {
+                ScalarTypeDefinitionSyntax::PhysicalTypeDefinition(inner.raw())
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedSecondaryUnitDeclaration(SecondaryUnitDeclarationSyntax);
+impl CheckedNode for CheckedSecondaryUnitDeclaration {
+    type Syntax = SecondaryUnitDeclarationSyntax;
+    fn cast_unchecked(syntax: SecondaryUnitDeclarationSyntax) -> Self {
+        CheckedSecondaryUnitDeclaration(syntax)
+    }
+    fn raw(&self) -> SecondaryUnitDeclarationSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedSecondaryUnitDeclaration {
+    pub fn identifier_token(&self) -> SyntaxToken {
+        self.0.identifier_token().unwrap()
+    }
+    pub fn eq_token(&self) -> SyntaxToken {
+        self.0.eq_token().unwrap()
+    }
+    pub fn physical_literal(&self) -> CheckedPhysicalLiteral {
+        CheckedPhysicalLiteral::cast_unchecked(self.0.physical_literal().unwrap())
+    }
+    pub fn semi_colon_token(&self) -> SyntaxToken {
+        self.0.semi_colon_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIndexConstraint(IndexConstraintSyntax);
+impl CheckedNode for CheckedIndexConstraint {
+    type Syntax = IndexConstraintSyntax;
+    fn cast_unchecked(syntax: IndexConstraintSyntax) -> Self {
+        CheckedIndexConstraint(syntax)
+    }
+    fn raw(&self) -> IndexConstraintSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIndexConstraint {
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn discrete_ranges(&self) -> impl Iterator<Item = CheckedDiscreteRange> + use<'_> {
+        self.0
+            .discrete_ranges()
+            .map(CheckedDiscreteRange::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedIndexSubtypeDefinitionList(IndexSubtypeDefinitionListSyntax);
+impl CheckedNode for CheckedIndexSubtypeDefinitionList {
+    type Syntax = IndexSubtypeDefinitionListSyntax;
+    fn cast_unchecked(syntax: IndexSubtypeDefinitionListSyntax) -> Self {
+        CheckedIndexSubtypeDefinitionList(syntax)
+    }
+    fn raw(&self) -> IndexSubtypeDefinitionListSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedIndexSubtypeDefinitionList {
+    pub fn index_subtype_definitions(
+        &self,
+    ) -> impl Iterator<Item = CheckedIndexSubtypeDefinition> + use<'_> {
+        self.0
+            .index_subtype_definitions()
+            .map(CheckedIndexSubtypeDefinition::cast_unchecked)
+    }
+    pub fn comma_token(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+        self.0.comma_token()
+    }
+}
+#[derive(Debug, Clone)]
+pub struct CheckedUnboundedArrayDefinition(UnboundedArrayDefinitionSyntax);
+impl CheckedNode for CheckedUnboundedArrayDefinition {
+    type Syntax = UnboundedArrayDefinitionSyntax;
+    fn cast_unchecked(syntax: UnboundedArrayDefinitionSyntax) -> Self {
+        CheckedUnboundedArrayDefinition(syntax)
+    }
+    fn raw(&self) -> UnboundedArrayDefinitionSyntax {
+        self.0.clone()
+    }
+}
+impl CheckedUnboundedArrayDefinition {
+    pub fn array_token(&self) -> SyntaxToken {
+        self.0.array_token().unwrap()
+    }
+    pub fn left_par_token(&self) -> SyntaxToken {
+        self.0.left_par_token().unwrap()
+    }
+    pub fn index_subtype_definition_list(&self) -> Option<CheckedIndexSubtypeDefinitionList> {
+        self.0
+            .index_subtype_definition_list()
+            .map(CheckedIndexSubtypeDefinitionList::cast_unchecked)
+    }
+    pub fn right_par_token(&self) -> SyntaxToken {
+        self.0.right_par_token().unwrap()
+    }
+    pub fn of_token(&self) -> SyntaxToken {
+        self.0.of_token().unwrap()
+    }
+    pub fn subtype_indication(&self) -> CheckedSubtypeIndication {
+        CheckedSubtypeIndication::cast_unchecked(self.0.subtype_indication().unwrap())
+    }
+}

--- a/vhdl_syntax/src/syntax/checked/mod.rs
+++ b/vhdl_syntax/src/syntax/checked/mod.rs
@@ -1,0 +1,25 @@
+use crate::syntax::{validate::{self, ValidationError}, AstNode};
+
+pub mod generated;
+pub use generated::*;
+
+/// A layer on top of an [`AstNode`] that guarantees there are no missing or
+/// extraneous elements.
+pub trait CheckedNode: Sized {
+    type Syntax: AstNode + Clone;
+
+    /// Wrap `syntax` without re-validating its children.  Caller must ensure
+    /// the node was already validated (e.g. came from a successful `cast` call
+    /// on a checked parent or was manually validated).
+    fn cast_unchecked(syntax: Self::Syntax) -> Self;
+
+    /// Return the underlying AST Node.
+    fn raw(&self) -> Self::Syntax;
+
+    /// Validate `syntax` and, on success, wrap it in the checked type.
+    fn cast(syntax: Self::Syntax) -> Result<Self, ValidationError> {
+        let node = syntax.raw();
+        validate::check(&node)?;
+        Ok(Self::cast_unchecked(syntax))
+    }
+}

--- a/vhdl_syntax/src/syntax/mod.rs
+++ b/vhdl_syntax/src/syntax/mod.rs
@@ -11,11 +11,13 @@ pub(crate) mod green;
 pub mod meta;
 pub mod node;
 pub mod rewrite;
+pub mod validate;
 pub mod visitor;
 
 use crate::syntax::meta::Layout;
 use crate::syntax::node::{SyntaxElement, SyntaxNode};
 use crate::syntax::rewrite::RewriteAction;
+use crate::syntax::validate::{check, ValidationError};
 use crate::syntax::visitor::Preorder;
 pub use generated::*;
 
@@ -27,6 +29,7 @@ where
     const META: &'static Layout;
 
     /// Cast without a kind check — caller must ensure `can_cast` is true.
+    /// Panics for Choice nodes (although this might change in the future)
     fn cast_unchecked(node: SyntaxNode) -> Self;
 
     /// Return the underlying Syntax Node.
@@ -57,5 +60,18 @@ where
     fn rewrite(&self, rewrite: impl Fn(&SyntaxElement) -> RewriteAction) -> Self {
         let result = self.raw().rewrite(rewrite);
         Self::cast_unchecked(result)
+    }
+}
+
+/// A layer on top of the `AstNode` with guarantees that there are no missing or extraneous elements.
+pub trait CheckedNode
+where
+    Self: Sized,
+{
+    /// Cast without a check. Caller has to ensure that there are no missing or extraneous elements in the provided node.
+    fn cast_unchecked(node: SyntaxNode) -> Self;
+
+    fn cast(node: SyntaxNode) -> Result<Self, ValidationError> {
+        check(&node).map(|_| CheckedNode::cast_unchecked(node))
     }
 }

--- a/vhdl_syntax/src/syntax/mod.rs
+++ b/vhdl_syntax/src/syntax/mod.rs
@@ -13,11 +13,11 @@ pub mod node;
 pub mod rewrite;
 pub mod validate;
 pub mod visitor;
+pub mod checked;
 
 use crate::syntax::meta::Layout;
 use crate::syntax::node::{SyntaxElement, SyntaxNode};
 use crate::syntax::rewrite::RewriteAction;
-use crate::syntax::validate::{check, ValidationError};
 use crate::syntax::visitor::Preorder;
 pub use generated::*;
 
@@ -60,18 +60,5 @@ where
     fn rewrite(&self, rewrite: impl Fn(&SyntaxElement) -> RewriteAction) -> Self {
         let result = self.raw().rewrite(rewrite);
         Self::cast_unchecked(result)
-    }
-}
-
-/// A layer on top of the `AstNode` with guarantees that there are no missing or extraneous elements.
-pub trait CheckedNode
-where
-    Self: Sized,
-{
-    /// Cast without a check. Caller has to ensure that there are no missing or extraneous elements in the provided node.
-    fn cast_unchecked(node: SyntaxNode) -> Self;
-
-    fn cast(node: SyntaxNode) -> Result<Self, ValidationError> {
-        check(&node).map(|_| CheckedNode::cast_unchecked(node))
     }
 }

--- a/vhdl_syntax/src/syntax/validate/error.rs
+++ b/vhdl_syntax/src/syntax/validate/error.rs
@@ -1,0 +1,106 @@
+use crate::syntax::{
+    meta::LayoutItemKind,
+    node::{SyntaxElement, SyntaxNode},
+};
+use std::fmt;
+
+/// Errors that may appear as part of the validation process.
+/// Validation errors always have at least one element (i.e., at least one
+/// missing or at least one extraneous)
+#[derive(Clone, Debug, Default)]
+pub struct ValidationError {
+    /// Any missing nodes. Those were expected to be in the tree, but weren't found.
+    missing: Vec<Missing>,
+    /// Any extraneous nodes. Those are in the tree, but shouldn't be.
+    extraneous: Vec<SyntaxElement>,
+}
+
+impl ValidationError {
+    pub(crate) fn new() -> ValidationError {
+        ValidationError::default()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.missing.is_empty() && self.extraneous.is_empty()
+    }
+
+    pub(crate) fn append(&mut self, other: &mut ValidationError) {
+        self.extraneous.append(&mut other.extraneous);
+        self.missing.append(&mut other.missing);
+    }
+
+    pub(crate) fn push_missing(&mut self, missing: Missing) {
+        self.missing.push(missing);
+    }
+
+    pub(crate) fn push_extraneous(&mut self, extraneous: SyntaxElement) {
+        self.extraneous.push(extraneous);
+    }
+
+    pub(crate) fn into_result(self) -> Result<(), Self> {
+        if self.is_empty() {
+            Ok(())
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Returns elements that are expected to be in the tree, but were missing
+    pub fn missing(&self) -> &[Missing] {
+        &self.missing
+    }
+
+    /// Returns elements that are in the tree, but weren't expected
+    pub fn extraneous(&self) -> &[SyntaxElement] {
+        &self.extraneous
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.missing.len(), self.extraneous.len()) {
+            (m, 0) => write!(f, "{m} missing element(s)"),
+            (0, e) => write!(f, "{e} extraneous element(s)"),
+            (m, e) => write!(f, "{m} missing and {e} extraneous element(s)"),
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Describes a node that was missing
+#[derive(Clone, Debug)]
+pub struct Missing {
+    /// The node before this one
+    previous: Option<SyntaxElement>,
+    /// The parent node (where the node was missing)
+    parent: SyntaxNode,
+    /// What was missing
+    kind: LayoutItemKind,
+}
+
+impl Missing {
+    pub(crate) fn new(
+        previous: Option<SyntaxElement>,
+        parent: SyntaxNode,
+        kind: LayoutItemKind,
+    ) -> Missing {
+        Missing {
+            previous,
+            parent,
+            kind,
+        }
+    }
+
+    pub fn previous(&self) -> Option<&SyntaxElement> {
+        self.previous.as_ref()
+    }
+
+    pub fn parent(&self) -> &SyntaxNode {
+        &self.parent
+    }
+
+    pub fn kind(&self) -> &LayoutItemKind {
+        &self.kind
+    }
+}

--- a/vhdl_syntax/src/syntax/validate/mod.rs
+++ b/vhdl_syntax/src/syntax/validate/mod.rs
@@ -19,12 +19,9 @@ pub fn check(node: &SyntaxNode) -> Result<(), ValidationError> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        parser::{builder::NodeBuilder, parse_syntax, Parser},
+        parser::{Parser, builder::NodeBuilder, parse, parse_syntax},
         syntax::{
-            meta::LayoutItemKind,
-            node::{SyntaxElement, SyntaxNode},
-            node_kind::NodeKind,
-            validate::check,
+            AstNode, meta::LayoutItemKind, node::{SyntaxElement, SyntaxNode}, node_kind::NodeKind, validate::check
         },
         tokens::{Keyword, Token, TokenKind, Trivia},
     };
@@ -85,6 +82,21 @@ mod tests {
             parse_syntax("entity a is end; entity b is end;", Parser::design_file);
         assert!(diagnostics.is_empty());
         assert!(check(&node).is_ok());
+    }
+
+    #[test]
+    fn full_vhdl_file() {
+        let (node, diagnostics) =
+            parse(r#"
+entity foo is
+    port (
+        clk : in bit;
+        rst : in bit
+    );
+end entity foo;
+            "#);
+        assert!(diagnostics.is_empty());
+        assert!(check(&node.raw()).is_ok());
     }
 
     // --- missing-element tests ---

--- a/vhdl_syntax/src/syntax/validate/mod.rs
+++ b/vhdl_syntax/src/syntax/validate/mod.rs
@@ -1,0 +1,230 @@
+//! Validate raw syntax nodes.
+// Improvements:
+// - Add configurable tree recursion depth (currently, entire tree must is searched).
+//   This could be needed by analysis (don't want to analyze the entire tree), but bit-by-bit
+// - "Error tolerant" / "smart": Currently, `architecture arch 1 of foo is ...` would return 4 incorrect elements
+//   ("1 of foo is"). Instead, it should be one extraneous element only.
+
+use crate::syntax::{node::SyntaxNode, validate::validator::Validator};
+
+pub mod error;
+mod validator;
+pub use error::{Missing, ValidationError};
+
+/// Check a node for missing and extraneous elements.
+pub fn check(node: &SyntaxNode) -> Result<(), ValidationError> {
+    Validator::new(node).validate().into_result()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        parser::{builder::NodeBuilder, parse_syntax, Parser},
+        syntax::{
+            meta::LayoutItemKind,
+            node::{SyntaxElement, SyntaxNode},
+            node_kind::NodeKind,
+            validate::check,
+        },
+        tokens::{Keyword, Token, TokenKind, Trivia},
+    };
+
+    fn tok(kind: TokenKind, text: &[u8]) -> Token {
+        Token::new(kind, text, Trivia::default())
+    }
+
+    /// Build an `EntityDeclarationPreamble` node from the given raw tokens.
+    /// Layout: entity (req) · name-identifier (req) · is (req)
+    fn build_preamble(tokens: impl IntoIterator<Item = Token>) -> SyntaxNode {
+        let mut b = NodeBuilder::new();
+        b.start_node(NodeKind::EntityDeclarationPreamble);
+        for t in tokens {
+            b.push(t);
+        }
+        b.end_node();
+        SyntaxNode::new_root(b.end())
+    }
+
+    // --- happy-path tests ---
+
+    #[test]
+    fn valid_preamble_passes() {
+        let (node, diagnostics) =
+            parse_syntax("entity foo is", Parser::entity_declaration_preamble);
+        assert!(diagnostics.is_empty());
+        assert!(check(&node).is_ok());
+    }
+
+    #[test]
+    fn optional_absent_passes() {
+        // EntityDeclarationEpilogue: end (req) · entity (opt) · identifier (opt) · ; (req)
+        // Both optional items omitted — must still pass.
+        let (node, diagnostics) = parse_syntax("end;", Parser::entity_declaration_epilogue);
+        assert!(diagnostics.is_empty());
+        assert!(check(&node).is_ok());
+    }
+
+    #[test]
+    fn optional_present_passes() {
+        let (node, diagnostics) =
+            parse_syntax("end entity foo;", Parser::entity_declaration_epilogue);
+        assert!(diagnostics.is_empty());
+        assert!(check(&node).is_ok());
+    }
+
+    #[test]
+    fn repeated_with_zero_occurrences_passes() {
+        // DesignFile: DesignUnit* (repeated, zero here) · EOF (req)
+        let (node, _) = parse_syntax("", Parser::design_file);
+        assert!(check(&node).is_ok());
+    }
+
+    #[test]
+    fn repeated_with_multiple_occurrences_passes() {
+        let (node, diagnostics) =
+            parse_syntax("entity a is end; entity b is end;", Parser::design_file);
+        assert!(diagnostics.is_empty());
+        assert!(check(&node).is_ok());
+    }
+
+    // --- missing-element tests ---
+
+    #[test]
+    fn missing_required_tokens_are_reported() {
+        // EntityDeclarationPreamble with only 'entity'; 'name' and 'is' are absent.
+        let node = build_preamble([tok(TokenKind::Keyword(Keyword::Entity), b"entity")]);
+        let err = check(&node).unwrap_err();
+
+        assert_eq!(err.missing().len(), 2);
+        assert_eq!(err.extraneous().len(), 0);
+
+        // First missing: the entity-name identifier.
+        assert!(matches!(
+            err.missing()[0].kind(),
+            LayoutItemKind::Token(TokenKind::Identifier)
+        ));
+        // The entity keyword was the last consumed element before the gap.
+        assert!(err.missing()[0].previous().is_some());
+        assert_eq!(
+            err.missing()[0].parent().kind(),
+            NodeKind::EntityDeclarationPreamble
+        );
+
+        // Second missing: the 'is' keyword.
+        assert!(matches!(
+            err.missing()[1].kind(),
+            LayoutItemKind::Token(TokenKind::Keyword(Keyword::Is))
+        ));
+        assert_eq!(
+            err.missing()[1].parent().kind(),
+            NodeKind::EntityDeclarationPreamble
+        );
+    }
+
+    #[test]
+    fn missing_required_after_optional_is_reported() {
+        // EntityDeclarationEpilogue with only 'end'; the mandatory ';' is absent.
+        let mut b = NodeBuilder::new();
+        b.start_node(NodeKind::EntityDeclarationEpilogue);
+        b.push(tok(TokenKind::Keyword(Keyword::End), b"end"));
+        b.end_node();
+        let node = SyntaxNode::new_root(b.end());
+
+        let err = check(&node).unwrap_err();
+
+        assert_eq!(err.missing().len(), 1);
+        assert!(matches!(
+            err.missing()[0].kind(),
+            LayoutItemKind::Token(TokenKind::SemiColon)
+        ));
+        // 'end' was consumed before the missing ';'.
+        assert!(err.missing()[0].previous().is_some());
+    }
+
+    // --- extraneous-element test ---
+
+    #[test]
+    fn extraneous_token_is_reported() {
+        // All required tokens present, plus one surplus identifier at the end.
+        let node = build_preamble([
+            tok(TokenKind::Keyword(Keyword::Entity), b"entity"),
+            tok(TokenKind::Identifier, b"foo"),
+            tok(TokenKind::Keyword(Keyword::Is), b"is"),
+            tok(TokenKind::Identifier, b"extra"),
+        ]);
+        let err = check(&node).unwrap_err();
+
+        assert_eq!(err.missing().len(), 0);
+        assert_eq!(err.extraneous().len(), 1);
+        assert!(matches!(err.extraneous()[0], SyntaxElement::Token(_)));
+    }
+
+    // --- recursive propagation test ---
+
+    #[test]
+    fn child_errors_propagate_to_parent() {
+        // EntityDeclarationPreamble with only 'entity' — 'name' and 'is' are missing.
+        let bad_preamble = build_preamble([tok(TokenKind::Keyword(Keyword::Entity), b"entity")]);
+
+        // Minimal valid epilogue: "end ;"
+        let mut b = NodeBuilder::new();
+        b.start_node(NodeKind::EntityDeclarationEpilogue);
+        b.push(tok(TokenKind::Keyword(Keyword::End), b"end"));
+        b.push(tok(TokenKind::SemiColon, b";"));
+        b.end_node();
+        let epilogue = SyntaxNode::new_root(b.end());
+
+        // Assemble an EntityDeclaration from the two children above.
+        // All intermediate optional children (EntityHeader, Declarations, …) are absent.
+        let mut b = NodeBuilder::new();
+        b.start_node(NodeKind::EntityDeclaration);
+        b.push_node(bad_preamble.green().clone());
+        b.push_node(epilogue.green().clone());
+        b.end_node();
+        let entity = SyntaxNode::new_root(b.end());
+
+        let err = check(&entity).unwrap_err();
+
+        // The two missing items from the preamble must bubble up through the parent check.
+        assert_eq!(err.missing().len(), 2);
+        assert_eq!(err.extraneous().len(), 0);
+        // The errors are attributed to the child (preamble), not the entity root.
+        assert_eq!(
+            err.missing()[0].parent().kind(),
+            NodeKind::EntityDeclarationPreamble
+        );
+    }
+
+    #[test]
+    fn missing_fields_are_correct() {
+        // Build a preamble that contains only the identifier, so:
+        //   - 'entity' (required, first) is missing  → previous must be None
+        //   - 'is'     (required, last)  is missing  → previous must be the identifier token
+        let node = build_preamble([tok(TokenKind::Identifier, b"foo")]);
+        let err = check(&node).unwrap_err();
+
+        assert_eq!(err.missing().len(), 2);
+
+        // First gap: 'entity' keyword, nothing consumed before it.
+        let first = &err.missing()[0];
+        assert!(matches!(
+            first.kind(),
+            LayoutItemKind::Token(TokenKind::Keyword(Keyword::Entity))
+        ));
+        assert_eq!(first.parent().kind(), NodeKind::EntityDeclarationPreamble);
+        assert!(first.previous().is_none());
+
+        // Second gap: 'is' keyword, the identifier was the last consumed token.
+        let second = &err.missing()[1];
+        assert!(matches!(
+            second.kind(),
+            LayoutItemKind::Token(TokenKind::Keyword(Keyword::Is))
+        ));
+        assert_eq!(second.parent().kind(), NodeKind::EntityDeclarationPreamble);
+        let prev = second
+            .previous()
+            .and_then(|el| el.as_token())
+            .expect("previous should be the identifier token");
+        assert_eq!(prev.kind(), TokenKind::Identifier);
+    }
+}

--- a/vhdl_syntax/src/syntax/validate/validator.rs
+++ b/vhdl_syntax/src/syntax/validate/validator.rs
@@ -1,0 +1,121 @@
+use crate::syntax::{
+    layout_of,
+    meta::{Layout, LayoutItemKind, Sequence},
+    node::{SyntaxElement, SyntaxNode},
+    validate::error::{Missing, ValidationError},
+};
+use std::collections::VecDeque;
+
+// OPTIMIZATION:
+// There are a few things one could optimize here:
+// - Use a bitmap to check which nodes are present / missing (cheap; requires no construction and no / small allocation)
+// - make recursive algorithm non-recursive, e.g., by using tree walking
+// - Collect everything into one error; don't use multiples (reduces allocation again for deep traversal)
+
+/// Internal helper to validate nodes for missing or extraneous elements.
+pub(crate) struct Validator {
+    nodes: VecDeque<SyntaxElement>,
+    err: ValidationError,
+    parent: SyntaxNode,
+    last: Option<SyntaxElement>,
+}
+
+fn validate_child(child: &SyntaxElement) -> ValidationError {
+    match child {
+        SyntaxElement::Node(node) => Validator::new(node).validate(),
+        _ => ValidationError::new(),
+    }
+}
+
+impl Validator {
+    pub(crate) fn new(node: &SyntaxNode) -> Validator {
+        Validator {
+            nodes: node.children_with_tokens().collect(),
+            err: ValidationError::new(),
+            parent: node.clone(),
+            last: None,
+        }
+    }
+
+    pub(crate) fn validate(mut self) -> ValidationError {
+        let layout = layout_of(self.parent.kind());
+        match layout {
+            Layout::Sequence(sequence) => {
+                self.validate_sequence_children(sequence);
+                for node in self.nodes {
+                    let mut errs = validate_child(&node);
+                    self.err.append(&mut errs);
+                    self.err.push_extraneous(node);
+                }
+                self.err
+            }
+            Layout::Choice(_) => {
+                debug_assert!(
+                    false,
+                    "layout_of(node.kind()) should never return a choice node"
+                );
+                ValidationError::new()
+            }
+        }
+    }
+
+    fn pop_front(&mut self) {
+        self.last = self.nodes.pop_front();
+        if let Some(last) = &self.last {
+            let mut child_errs = validate_child(last);
+            self.err.append(&mut child_errs);
+        };
+    }
+
+    fn push_missing(&mut self, kind: LayoutItemKind) {
+        self.err
+            .push_missing(Missing::new(self.last.clone(), self.parent.clone(), kind));
+    }
+
+    fn next_matches_layout(&self, kind: &LayoutItemKind) -> bool {
+        self.nodes.front().is_some_and(|node| match node {
+            SyntaxElement::Node(node) => match kind {
+                LayoutItemKind::Token(_) | LayoutItemKind::TokenChoice(_) => false,
+                LayoutItemKind::Node(node_kind) => &node.kind() == node_kind,
+                LayoutItemKind::NodeChoice(node_kinds) => node_kinds.contains(&node.kind()),
+            },
+            SyntaxElement::Token(token) => match kind {
+                LayoutItemKind::Token(token_kind) => &token.kind() == token_kind,
+                LayoutItemKind::Node(_) | LayoutItemKind::NodeChoice(_) => false,
+                LayoutItemKind::TokenChoice(token_kinds) => token_kinds.contains(&token.kind()),
+            },
+        })
+    }
+
+    fn require(&mut self, kind: &LayoutItemKind) {
+        if self.next_matches_layout(kind) {
+            self.pop_front();
+        } else {
+            self.push_missing(*kind);
+        }
+    }
+
+    fn optional(&mut self, kind: &LayoutItemKind) {
+        if self.next_matches_layout(kind) {
+            self.pop_front();
+        }
+    }
+
+    fn consume_repeated(&mut self, kind: &LayoutItemKind) {
+        while self.next_matches_layout(kind) {
+            self.pop_front();
+        }
+    }
+
+    fn validate_sequence_children(&mut self, sequence: &Sequence) {
+        for node in sequence.items {
+            if node.repeated {
+                self.consume_repeated(&node.kind);
+            } else if node.optional {
+                self.optional(&node.kind);
+            } else {
+                self.require(&node.kind);
+            }
+        }
+    }
+}

--- a/xtask/src/generate/checked_nodes.rs
+++ b/xtask/src/generate/checked_nodes.rs
@@ -1,0 +1,300 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025, Lukas Scheller lukasscheller@icloud.com
+
+use crate::generate::naming::{checked_type_ident, syntax_type_ident, variant_ident};
+use crate::generate::Generator;
+use crate::model::{ChoiceNode, Model, Node, NodeRef, NodesOrTokens, SequenceNode, Token, TokenOrNode};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+fn section_needs_syntax_token(nodes: &[Node]) -> bool {
+    nodes.iter().any(|n| match n {
+        Node::Items(seq) => seq.items.iter().any(|item| matches!(item, TokenOrNode::Token(_))),
+        _ => false,
+    })
+}
+
+fn section_needs_super(nodes: &[Node], model: &Model) -> bool {
+    nodes.iter().any(|n| match n {
+        Node::Items(seq) => seq.items.iter().any(|item| match item {
+            TokenOrNode::Node(node_ref) => !model.is_token_choice(&node_ref.kind),
+            _ => false,
+        }),
+        // Node-choice enums hold Checked* variants whose raw() impl references those
+        // types — so the section needs `use super::*` to bring them into scope.
+        Node::Choices(choice) => matches!(&choice.items, NodesOrTokens::Nodes(_)),
+        _ => false,
+    })
+}
+
+pub struct CheckedNodeGenerator;
+
+impl Generator for CheckedNodeGenerator {
+    fn name(&self) -> &str {
+        "checked_nodes"
+    }
+
+    fn generate_files(&self, model: &Model) -> Vec<(String, TokenStream)> {
+        let mut files = Vec::new();
+
+        let mut sections: Vec<(&String, &Vec<Node>)> = model.sections().iter().collect();
+        sections.sort_by_key(|(name, _)| *name);
+
+        for (category, nodes) in &sections {
+            let syntax_token_import = section_needs_syntax_token(nodes).then(|| quote! {
+                use crate::syntax::node::SyntaxToken;
+            });
+            let super_import = section_needs_super(nodes, model).then(|| quote! {
+                use super::*;
+            });
+            let mut stream = quote! {
+                #super_import
+                use crate::syntax::checked::CheckedNode;
+                use crate::syntax::*;
+                #syntax_token_import
+            };
+            for node in *nodes {
+                stream.extend(generate_checked_node(node, model));
+            }
+            files.push(((*category).clone(), stream));
+        }
+
+        files.push(("mod".to_string(), generate_mod(model)));
+
+        files
+    }
+}
+
+fn generate_checked_node(node: &Node, model: &Model) -> TokenStream {
+    match node {
+        Node::Items(seq) => generate_checked_sequence(seq, model),
+        Node::RawTokens(name) => generate_checked_raw_tokens(name),
+        Node::Choices(choice) => match &choice.items {
+            NodesOrTokens::Nodes(_) => generate_checked_node_choice(choice),
+            // Token-choices don't need a checked wrapper: callers receive the
+            // existing *Syntax enum directly (required fields unwrap the Option).
+            NodesOrTokens::Tokens(_) => quote! {},
+        },
+    }
+}
+
+// MARK: Sequence nodes
+
+fn generate_checked_sequence(seq: &SequenceNode, model: &Model) -> TokenStream {
+    let checked_name = checked_type_ident(&seq.name);
+    let syntax_name = syntax_type_ident(&seq.name);
+
+    let getters: TokenStream = seq
+        .items
+        .iter()
+        .map(|item| build_checked_getter(item, model))
+        .collect();
+
+    quote! {
+        #[derive(Debug, Clone)]
+        pub struct #checked_name(#syntax_name);
+
+        impl CheckedNode for #checked_name {
+            type Syntax = #syntax_name;
+            fn cast_unchecked(syntax: #syntax_name) -> Self {
+                #checked_name(syntax)
+            }
+            fn raw(&self) -> #syntax_name {
+                self.0.clone()
+            }
+        }
+
+        impl #checked_name {
+            #getters
+        }
+    }
+}
+
+// MARK: Raw-token nodes
+
+fn generate_checked_raw_tokens(name: &str) -> TokenStream {
+    let checked_name = checked_type_ident(name);
+    let syntax_name = syntax_type_ident(name);
+
+    quote! {
+        #[derive(Debug, Clone)]
+        pub struct #checked_name(#syntax_name);
+
+        impl CheckedNode for #checked_name {
+            type Syntax = #syntax_name;
+            fn cast_unchecked(syntax: #syntax_name) -> Self {
+                #checked_name(syntax)
+            }
+            fn raw(&self) -> #syntax_name {
+                self.0.clone()
+            }
+        }
+    }
+}
+
+// MARK: Node-choice enums
+
+fn generate_checked_node_choice(choice: &ChoiceNode) -> TokenStream {
+    let NodesOrTokens::Nodes(variants) = &choice.items else {
+        return quote! {};
+    };
+
+    let checked_name = checked_type_ident(&choice.name);
+    let syntax_name = syntax_type_ident(&choice.name);
+
+    let enum_variants: Vec<TokenStream> = variants
+        .iter()
+        .map(|item| {
+            let variant = variant_ident(&item.kind);
+            let checked = checked_type_ident(&item.kind);
+            quote! { #variant(#checked) }
+        })
+        .collect();
+
+    let cast_branches: Vec<TokenStream> = variants
+        .iter()
+        .map(|item| {
+            let variant = variant_ident(&item.kind);
+            let checked = checked_type_ident(&item.kind);
+            quote! {
+                #syntax_name::#variant(inner) =>
+                    #checked_name::#variant(#checked::cast_unchecked(inner))
+            }
+        })
+        .collect();
+
+    let raw_cast_branches: Vec<TokenStream> = variants
+        .iter()
+        .map(|item| {
+            let variant = variant_ident(&item.kind);
+            quote! {
+                #checked_name::#variant(inner) => #syntax_name::#variant(inner.raw())
+            }
+        })
+        .collect();
+
+    quote! {
+        #[derive(Debug, Clone)]
+        pub enum #checked_name {
+            #(#enum_variants,)*
+        }
+
+        impl CheckedNode for #checked_name {
+            type Syntax = #syntax_name;
+            fn cast_unchecked(syntax: #syntax_name) -> Self {
+                match syntax {
+                    #(#cast_branches,)*
+                }
+            }
+            fn raw(&self) -> Self::Syntax {
+                match self {
+                    #(#raw_cast_branches,)*
+                }
+            }
+        }
+    }
+}
+
+// MARK: Getter helpers
+
+fn build_checked_getter(item: &TokenOrNode, model: &Model) -> TokenStream {
+    match item {
+        TokenOrNode::Token(token) => build_checked_token_getter(token),
+        TokenOrNode::Node(node_ref) => build_checked_node_ref_getter(node_ref, model),
+    }
+}
+
+fn build_checked_token_getter(token: &Token) -> TokenStream {
+    let fn_name = format_ident!("{}", token.getter_name());
+    if token.repeated {
+        quote! {
+            pub fn #fn_name(&self) -> impl Iterator<Item = SyntaxToken> + use<'_> {
+                self.0.#fn_name()
+            }
+        }
+    } else if token.optional {
+        quote! {
+            pub fn #fn_name(&self) -> Option<SyntaxToken> {
+                self.0.#fn_name()
+            }
+        }
+    } else {
+        quote! {
+            pub fn #fn_name(&self) -> SyntaxToken {
+                self.0.#fn_name().unwrap()
+            }
+        }
+    }
+}
+
+fn build_checked_node_ref_getter(node_ref: &NodeRef, model: &Model) -> TokenStream {
+    let fn_name = format_ident!("{}", node_ref.getter_name());
+    let is_token_choice = model.is_token_choice(&node_ref.kind);
+
+    // Token-choices return the existing *Syntax enum directly (no Checked* wrapper).
+    // Everything else (sequence nodes, raw-token nodes, node-choice enums) returns
+    // the corresponding Checked* type.
+    if is_token_choice {
+        let syntax_type = syntax_type_ident(&node_ref.kind);
+        if node_ref.repeated {
+            quote! {
+                pub fn #fn_name(&self) -> impl Iterator<Item = #syntax_type> + use<'_> {
+                    self.0.#fn_name()
+                }
+            }
+        } else if node_ref.optional {
+            quote! {
+                pub fn #fn_name(&self) -> Option<#syntax_type> {
+                    self.0.#fn_name()
+                }
+            }
+        } else {
+            quote! {
+                pub fn #fn_name(&self) -> #syntax_type {
+                    self.0.#fn_name().unwrap()
+                }
+            }
+        }
+    } else {
+        let checked_type = checked_type_ident(&node_ref.kind);
+        if node_ref.repeated {
+            quote! {
+                pub fn #fn_name(&self) -> impl Iterator<Item = #checked_type> + use<'_> {
+                    self.0.#fn_name().map(#checked_type::cast_unchecked)
+                }
+            }
+        } else if node_ref.optional {
+            quote! {
+                pub fn #fn_name(&self) -> Option<#checked_type> {
+                    self.0.#fn_name().map(#checked_type::cast_unchecked)
+                }
+            }
+        } else {
+            quote! {
+                pub fn #fn_name(&self) -> #checked_type {
+                    #checked_type::cast_unchecked(self.0.#fn_name().unwrap())
+                }
+            }
+        }
+    }
+}
+
+// MARK: mod.rs
+
+fn generate_mod(model: &Model) -> TokenStream {
+    let mut sections = model.sections().keys().collect::<Vec<_>>();
+    sections.sort();
+    sections
+        .into_iter()
+        .map(|section| {
+            let mod_ident = format_ident!("{}", section);
+            quote! {
+                pub mod #mod_ident;
+                pub use #mod_ident::*;
+            }
+        })
+        .collect()
+}

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -5,10 +5,12 @@
 // Copyright (c) 2025, Lukas Scheller lukasscheller@icloud.com
 
 pub mod builders;
-pub mod naming;
 pub use builders::BuilderGenerator;
+pub mod checked_nodes;
+pub use checked_nodes::CheckedNodeGenerator;
 pub mod meta;
 pub use meta::MetaGenerator;
+pub mod naming;
 pub mod syntax_nodes;
 pub use syntax_nodes::SyntaxNodeGenerator;
 

--- a/xtask/src/generate/naming.rs
+++ b/xtask/src/generate/naming.rs
@@ -29,6 +29,11 @@ pub fn token_type_ident(name: &str) -> Ident {
     format_ident!("{}Token", name.to_case(Case::UpperCamel))
 }
 
+/// `CheckedFoo`
+pub fn checked_type_ident(name: &str) -> Ident {
+    format_ident!("Checked{}", name.to_case(Case::UpperCamel))
+}
+
 /// `Foo`  (used for enum variant names — merges the two identical functions)
 pub fn variant_ident(name: &str) -> Ident {
     format_ident!("{}", name.to_case(Case::UpperCamel))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,8 +6,8 @@
 
 use clap::{Parser, Subcommand};
 use generate::{
-    check_generators, run_generators, BuilderGenerator, Generator, MetaGenerator,
-    SyntaxNodeGenerator,
+    check_generators, run_generators, BuilderGenerator, CheckedNodeGenerator, Generator,
+    MetaGenerator, SyntaxNodeGenerator,
 };
 use model::load_model;
 use std::path::Path;
@@ -43,14 +43,21 @@ fn main() {
     match cli.command {
         Commands::Codegen { check } => {
             let output_dir = workspace_root.join("vhdl_syntax/src/syntax/generated");
+            let checked_output_dir =
+                workspace_root.join("vhdl_syntax/src/syntax/checked/generated");
             let definitions_dir = workspace_root.join("xtask/src/syntax_definitions");
             let model = load_model(&definitions_dir);
             let generators: &[&dyn Generator] =
                 &[&SyntaxNodeGenerator, &BuilderGenerator, &MetaGenerator];
+            let checked_generators: &[&dyn Generator] = &[&CheckedNodeGenerator];
 
             if check {
-                let stale = check_generators(generators, &model, &output_dir)
+                let mut stale = check_generators(generators, &model, &output_dir)
                     .expect("failed to check generators");
+                stale.extend(
+                    check_generators(checked_generators, &model, &checked_output_dir)
+                        .expect("failed to check checked generators"),
+                );
                 if stale.is_empty() {
                     println!("All generated files are up-to-date.");
                 } else {
@@ -63,7 +70,13 @@ fn main() {
                 }
             } else {
                 run_generators(generators, &model, &output_dir).expect("failed to run generators");
+                run_generators(checked_generators, &model, &checked_output_dir)
+                    .expect("failed to run checked generators");
                 println!("Generated files written to {}", output_dir.display());
+                println!(
+                    "Checked generated files written to {}",
+                    checked_output_dir.display()
+                );
             }
         }
     }


### PR DESCRIPTION
`CheckedNode`s are a wrapper around `SyntaxNode`s with guarantees that there are no missing or extraneous elements.
This information is extracted from the new meta-API and checked nodes can only be constructed (safely) if they pass validation.
They enable a more ergonomic API entry to the design as all optional nodes are now truly optional, and all required nodes simply return the node instead of `Option` as would be the case for the `SyntaxNode`

Changes are fairly simple, but contains ~10k of generated code