### PR TITLE
fix: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,12 +108,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -457,6 +451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b8ec601e62362b666a3def1fed667ee87b10a4507402618376d142a05373c6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,12 +532,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -540,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -553,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -567,15 +573,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -587,15 +593,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -709,7 +715,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
 ]
 
@@ -731,9 +737,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -761,19 +767,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -916,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1013,7 +1006,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1062,7 +1055,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1132,17 +1125,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1327,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1501,9 +1483,9 @@ dependencies = [
  "env_logger",
  "fnv",
  "fuzzy-matcher",
+ "gen-lsp-types",
  "log",
  "lsp-server",
- "lsp-types",
  "pretty_assertions",
  "regex",
  "serde",
@@ -1653,9 +1635,9 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
@@ -1681,9 +1663,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1692,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1704,18 +1686,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1725,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1736,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1747,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ fuzzy-matcher = "0.3.7"
 glob = "0.3.2"
 itertools = "0.14.0"
 log = "0.4.27"
-lsp-types = "^0.95.1"
+lsp-types = { package = "gen-lsp-types", version = "0.4.0", features = ["url"] }
 lsp-server = "0.7.8"
 parking_lot = "0.12.3"
 pinned_vec = "0.1.1"

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -9,7 +9,13 @@
 //! dispatching them to the appropriate server methods.
 
 use lsp_server::{Connection, ExtractError, Request, RequestId};
-use lsp_types::{notification, request, InitializeParams};
+use lsp_types::{
+    CompletionRequest, CompletionResolveRequest, DeclarationRequest, DefinitionRequest,
+    DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
+    DidOpenTextDocumentNotification, DocumentHighlightRequest, DocumentSymbolRequest, HoverRequest,
+    ImplementationRequest, InitializeParams, Notification, PrepareRenameRequest, ReferencesRequest,
+    RenameRequest, SemanticTokensRangeRequest, SemanticTokensRequest, WorkspaceSymbolRequest,
+};
 use serde_json::Value;
 
 use std::{cell::RefCell, rc::Rc};
@@ -121,10 +127,10 @@ impl ConnectionRpcChannel {
             request: lsp_server::Request,
         ) -> Result<(lsp_server::RequestId, R::Params), lsp_server::Request>
         where
-            R: request::Request,
+            R: lsp_types::Request,
             R::Params: serde::de::DeserializeOwned,
         {
-            request.extract(R::METHOD).map_err(|e| match e {
+            request.extract(R::METHOD.as_str()).map_err(|e| match e {
                 ExtractError::MethodMismatch(r) => r,
                 err @ ExtractError::JsonError { .. } => {
                     panic!("{err:?}");
@@ -133,7 +139,7 @@ impl ConnectionRpcChannel {
         }
 
         trace!("Handling request: {request:?}");
-        let request = match extract::<request::GotoDeclaration>(request) {
+        let request = match extract::<DeclarationRequest>(request) {
             Ok((id, params)) => {
                 let result =
                     server.text_document_declaration(&params.text_document_position_params);
@@ -142,7 +148,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::GotoDefinition>(request) {
+        let request = match extract::<DefinitionRequest>(request) {
             Ok((id, params)) => {
                 let result = server.text_document_definition(&params.text_document_position_params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -150,7 +156,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::GotoImplementation>(request) {
+        let request = match extract::<ImplementationRequest>(request) {
             Ok((id, params)) => {
                 let result =
                     server.text_document_implementation(&params.text_document_position_params);
@@ -159,7 +165,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::Rename>(request) {
+        let request = match extract::<RenameRequest>(request) {
             Ok((id, params)) => {
                 let result = server.rename(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -167,15 +173,15 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::PrepareRenameRequest>(request) {
+        let request = match extract::<PrepareRenameRequest>(request) {
             Ok((id, params)) => {
-                let result = server.prepare_rename(&params);
+                let result = server.prepare_rename(&params.text_document_position_params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
                 return;
             }
             Err(request) => request,
         };
-        let request = match extract::<request::WorkspaceSymbolRequest>(request) {
+        let request = match extract::<WorkspaceSymbolRequest>(request) {
             Ok((id, params)) => {
                 let result = server.workspace_symbol(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -183,7 +189,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::DocumentSymbolRequest>(request) {
+        let request = match extract::<DocumentSymbolRequest>(request) {
             Ok((id, params)) => {
                 let result = server.document_symbol(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -191,7 +197,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::DocumentHighlightRequest>(request) {
+        let request = match extract::<DocumentHighlightRequest>(request) {
             Ok((id, params)) => {
                 let result = server.document_highlight(&params.text_document_position_params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -199,7 +205,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::HoverRequest>(request) {
+        let request = match extract::<HoverRequest>(request) {
             Ok((id, params)) => {
                 let result = server.text_document_hover(&params.text_document_position_params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -207,7 +213,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::References>(request) {
+        let request = match extract::<ReferencesRequest>(request) {
             Ok((id, params)) => {
                 let result = server.text_document_references(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -215,7 +221,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::Completion>(request) {
+        let request = match extract::<CompletionRequest>(request) {
             Ok((id, params)) => {
                 let res = server.request_completion(&params);
                 self.send_response(lsp_server::Response::new_ok(id, res));
@@ -223,7 +229,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::ResolveCompletionItem>(request) {
+        let request = match extract::<CompletionResolveRequest>(request) {
             Ok((id, params)) => {
                 let res = server.resolve_completion_item(&params);
                 self.send_response(lsp_server::Response::new_ok(id, res));
@@ -231,7 +237,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::SemanticTokensFullRequest>(request) {
+        let request = match extract::<SemanticTokensRequest>(request) {
             Ok((id, params)) => {
                 let result = server.semantic_tokens_full(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -239,7 +245,7 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
-        let request = match extract::<request::SemanticTokensRangeRequest>(request) {
+        let request = match extract::<SemanticTokensRangeRequest>(request) {
             Ok((id, params)) => {
                 let result = server.semantic_tokens_range(&params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
@@ -262,30 +268,32 @@ impl ConnectionRpcChannel {
             notification: lsp_server::Notification,
         ) -> Result<N::Params, lsp_server::Notification>
         where
-            N: notification::Notification,
+            N: Notification,
             N::Params: serde::de::DeserializeOwned,
         {
-            notification.extract(N::METHOD).map_err(|e| match e {
-                ExtractError::MethodMismatch(n) => n,
-                err @ ExtractError::JsonError { .. } => {
-                    panic!("{err:?}");
-                }
-            })
+            notification
+                .extract(N::METHOD.as_str())
+                .map_err(|e| match e {
+                    ExtractError::MethodMismatch(n) => n,
+                    err @ ExtractError::JsonError { .. } => {
+                        panic!("{err:?}");
+                    }
+                })
         }
 
         trace!("Handling notification: {notification:?}");
         // textDocument/didChange
-        let notification = match extract::<notification::DidChangeTextDocument>(notification) {
+        let notification = match extract::<DidChangeTextDocumentNotification>(notification) {
             Ok(params) => return server.text_document_did_change_notification(&params),
             Err(notification) => notification,
         };
         // textDocument/didOpen
-        let notification = match extract::<notification::DidOpenTextDocument>(notification) {
+        let notification = match extract::<DidOpenTextDocumentNotification>(notification) {
             Ok(params) => return server.text_document_did_open_notification(&params),
             Err(notification) => notification,
         };
         // workspace.didChangeWatchedFiles
-        let notification = match extract::<notification::DidChangeWatchedFiles>(notification) {
+        let notification = match extract::<DidChangeWatchedFilesNotification>(notification) {
             Ok(params) => return server.workspace_did_change_watched_files(&params),
             Err(notification) => notification,
         };

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -63,8 +63,8 @@ pub struct VHDLServer {
     // To have well defined unit tests that are not affected by environment
     use_external_config: bool,
     project: Project,
-    diagnostic_cache: FnvHashMap<Url, Vec<vhdl_lang::Diagnostic>>,
-    semantic_token_cache: FnvHashMap<Url, Vec<semantic_tokens::CachedToken>>,
+    diagnostic_cache: FnvHashMap<Uri, Vec<vhdl_lang::Diagnostic>>,
+    semantic_token_cache: FnvHashMap<Uri, Vec<semantic_tokens::CachedToken>>,
     init_params: Option<InitializeParams>,
     config_file: Option<PathBuf>,
     severity_map: SeverityMap,
@@ -190,6 +190,7 @@ impl VHDLServer {
                 .as_ref()?
                 .publish_diagnostics
                 .as_ref()?
+                .diagnostics_capabilities
                 .related_information
         };
         try_fun().unwrap_or(false)
@@ -285,7 +286,7 @@ impl VHDLServer {
                 }
             }
 
-            Some(DocumentSymbolResponse::Nested(
+            Some(DocumentSymbolResponse::DocumentSymbolList(
                 self.project
                     .document_symbols(&library_name, &source)
                     .into_iter()
@@ -300,16 +301,18 @@ impl VHDLServer {
                     .unwrap_or_else(|| ent.src_span.start_token.pos(ctx));
                 #[allow(deprecated)]
                 SymbolInformation {
-                    name: ent.describe(),
-                    kind: to_symbol_kind(ent.kind()),
-                    tags: None,
                     location: srcpos_to_location(selection_pos),
                     deprecated: None,
-                    container_name: ent.parent_in_same_source().map(|ent| ent.describe()),
+                    base_symbol_information: BaseSymbolInformation {
+                        name: ent.describe(),
+                        kind: to_symbol_kind(ent.kind()),
+                        tags: None,
+                        container_name: ent.parent_in_same_source().map(|ent| ent.describe()),
+                    },
                 }
             }
 
-            Some(DocumentSymbolResponse::Flat(
+            Some(DocumentSymbolResponse::SymbolInformationList(
                 self.project
                     .document_symbols(&library_name, &source)
                     .into_iter()
@@ -351,7 +354,7 @@ impl MessageHandler for MessageFilter {
             self.rpc.send_notification(
                 "window/showMessage",
                 ShowMessageParams {
-                    typ: to_lsp_message_type(&msg.message_type),
+                    kind: to_lsp_message_type(&msg.message_type),
                     message: msg.message.clone(),
                 },
             );
@@ -360,7 +363,7 @@ impl MessageHandler for MessageFilter {
         self.rpc.send_notification(
             "window/logMessage",
             LogMessageParams {
-                typ: to_lsp_message_type(&msg.message_type),
+                kind: to_lsp_message_type(&msg.message_type),
                 message: msg.message,
             },
         );
@@ -369,10 +372,10 @@ impl MessageHandler for MessageFilter {
 
 fn to_lsp_message_type(message_type: &vhdl_lang::MessageType) -> MessageType {
     match message_type {
-        vhdl_lang::MessageType::Error => MessageType::ERROR,
-        vhdl_lang::MessageType::Warning => MessageType::WARNING,
-        vhdl_lang::MessageType::Info => MessageType::INFO,
-        vhdl_lang::MessageType::Log => MessageType::LOG,
+        vhdl_lang::MessageType::Error => MessageType::Error,
+        vhdl_lang::MessageType::Warning => MessageType::Warning,
+        vhdl_lang::MessageType::Info => MessageType::Info,
+        vhdl_lang::MessageType::Log => MessageType::Log,
     }
 }
 
@@ -412,33 +415,33 @@ fn from_lsp_range(range: lsp_types::Range) -> vhdl_lang::Range {
     }
 }
 
-fn file_name_to_uri(file_name: &Path) -> Url {
+fn file_name_to_uri(file_name: &Path) -> Uri {
     // @TODO return error to client
-    Url::from_file_path(file_name).unwrap()
+    Uri::from_file_path(file_name).unwrap()
 }
 
-fn uri_to_file_name(uri: &Url) -> PathBuf {
+fn uri_to_file_name(uri: &Uri) -> PathBuf {
     // @TODO return error to client
     uri.to_file_path().unwrap()
 }
 
 fn overloaded_kind(overloaded: &Overloaded) -> SymbolKind {
     match overloaded {
-        Overloaded::SubprogramDecl(_) => SymbolKind::FUNCTION,
-        Overloaded::Subprogram(_) => SymbolKind::FUNCTION,
-        Overloaded::UninstSubprogramDecl(..) => SymbolKind::FUNCTION,
-        Overloaded::UninstSubprogram(..) => SymbolKind::FUNCTION,
-        Overloaded::InterfaceSubprogram(_) => SymbolKind::FUNCTION,
-        Overloaded::EnumLiteral(_) => SymbolKind::ENUM_MEMBER,
+        Overloaded::SubprogramDecl(_) => SymbolKind::Function,
+        Overloaded::Subprogram(_) => SymbolKind::Function,
+        Overloaded::UninstSubprogramDecl(..) => SymbolKind::Function,
+        Overloaded::UninstSubprogram(..) => SymbolKind::Function,
+        Overloaded::InterfaceSubprogram(_) => SymbolKind::Function,
+        Overloaded::EnumLiteral(_) => SymbolKind::EnumMember,
         Overloaded::Alias(o) => overloaded_kind(o.kind()),
     }
 }
 
 fn object_kind(object: &Object) -> SymbolKind {
     if matches!(object.subtype.type_mark().kind(), Type::Protected(..)) {
-        SymbolKind::OBJECT
+        SymbolKind::Object
     } else if object.iface.is_some() {
-        SymbolKind::INTERFACE
+        SymbolKind::Interface
     } else {
         object_class_kind(object.class)
     }
@@ -446,29 +449,29 @@ fn object_kind(object: &Object) -> SymbolKind {
 
 fn object_class_kind(class: ObjectClass) -> SymbolKind {
     match class {
-        ObjectClass::Signal => SymbolKind::EVENT,
-        ObjectClass::Constant => SymbolKind::CONSTANT,
-        ObjectClass::Variable => SymbolKind::VARIABLE,
-        ObjectClass::SharedVariable => SymbolKind::VARIABLE,
+        ObjectClass::Signal => SymbolKind::Event,
+        ObjectClass::Constant => SymbolKind::Constant,
+        ObjectClass::Variable => SymbolKind::Variable,
+        ObjectClass::SharedVariable => SymbolKind::Variable,
     }
 }
 
 fn type_kind(t: &Type) -> SymbolKind {
     match t {
-        vhdl_lang::Type::Array { .. } => SymbolKind::ARRAY,
-        vhdl_lang::Type::Enum(_) => SymbolKind::ENUM,
-        vhdl_lang::Type::Integer => SymbolKind::NUMBER,
-        vhdl_lang::Type::Real => SymbolKind::NUMBER,
-        vhdl_lang::Type::Physical => SymbolKind::NUMBER,
-        vhdl_lang::Type::Access(_) => SymbolKind::ENUM,
-        vhdl_lang::Type::Record(_) => SymbolKind::STRUCT,
-        vhdl_lang::Type::Incomplete => SymbolKind::NULL,
+        vhdl_lang::Type::Array { .. } => SymbolKind::Array,
+        vhdl_lang::Type::Enum(_) => SymbolKind::Enum,
+        vhdl_lang::Type::Integer => SymbolKind::Number,
+        vhdl_lang::Type::Real => SymbolKind::Number,
+        vhdl_lang::Type::Physical => SymbolKind::Number,
+        vhdl_lang::Type::Access(_) => SymbolKind::Enum,
+        vhdl_lang::Type::Record(_) => SymbolKind::Struct,
+        vhdl_lang::Type::Incomplete => SymbolKind::Null,
         vhdl_lang::Type::Subtype(t) => type_kind(t.type_mark().kind()),
-        vhdl_lang::Type::Protected(_, _) => SymbolKind::CLASS,
-        vhdl_lang::Type::File => SymbolKind::FILE,
-        vhdl_lang::Type::Interface => SymbolKind::TYPE_PARAMETER,
+        vhdl_lang::Type::Protected(_, _) => SymbolKind::Class,
+        vhdl_lang::Type::File => SymbolKind::File,
+        vhdl_lang::Type::Interface => SymbolKind::TypeParameter,
         vhdl_lang::Type::Alias(t) => type_kind(t.kind()),
-        vhdl_lang::Type::Universal(_) => SymbolKind::NUMBER,
+        vhdl_lang::Type::Universal(_) => SymbolKind::Number,
     }
 }
 
@@ -477,31 +480,31 @@ fn to_symbol_kind(kind: &AnyEntKind) -> SymbolKind {
         AnyEntKind::ExternalAlias { class, .. } => object_class_kind(ObjectClass::from(*class)),
         AnyEntKind::ObjectAlias { base_object, .. } => object_kind(base_object.object()),
         AnyEntKind::Object(o) => object_kind(o),
-        AnyEntKind::LoopParameter(_) => SymbolKind::CONSTANT,
-        AnyEntKind::PhysicalLiteral(_) => SymbolKind::CONSTANT,
-        AnyEntKind::DeferredConstant(_) => SymbolKind::CONSTANT,
-        AnyEntKind::File { .. } => SymbolKind::FILE,
-        AnyEntKind::InterfaceFile { .. } => SymbolKind::INTERFACE,
-        AnyEntKind::Component(_) => SymbolKind::CLASS,
-        AnyEntKind::Attribute(_) => SymbolKind::PROPERTY,
+        AnyEntKind::LoopParameter(_) => SymbolKind::Constant,
+        AnyEntKind::PhysicalLiteral(_) => SymbolKind::Constant,
+        AnyEntKind::DeferredConstant(_) => SymbolKind::Constant,
+        AnyEntKind::File { .. } => SymbolKind::File,
+        AnyEntKind::InterfaceFile { .. } => SymbolKind::Interface,
+        AnyEntKind::Component(_) => SymbolKind::Class,
+        AnyEntKind::Attribute(_) => SymbolKind::Property,
         AnyEntKind::Overloaded(o) => overloaded_kind(o),
         AnyEntKind::Type(t) => type_kind(t),
-        AnyEntKind::ElementDeclaration(_) => SymbolKind::FIELD,
-        AnyEntKind::Sequential(_) => SymbolKind::NAMESPACE,
-        AnyEntKind::Concurrent(Some(Concurrent::Instance), _) => SymbolKind::MODULE,
-        AnyEntKind::Concurrent(..) => SymbolKind::NAMESPACE,
-        AnyEntKind::Library => SymbolKind::NAMESPACE,
-        AnyEntKind::View(_) => SymbolKind::INTERFACE,
+        AnyEntKind::ElementDeclaration(_) => SymbolKind::Field,
+        AnyEntKind::Sequential(_) => SymbolKind::Namespace,
+        AnyEntKind::Concurrent(Some(Concurrent::Instance), _) => SymbolKind::Module,
+        AnyEntKind::Concurrent(..) => SymbolKind::Namespace,
+        AnyEntKind::Library => SymbolKind::Namespace,
+        AnyEntKind::View(_) => SymbolKind::Interface,
         AnyEntKind::Design(d) => match d {
-            vhdl_lang::Design::Entity(_, _) => SymbolKind::MODULE,
-            vhdl_lang::Design::Architecture(..) => SymbolKind::MODULE,
-            vhdl_lang::Design::Configuration => SymbolKind::MODULE,
-            vhdl_lang::Design::Package(_, _) => SymbolKind::PACKAGE,
-            vhdl_lang::Design::PackageBody(..) => SymbolKind::PACKAGE,
-            vhdl_lang::Design::UninstPackage(_, _) => SymbolKind::PACKAGE,
-            vhdl_lang::Design::PackageInstance(_) => SymbolKind::PACKAGE,
-            vhdl_lang::Design::InterfacePackageInstance(..) => SymbolKind::PACKAGE,
-            vhdl_lang::Design::Context(_) => SymbolKind::NAMESPACE,
+            vhdl_lang::Design::Entity(_, _) => SymbolKind::Module,
+            vhdl_lang::Design::Architecture(..) => SymbolKind::Module,
+            vhdl_lang::Design::Configuration => SymbolKind::Module,
+            vhdl_lang::Design::Package(_, _) => SymbolKind::Package,
+            vhdl_lang::Design::PackageBody(..) => SymbolKind::Package,
+            vhdl_lang::Design::UninstPackage(_, _) => SymbolKind::Package,
+            vhdl_lang::Design::PackageInstance(_) => SymbolKind::Package,
+            vhdl_lang::Design::InterfacePackageInstance(..) => SymbolKind::Package,
+            vhdl_lang::Design::Context(_) => SymbolKind::Namespace,
         },
     }
 }
@@ -516,7 +519,7 @@ mod tests {
         vhdl_server::semantic_tokens::{ENUM_MEMBER, FUNCTION, MOD_READONLY, PARAMETER, VARIABLE},
     };
 
-    pub(crate) fn initialize_server(server: &mut VHDLServer, root_uri: Url) {
+    pub(crate) fn initialize_server(server: &mut VHDLServer, root_uri: Uri) {
         let capabilities = ClientCapabilities::default();
 
         #[allow(deprecated)]
@@ -527,7 +530,9 @@ mod tests {
             initialization_options: None,
             capabilities,
             trace: None,
-            workspace_folders: None,
+            workspace_folders_initialize_params: WorkspaceFoldersInitializeParams {
+                workspace_folders: None,
+            },
             client_info: None,
             locale: None,
             work_done_progress_params: WorkDoneProgressParams::default(),
@@ -537,13 +542,13 @@ mod tests {
         server.initialized_notification();
     }
 
-    pub(crate) fn temp_root_uri() -> (tempfile::TempDir, Url) {
+    pub(crate) fn temp_root_uri() -> (tempfile::TempDir, Uri) {
         let tempdir = tempfile::tempdir().unwrap();
-        let root_uri = Url::from_file_path(tempdir.path().canonicalize().unwrap()).unwrap();
+        let root_uri = Uri::from_file_path(tempdir.path().canonicalize().unwrap()).unwrap();
         (tempdir, root_uri)
     }
 
-    pub(crate) fn expect_loaded_config_messages(mock: &RpcMock, config_uri: &Url) {
+    pub(crate) fn expect_loaded_config_messages(mock: &RpcMock, config_uri: &Uri) {
         let file_name = config_uri
             .to_file_path()
             .unwrap()
@@ -598,7 +603,7 @@ end entity ent;
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: file_url,
-                language_id: "vhdl".to_owned(),
+                language_id: LanguageKind::new("vhdl"),
                 version: 0,
                 text: code,
             },
@@ -627,7 +632,7 @@ end entity ent2;
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: file_url.clone(),
-                language_id: "vhdl".to_owned(),
+                language_id: LanguageKind::new("vhdl"),
                 version: 0,
                 text: code,
             },
@@ -646,8 +651,8 @@ end entity ent2;
                         character: "end entity ent2".len() as u32,
                     },
                 },
-                code: Some(NumberOrString::String("syntax_error".to_owned())),
-                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(Code::String("syntax_error".to_owned())),
+                severity: Some(DiagnosticSeverity::Error),
                 source: Some("vhdl ls".to_owned()),
                 message: "End identifier mismatch, expected ent".to_owned(),
                 ..Default::default()
@@ -668,14 +673,10 @@ end entity ent;
 
         let did_change = DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {
-                uri: file_url.clone(),
+                text_document_identifier: TextDocumentIdentifier::new(file_url.clone()),
                 version: 1,
             },
-            content_changes: vec![TextDocumentContentChangeEvent {
-                range: None,
-                range_length: None,
-                text: code,
-            }],
+            content_changes: vec![TextDocumentContentChangeWholeDocument { text: code }.into()],
         };
 
         let publish_diagnostics = PublishDiagnosticsParams {
@@ -689,16 +690,16 @@ end entity ent;
     }
 
     pub(crate) fn write_file(
-        root_uri: &Url,
+        root_uri: &Uri,
         file_name: impl AsRef<str>,
         contents: impl AsRef<str>,
-    ) -> Url {
+    ) -> Uri {
         let path = root_uri.to_file_path().unwrap().join(file_name.as_ref());
         std::fs::write(&path, contents.as_ref()).unwrap();
-        Url::from_file_path(path).unwrap()
+        Uri::from_file_path(path).unwrap()
     }
 
-    pub(crate) fn write_config(root_uri: &Url, contents: impl AsRef<str>) -> Url {
+    pub(crate) fn write_config(root_uri: &Uri, contents: impl AsRef<str>) -> Uri {
         write_file(root_uri, "vhdl_ls.toml", contents)
     }
 
@@ -742,8 +743,8 @@ lib.files = [
                         character: "architecture rtl of ent2".len() as u32,
                     },
                 },
-                code: Some(NumberOrString::String("unresolved".to_owned())),
-                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(Code::String("unresolved".to_owned())),
+                severity: Some(DiagnosticSeverity::Error),
                 source: Some("vhdl ls".to_owned()),
                 message: "No primary unit \'ent2\' within library \'lib\'".to_owned(),
                 ..Default::default()
@@ -839,7 +840,7 @@ lib.files = [
         let did_open = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: file_url2.clone(),
-                language_id: "vhdl".to_owned(),
+                language_id: LanguageKind::new("vhdl"),
                 version: 0,
                 text: code2,
             },
@@ -886,7 +887,7 @@ lib.files = [
 
         let register_options = DidChangeWatchedFilesRegistrationOptions {
             watchers: vec![FileSystemWatcher {
-                glob_pattern: GlobPattern::String("**/vhdl_ls.toml".to_owned()),
+                glob_pattern: GlobPattern::Pattern("**/vhdl_ls.toml".to_owned()),
                 kind: None,
             }],
         };
@@ -967,8 +968,8 @@ lib.files = [
                         character: "architecture rtl of ent".len() as u32,
                     },
                 },
-                code: Some(NumberOrString::String("unresolved".to_owned())),
-                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(Code::String("unresolved".to_owned())),
+                severity: Some(DiagnosticSeverity::Error),
                 source: Some("vhdl ls".to_owned()),
                 message: "No primary unit \'ent\' within library \'lib\'".to_owned(),
                 ..Default::default()
@@ -1007,7 +1008,7 @@ lib.files = [
         );
         server.workspace_did_change_watched_files(&DidChangeWatchedFilesParams {
             changes: vec![FileEvent {
-                typ: FileChangeType::CHANGED,
+                kind: FileChangeType::Changed,
                 uri: config_uri,
             }],
         });
@@ -1057,7 +1058,7 @@ lib.files = [
             .map(|t| (t.token_type, t.modifiers))
     }
 
-    fn get_semantic_tokens(server: &mut VHDLServer, uri: &Url) -> Vec<DecodedToken> {
+    fn get_semantic_tokens(server: &mut VHDLServer, uri: &Uri) -> Vec<DecodedToken> {
         let result = server
             .semantic_tokens_full(&SemanticTokensParams {
                 text_document: TextDocumentIdentifier { uri: uri.clone() },
@@ -1065,10 +1066,7 @@ lib.files = [
                 partial_result_params: Default::default(),
             })
             .expect("semantic tokens result");
-        match result {
-            SemanticTokensResult::Tokens(t) => decode_semantic_tokens(&t.data),
-            _ => panic!("expected full tokens"),
-        }
+        decode_semantic_tokens(&result.data)
     }
 
     #[test]

--- a/vhdl_ls/src/vhdl_server/completion.rs
+++ b/vhdl_ls/src/vhdl_server/completion.rs
@@ -21,13 +21,13 @@ impl VHDLServer {
             vhdl_lang::CompletionItem::Work => CompletionItem {
                 label: self.insert_text("work"),
                 detail: Some("work library".to_string()),
-                kind: Some(CompletionItemKind::MODULE),
+                kind: Some(CompletionItemKind::Module),
                 ..Default::default()
             },
             vhdl_lang::CompletionItem::Formal(ent) => {
                 let mut item = self.entity_to_completion_item(ent);
                 if self.client_supports_snippets() {
-                    item.insert_text_format = Some(InsertTextFormat::SNIPPET);
+                    item.insert_text_format = Some(InsertTextFormat::Snippet);
                     item.insert_text = Some(format!(
                         "{} => $1,",
                         item.insert_text.as_ref().unwrap_or(&item.label)
@@ -37,8 +37,8 @@ impl VHDLServer {
             }
             vhdl_lang::CompletionItem::Overloaded(desi, count) => {
                 let kind = match desi {
-                    Designator::Identifier(_) => Some(CompletionItemKind::FUNCTION),
-                    Designator::OperatorSymbol(_) => Some(CompletionItemKind::OPERATOR),
+                    Designator::Identifier(_) => Some(CompletionItemKind::Function),
+                    Designator::OperatorSymbol(_) => Some(CompletionItemKind::Operator),
                     _ => None,
                 };
                 CompletionItem {
@@ -51,7 +51,7 @@ impl VHDLServer {
             vhdl_lang::CompletionItem::Keyword(kind) => CompletionItem {
                 label: self.insert_text(kind_str(kind)),
                 detail: Some(kind_str(kind).to_string()),
-                kind: Some(CompletionItemKind::KEYWORD),
+                kind: Some(CompletionItemKind::Keyword),
                 ..Default::default()
             },
             vhdl_lang::CompletionItem::Instantiation(ent, architectures) => {
@@ -119,14 +119,14 @@ impl VHDLServer {
                 CompletionItem {
                     label: format!("{designator} instantiation"),
                     insert_text: Some(template),
-                    insert_text_format: Some(InsertTextFormat::SNIPPET),
-                    kind: Some(CompletionItemKind::MODULE),
+                    insert_text_format: Some(InsertTextFormat::Snippet),
+                    kind: Some(CompletionItemKind::Module),
                     ..Default::default()
                 }
             }
             vhdl_lang::CompletionItem::Attribute(attribute) => CompletionItem {
                 label: self.insert_text(attribute),
-                kind: Some(CompletionItemKind::REFERENCE),
+                kind: Some(CompletionItemKind::Reference),
                 ..Default::default()
             },
         }
@@ -135,7 +135,7 @@ impl VHDLServer {
     /// Called when the client requests a completion.
     /// This function looks in the source code to find suitable options and then returns them
     pub fn request_completion(&mut self, params: &CompletionParams) -> CompletionList {
-        let binding = uri_to_file_name(&params.text_document_position.text_document.uri);
+        let binding = uri_to_file_name(&params.text_document_position_params.text_document.uri);
         let file = binding.as_path();
         // 1) get source position, and source file
         let Some(source) = self.project.get_source(file) else {
@@ -144,7 +144,7 @@ impl VHDLServer {
                 ..Default::default()
             };
         };
-        let cursor = from_lsp_pos(params.text_document_position.position);
+        let cursor = from_lsp_pos(params.text_document_position_params.position);
         // 2) Optimization chance: go to last recognizable token before the cursor. For example:
         //    - Any primary unit (e.g. entity declaration, package declaration, ...)
         //      => keyword `entity`, `package`, ...
@@ -162,6 +162,8 @@ impl VHDLServer {
         CompletionList {
             items: options,
             is_incomplete: true,
+            apply_kind: None,
+            item_defaults: None,
         }
     }
 
@@ -197,34 +199,34 @@ impl VHDLServer {
 fn entity_kind_to_completion_kind(kind: &AnyEntKind) -> CompletionItemKind {
     match kind {
         AnyEntKind::ExternalAlias { .. } | AnyEntKind::ObjectAlias { .. } => {
-            CompletionItemKind::FIELD
+            CompletionItemKind::Field
         }
-        AnyEntKind::File(_) | AnyEntKind::InterfaceFile(_) => CompletionItemKind::FILE,
-        AnyEntKind::Component(_) => CompletionItemKind::MODULE,
-        AnyEntKind::Attribute(_) => CompletionItemKind::REFERENCE,
+        AnyEntKind::File(_) | AnyEntKind::InterfaceFile(_) => CompletionItemKind::File,
+        AnyEntKind::Component(_) => CompletionItemKind::Module,
+        AnyEntKind::Attribute(_) => CompletionItemKind::Reference,
         AnyEntKind::Overloaded(overloaded) => match overloaded {
             Overloaded::SubprogramDecl(_)
             | Overloaded::Subprogram(_)
             | Overloaded::UninstSubprogramDecl(..)
             | Overloaded::UninstSubprogram(..)
-            | Overloaded::InterfaceSubprogram(_) => CompletionItemKind::FUNCTION,
-            Overloaded::EnumLiteral(_) => CompletionItemKind::ENUM_MEMBER,
-            Overloaded::Alias(_) => CompletionItemKind::FIELD,
+            | Overloaded::InterfaceSubprogram(_) => CompletionItemKind::Function,
+            Overloaded::EnumLiteral(_) => CompletionItemKind::EnumMember,
+            Overloaded::Alias(_) => CompletionItemKind::Field,
         },
-        AnyEntKind::Type(_) => CompletionItemKind::TYPE_PARAMETER,
-        AnyEntKind::ElementDeclaration(_) => CompletionItemKind::FIELD,
-        AnyEntKind::Concurrent(..) => CompletionItemKind::MODULE,
-        AnyEntKind::Sequential(_) => CompletionItemKind::MODULE,
+        AnyEntKind::Type(_) => CompletionItemKind::TypeParameter,
+        AnyEntKind::ElementDeclaration(_) => CompletionItemKind::Field,
+        AnyEntKind::Concurrent(..) => CompletionItemKind::Module,
+        AnyEntKind::Sequential(_) => CompletionItemKind::Module,
         AnyEntKind::Object(object) => match object.class {
-            ObjectClass::Signal => CompletionItemKind::EVENT,
-            ObjectClass::Constant => CompletionItemKind::CONSTANT,
-            ObjectClass::Variable | ObjectClass::SharedVariable => CompletionItemKind::VARIABLE,
+            ObjectClass::Signal => CompletionItemKind::Event,
+            ObjectClass::Constant => CompletionItemKind::Constant,
+            ObjectClass::Variable | ObjectClass::SharedVariable => CompletionItemKind::Variable,
         },
-        AnyEntKind::LoopParameter(_) => CompletionItemKind::MODULE,
-        AnyEntKind::PhysicalLiteral(_) => CompletionItemKind::UNIT,
-        AnyEntKind::DeferredConstant(_) => CompletionItemKind::CONSTANT,
-        AnyEntKind::Library => CompletionItemKind::MODULE,
-        AnyEntKind::Design(_) => CompletionItemKind::MODULE,
-        AnyEntKind::View(_) => CompletionItemKind::INTERFACE,
+        AnyEntKind::LoopParameter(_) => CompletionItemKind::Module,
+        AnyEntKind::PhysicalLiteral(_) => CompletionItemKind::Unit,
+        AnyEntKind::DeferredConstant(_) => CompletionItemKind::Constant,
+        AnyEntKind::Library => CompletionItemKind::Module,
+        AnyEntKind::Design(_) => CompletionItemKind::Module,
+        AnyEntKind::View(_) => CompletionItemKind::Interface,
     }
 }

--- a/vhdl_ls/src/vhdl_server/diagnostics.rs
+++ b/vhdl_ls/src/vhdl_server/diagnostics.rs
@@ -1,8 +1,7 @@
 use crate::vhdl_server::{file_name_to_uri, to_lsp_range, VHDLServer};
 use fnv::FnvHashMap;
 use lsp_types::{
-    DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString,
-    PublishDiagnosticsParams, Url,
+    Code, DiagnosticRelatedInformation, DiagnosticSeverity, Location, PublishDiagnosticsParams, Uri,
 };
 use std::collections::hash_map::Entry;
 use vhdl_lang::{Diagnostic, Severity, SeverityMap};
@@ -79,8 +78,8 @@ impl VHDLServer {
     }
 }
 
-fn diagnostics_by_uri(diagnostics: Vec<Diagnostic>) -> FnvHashMap<Url, Vec<Diagnostic>> {
-    let mut map: FnvHashMap<Url, Vec<Diagnostic>> = FnvHashMap::default();
+fn diagnostics_by_uri(diagnostics: Vec<Diagnostic>) -> FnvHashMap<Uri, Vec<Diagnostic>> {
+    let mut map: FnvHashMap<Uri, Vec<Diagnostic>> = FnvHashMap::default();
 
     for diagnostic in diagnostics {
         let uri = file_name_to_uri(diagnostic.pos.source.file_name());
@@ -110,10 +109,10 @@ fn to_lsp_diagnostic(
     severity_map: &SeverityMap,
 ) -> Option<lsp_types::Diagnostic> {
     let severity = match severity_map[diagnostic.code]? {
-        Severity::Error => DiagnosticSeverity::ERROR,
-        Severity::Warning => DiagnosticSeverity::WARNING,
-        Severity::Info => DiagnosticSeverity::INFORMATION,
-        Severity::Hint => DiagnosticSeverity::HINT,
+        Severity::Error => DiagnosticSeverity::Error,
+        Severity::Warning => DiagnosticSeverity::Warning,
+        Severity::Info => DiagnosticSeverity::Information,
+        Severity::Hint => DiagnosticSeverity::Hint,
     };
 
     let related_information = if !diagnostic.related.is_empty() {
@@ -136,7 +135,7 @@ fn to_lsp_diagnostic(
     Some(lsp_types::Diagnostic {
         range: to_lsp_range(diagnostic.pos.range()),
         severity: Some(severity),
-        code: Some(NumberOrString::String(format!("{}", diagnostic.code))),
+        code: Some(Code::String(format!("{}", diagnostic.code))),
         source: Some("vhdl ls".to_owned()),
         message: diagnostic.message,
         related_information,
@@ -151,9 +150,8 @@ pub mod tests {
         write_config, write_file,
     };
     use lsp_types::{
-        DiagnosticSeverity, DidChangeTextDocumentParams, NumberOrString, Position,
-        PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
-        VersionedTextDocumentIdentifier,
+        Code, DiagnosticSeverity, DidChangeTextDocumentParams, Position, PublishDiagnosticsParams,
+        Range, TextDocumentContentChangePartial, VersionedTextDocumentIdentifier,
     };
     use regex::Regex;
 
@@ -197,8 +195,8 @@ lib.files = [
                     Position::new(0, "architecture rtl of ".len() as u32),
                     Position::new(0, "architecture rtl of ent3".len() as u32),
                 ),
-                code: Some(NumberOrString::String("unresolved".to_owned())),
-                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(Code::String("unresolved".to_owned())),
+                severity: Some(DiagnosticSeverity::Error),
                 source: Some("vhdl ls".to_owned()),
                 message: "No primary unit \'ent3\' within library \'lib\'".to_owned(),
                 ..Default::default()
@@ -223,15 +221,19 @@ lib.files = [
 
         // Change "ent2" to "ent3"
         server.text_document_did_change_notification(&DidChangeTextDocumentParams {
-            text_document: VersionedTextDocumentIdentifier::new(file2_uri, 0),
-            content_changes: vec![TextDocumentContentChangeEvent {
-                range: Some(Range::new(
+            text_document: VersionedTextDocumentIdentifier {
+                version: 0,
+                text_document_identifier: lsp_types::TextDocumentIdentifier { uri: file2_uri },
+            },
+            content_changes: vec![TextDocumentContentChangePartial {
+                range: Range::new(
                     Position::new(0, "architecture rtl of ent".len() as u32),
                     Position::new(0, "architecture rtl of ent2".len() as u32),
-                )),
-                range_length: None,
+                ),
                 text: "3".to_string(),
-            }],
+                ..Default::default()
+            }
+            .into()],
         })
     }
 }

--- a/vhdl_ls/src/vhdl_server/lifecycle.rs
+++ b/vhdl_ls/src/vhdl_server/lifecycle.rs
@@ -26,7 +26,7 @@ impl VHDLServer {
         if self.client_supports_did_change_watched_files() {
             let register_options = DidChangeWatchedFilesRegistrationOptions {
                 watchers: vec![FileSystemWatcher {
-                    glob_pattern: GlobPattern::String("**/vhdl_ls.toml".to_owned()),
+                    glob_pattern: GlobPattern::Pattern("**/vhdl_ls.toml".to_owned()),
                     kind: None,
                 }],
             };
@@ -60,36 +60,38 @@ impl VHDLServer {
         let trigger_chars: Vec<String> = r"'.".chars().map(|ch| ch.to_string()).collect();
 
         let capabilities = ServerCapabilities {
-            text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                TextDocumentSyncKind::INCREMENTAL,
-            )),
-            declaration_provider: Some(DeclarationCapability::Simple(true)),
-            definition_provider: Some(OneOf::Left(true)),
-            hover_provider: Some(HoverProviderCapability::Simple(true)),
-            references_provider: Some(OneOf::Left(true)),
-            implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
-            rename_provider: Some(OneOf::Right(RenameOptions {
-                prepare_provider: Some(true),
-                work_done_progress_options: Default::default(),
-            })),
-            workspace_symbol_provider: Some(OneOf::Left(true)),
-            document_symbol_provider: Some(OneOf::Left(true)),
-            document_highlight_provider: Some(OneOf::Left(true)),
-            semantic_tokens_provider: Some(
-                SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
-                    legend: SemanticTokensLegend {
-                        token_types: TOKEN_TYPES.to_vec(),
-                        token_modifiers: TOKEN_MODIFIERS.to_vec(),
-                    },
-                    full: Some(SemanticTokensFullOptions::Bool(true)),
-                    range: Some(true),
+            text_document_sync: Some(TextDocumentSyncKind::Incremental.into()),
+            declaration_provider: Some(true.into()),
+            definition_provider: Some(true.into()),
+            hover_provider: Some(true.into()),
+            references_provider: Some(true.into()),
+            implementation_provider: Some(true.into()),
+            rename_provider: Some(
+                RenameOptions {
+                    prepare_provider: Some(true),
                     work_done_progress_options: Default::default(),
-                }),
+                }
+                .into(),
+            ),
+            workspace_symbol_provider: Some(true.into()),
+            document_symbol_provider: Some(true.into()),
+            document_highlight_provider: Some(true.into()),
+            semantic_tokens_provider: Some(
+                SemanticTokensOptions {
+                    legend: SemanticTokensLegend {
+                        token_types: TOKEN_TYPES.iter().map(|t| t.to_string()).collect(),
+                        token_modifiers: TOKEN_MODIFIERS.iter().map(|t| t.to_string()).collect(),
+                    },
+                    full: Some(true.into()),
+                    range: Some(true.into()),
+                    work_done_progress_options: Default::default(),
+                }
+                .into(),
             ),
             completion_provider: Some(CompletionOptions {
                 resolve_provider: Some(true),
                 trigger_characters: Some(trigger_chars),
-                completion_item: Some(CompletionOptionsCompletionItem {
+                completion_item: Some(ServerCompletionItemOptions {
                     label_details_support: Some(true),
                 }),
                 ..Default::default()

--- a/vhdl_ls/src/vhdl_server/rename.rs
+++ b/vhdl_ls/src/vhdl_server/rename.rs
@@ -2,7 +2,7 @@ use crate::vhdl_server::{
     from_lsp_pos, srcpos_to_location, to_lsp_range, uri_to_file_name, VHDLServer,
 };
 use lsp_types::{
-    PrepareRenameResponse, RenameParams, TextDocumentPositionParams, TextEdit, Url, WorkspaceEdit,
+    PrepareRenameResult, RenameParams, TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
 };
 use std::collections::HashMap;
 use vhdl_lang::ast::Designator;
@@ -11,7 +11,7 @@ impl VHDLServer {
     pub fn prepare_rename(
         &mut self,
         params: &TextDocumentPositionParams,
-    ) -> Option<PrepareRenameResponse> {
+    ) -> Option<PrepareRenameResult> {
         let source = self
             .project
             .get_source(&uri_to_file_name(&params.text_document.uri))?;
@@ -21,7 +21,7 @@ impl VHDLServer {
             .item_at_cursor(&source, from_lsp_pos(params.position))?;
 
         if let Designator::Identifier(_) = ent.designator() {
-            Some(PrepareRenameResponse::Range(to_lsp_range(pos.range)))
+            Some(PrepareRenameResult::Range(to_lsp_range(pos.range)))
         } else {
             // It does not make sense to rename operator symbols and character literals
             // Also they have different representations that would not be handled consistently
@@ -32,15 +32,15 @@ impl VHDLServer {
 
     pub fn rename(&mut self, params: &RenameParams) -> Option<WorkspaceEdit> {
         let source = self.project.get_source(&uri_to_file_name(
-            &params.text_document_position.text_document.uri,
+            &params.text_document_position_params.text_document.uri,
         ))?;
 
         let ent = self.project.find_declaration(
             &source,
-            from_lsp_pos(params.text_document_position.position),
+            from_lsp_pos(params.text_document_position_params.position),
         )?;
 
-        let mut changes: HashMap<Url, Vec<TextEdit>> = Default::default();
+        let mut changes: HashMap<Uri, Vec<TextEdit>> = Default::default();
 
         for srcpos in self.project.find_all_references(ent) {
             let loc = srcpos_to_location(&srcpos);

--- a/vhdl_ls/src/vhdl_server/semantic_tokens.rs
+++ b/vhdl_ls/src/vhdl_server/semantic_tokens.rs
@@ -9,7 +9,7 @@ macro_rules! define_token_types {
     ( $( ($const:ident = $lsp_type:expr) ),+ $(,)? ) => {
         define_token_types!(@consts 0, $( $const, )+);
 
-        pub const TOKEN_TYPES: &[SemanticTokenType] = &[
+        pub const TOKEN_TYPES: &[SemanticTokenTypes] = &[
             $( $lsp_type, )+
         ];
     };
@@ -24,23 +24,23 @@ macro_rules! define_token_types {
 }
 
 define_token_types! {
-    (VARIABLE    = SemanticTokenType::VARIABLE),    // signals, variables, constants, files
-    (PARAMETER   = SemanticTokenType::PARAMETER),   // subprogram parameters
-    (PROPERTY    = SemanticTokenType::PROPERTY),     // attributes, record fields
-    (ENUM_MEMBER = SemanticTokenType::ENUM_MEMBER),  // enum literals
-    (FUNCTION    = SemanticTokenType::FUNCTION),     // functions, procedures
-    (TYPE        = SemanticTokenType::TYPE),          // types (general)
-    (CLASS       = SemanticTokenType::CLASS),         // protected types, components
-    (NAMESPACE   = SemanticTokenType::NAMESPACE),    // libraries, design units, labels
-    (STRUCT      = SemanticTokenType::STRUCT),        // record types
-    (ENUM        = SemanticTokenType::ENUM),          // enum types
+    (VARIABLE    = SemanticTokenTypes::Variable),    // signals, variables, constants, files
+    (PARAMETER   = SemanticTokenTypes::Parameter),   // subprogram parameters
+    (PROPERTY    = SemanticTokenTypes::Property),     // attributes, record fields
+    (ENUM_MEMBER = SemanticTokenTypes::EnumMember),  // enum literals
+    (FUNCTION    = SemanticTokenTypes::Function),     // functions, procedures
+    (TYPE        = SemanticTokenTypes::Type),          // types (general)
+    (CLASS       = SemanticTokenTypes::Class),         // protected types, components
+    (NAMESPACE   = SemanticTokenTypes::Namespace),    // libraries, design units, labels
+    (STRUCT      = SemanticTokenTypes::Struct),        // record types
+    (ENUM        = SemanticTokenTypes::Enum),          // enum types
 }
 
 // Semantic token modifier bits
 pub(crate) const MOD_READONLY: u32 = 1 << 0;
 
-pub const TOKEN_MODIFIERS: &[SemanticTokenModifier] = &[
-    SemanticTokenModifier::READONLY, // bit 0: constants, generics
+pub const TOKEN_MODIFIERS: &[SemanticTokenModifiers] = &[
+    SemanticTokenModifiers::Readonly, // bit 0: constants, generics
 ];
 
 /// Classification of a VHDL entity into an LSP semantic token.
@@ -229,7 +229,7 @@ fn encode(tokens: &[CachedToken], range_filter: Option<&vhdl_lang::Range>) -> Ve
 
 impl VHDLServer {
     /// Get or compute the cached semantic tokens for a file.
-    fn cached_semantic_tokens(&mut self, uri: &Url) -> Option<&[CachedToken]> {
+    fn cached_semantic_tokens(&mut self, uri: &Uri) -> Option<&[CachedToken]> {
         if !self.semantic_token_cache.contains_key(uri) {
             let source = self.project.get_source(&uri_to_file_name(uri))?;
             let raw_tokens = self.project.find_all_entity_references(&source);
@@ -242,27 +242,27 @@ impl VHDLServer {
     pub fn semantic_tokens_full(
         &mut self,
         params: &SemanticTokensParams,
-    ) -> Option<SemanticTokensResult> {
+    ) -> Option<SemanticTokens> {
         let tokens = self.cached_semantic_tokens(&params.text_document.uri)?;
         let data = encode(tokens, None);
 
-        Some(SemanticTokensResult::Tokens(SemanticTokens {
+        Some(SemanticTokens {
             result_id: None,
             data,
-        }))
+        })
     }
 
     pub fn semantic_tokens_range(
         &mut self,
         params: &SemanticTokensRangeParams,
-    ) -> Option<SemanticTokensRangeResult> {
+    ) -> Option<SemanticTokens> {
         let filter = from_lsp_range(params.range);
         let tokens = self.cached_semantic_tokens(&params.text_document.uri)?;
         let data = encode(tokens, Some(&filter));
 
-        Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+        Some(SemanticTokens {
             result_id: None,
             data,
-        }))
+        })
     }
 }

--- a/vhdl_ls/src/vhdl_server/text_document.rs
+++ b/vhdl_ls/src/vhdl_server/text_document.rs
@@ -2,11 +2,13 @@ use crate::vhdl_server::{
     from_lsp_pos, from_lsp_range, srcpos_to_location, to_lsp_range, uri_to_file_name,
     NonProjectFileHandling, VHDLServer,
 };
+#[allow(deprecated)]
 use lsp_types::{
-    DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentHighlight,
-    DocumentHighlightKind, GotoDefinitionResponse, Hover, HoverContents, LanguageString, Location,
-    MarkedString, ReferenceParams, TextDocumentItem, TextDocumentPositionParams,
+    Contents, DefinitionResponse, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
+    DocumentHighlight, DocumentHighlightKind, Hover, Location, MarkedString,
+    MarkedStringWithLanguage, ReferenceParams, TextDocumentItem, TextDocumentPositionParams,
 };
+use lsp_types::{Definition, TextDocumentContentChangeEvent};
 use vhdl_lang::{Message, Source};
 
 impl VHDLServer {
@@ -38,11 +40,22 @@ impl VHDLServer {
     }
 
     pub fn text_document_did_change_notification(&mut self, params: &DidChangeTextDocumentParams) {
-        let file_name = uri_to_file_name(&params.text_document.uri);
+        let file_name = uri_to_file_name(&params.text_document.text_document_identifier.uri);
         if let Some(source) = self.project.get_source(&file_name) {
             for content_change in params.content_changes.iter() {
-                let range = content_change.range.map(from_lsp_range);
-                source.change(range.as_ref(), &content_change.text);
+                match content_change {
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        content_change,
+                    ) => {
+                        let range = from_lsp_range(content_change.range);
+                        source.change(Some(&range), &content_change.text);
+                    }
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        content_change,
+                    ) => {
+                        source.change(None, &content_change.text);
+                    }
+                };
             }
             self.project.update_source(&source);
             self.semantic_token_cache.clear();
@@ -86,7 +99,7 @@ impl VHDLServer {
     pub fn text_document_implementation(
         &mut self,
         params: &TextDocumentPositionParams,
-    ) -> Option<GotoDefinitionResponse> {
+    ) -> Option<DefinitionResponse> {
         let source = self
             .project
             .get_source(&uri_to_file_name(&params.text_document.uri))?;
@@ -95,11 +108,11 @@ impl VHDLServer {
             .project
             .find_implementation(&source, from_lsp_pos(params.position));
 
-        Some(GotoDefinitionResponse::Array(
+        Some(DefinitionResponse::Definition(Definition::LocationList(
             ents.into_iter()
                 .filter_map(|ent| ent.decl_pos().map(srcpos_to_location))
                 .collect(),
-        ))
+        )))
     }
 
     pub fn text_document_hover(&mut self, params: &TextDocumentPositionParams) -> Option<Hover> {
@@ -113,10 +126,13 @@ impl VHDLServer {
         let value = self.project.format_declaration(ent)?;
 
         Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
-                language: "vhdl".to_string(),
-                value,
-            })),
+            contents: Contents::MarkedString(MarkedString::MarkedStringWithLanguage(
+                #[allow(deprecated)]
+                MarkedStringWithLanguage {
+                    language: "vhdl".to_string(),
+                    value,
+                },
+            )),
             range: None,
         })
     }
@@ -125,12 +141,12 @@ impl VHDLServer {
         let ent = self
             .project
             .get_source(&uri_to_file_name(
-                &params.text_document_position.text_document.uri,
+                &params.text_document_position_params.text_document.uri,
             ))
             .and_then(|source| {
                 self.project.find_declaration(
                     &source,
-                    from_lsp_pos(params.text_document_position.position),
+                    from_lsp_pos(params.text_document_position_params.position),
                 )
             });
 
@@ -163,7 +179,7 @@ impl VHDLServer {
                 .iter()
                 .map(|pos| DocumentHighlight {
                     range: to_lsp_range(pos.range()),
-                    kind: Some(DocumentHighlightKind::TEXT),
+                    kind: Some(DocumentHighlightKind::Text),
                 })
                 .collect(),
         )

--- a/vhdl_ls/src/vhdl_server/workspace.rs
+++ b/vhdl_ls/src/vhdl_server/workspace.rs
@@ -1,7 +1,7 @@
 use crate::vhdl_server::{srcpos_to_location, to_symbol_kind, uri_to_file_name, VHDLServer};
 use fuzzy_matcher::FuzzyMatcher;
 use lsp_types::{
-    DidChangeWatchedFilesParams, OneOf, WorkspaceSymbol, WorkspaceSymbolParams,
+    BaseSymbolInformation, DidChangeWatchedFilesParams, WorkspaceSymbol, WorkspaceSymbolParams,
     WorkspaceSymbolResponse,
 };
 use std::cmp::Ordering;
@@ -48,7 +48,7 @@ impl VHDLServer {
                 Designator::Anonymous(_) => None,
             });
 
-        Some(WorkspaceSymbolResponse::Nested(
+        Some(WorkspaceSymbolResponse::WorkspaceSymbolList(
             self.filter_workspace_symbols(symbols.into_iter(), &query, trunc_limit),
         ))
     }
@@ -89,11 +89,13 @@ impl VHDLServer {
                 self.string_matcher.fuzzy_match(&name, query).map(|score| {
                     WorkspaceSymbolWithScore {
                         symbol: WorkspaceSymbol {
-                            name: ent.describe(),
-                            kind: to_symbol_kind(ent.kind()),
-                            tags: None,
-                            container_name: ent.parent.map(|ent| ent.path_name()),
-                            location: OneOf::Left(srcpos_to_location(decl_pos)),
+                            base_symbol_information: BaseSymbolInformation {
+                                name: ent.describe(),
+                                kind: to_symbol_kind(ent.kind()),
+                                tags: None,
+                                container_name: ent.parent.map(|ent| ent.path_name()),
+                            },
+                            location: srcpos_to_location(decl_pos).into(),
                             data: None,
                         },
                         score,


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93