### PR TITLE
Add design instantiation hierarchy queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,8 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "rayon",
+ "serde",
+ "serde_json",
  "strum",
  "subst",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ the [Contributors Guide](https://github.com/kraigher/rust_hdl/wiki/Contributor-G
 - Rename symbol
 - Find workspace symbols
 - View/find document symbols
+- View design instantiation hierarchy via the custom requests
+  `vhdl/designHierarchy` and `vhdl/designHierarchyCandidates` (see below)
 
 ## When Installing it from Crate
 
@@ -196,6 +198,65 @@ begin
     -- vhdl_ls on
 end architecture;
 ```
+
+## Design hierarchy (custom LSP requests)
+
+Beyond the standard LSP surface, `vhdl_ls` exposes two custom JSON-RPC
+requests that let an editor render a project's instantiation hierarchy.
+
+### `vhdl/designHierarchyCandidates`
+
+Returns every entity in the project ranked as a top-level candidate. Roots
+(entities with no incoming instantiations) come first, deepest subtree
+first; the rest follow in the same order. Useful for populating a
+"choose top entity" picker.
+
+* Params: none (`{}`).
+* Result:
+  ```json
+  {
+    "candidates": [
+      {
+        "library": "ie",
+        "entity": "gev",
+        "depth": 4,
+        "instanceCount": 0,
+        "isRoot": true,
+        "entityLocation": { "uri": "file:///...", "range": { ... } }
+      }
+    ]
+  }
+  ```
+
+### `vhdl/designHierarchy`
+
+Walks the instantiation tree starting at the given top entity. Component
+instantiations are followed through default binding to the bound entity;
+configuration instantiations appear as leaves; cycles are detected and
+truncated with a note.
+
+* Params: `{ "library": "ie", "entity": "gev" }`.
+* Result: a tree node
+  ```json
+  {
+    "label": null,
+    "entity": "ie.gev",
+    "architecture": "rtl",
+    "kind": "top",
+    "instanceLocation": null,
+    "entityLocation": { "uri": "file:///...", "range": { ... } },
+    "notes": [],
+    "children": [ /* recursive */ ]
+  }
+  ```
+  `kind` is one of `top`, `entity`, `boundComponent`, `unboundComponent`,
+  `configuration`, `unresolved`.
+* Errors: `InvalidRequest` if the library or entity does not exist; the
+  message lists known names.
+
+The same walker is reachable from the `vhdl_lang` CLI via
+`vhdl_lang --config vhdl_ls.toml --hierarchy [LIB.]ENTITY`
+(use `--hierarchy-format json` for machine-readable output).
 
 ## As an LSP-client developer how should I integrate VHDL-LS?
 

--- a/vhdl_lang/Cargo.toml
+++ b/vhdl_lang/Cargo.toml
@@ -29,6 +29,8 @@ itertools.workspace = true
 subst.workspace = true
 strum.workspace = true
 enum-map.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/vhdl_lang/src/analysis/tests/design_hierarchy.rs
+++ b/vhdl_lang/src/analysis/tests/design_hierarchy.rs
@@ -1,0 +1,305 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use super::*;
+use crate::hierarchy::{
+    compute_design_hierarchy, list_top_candidates, DesignHierarchyNode, HierarchyError,
+    HierarchyKind,
+};
+use pretty_assertions::assert_eq;
+
+fn build(libname: &str, code: &str) -> DesignRoot {
+    let mut builder = LibraryBuilder::new();
+    builder.code(libname, code);
+    let (root, diagnostics) = builder.get_analyzed_root();
+    check_no_diagnostics(&diagnostics);
+    root
+}
+
+fn child_summary(node: &DesignHierarchyNode) -> Vec<(String, String)> {
+    node.children
+        .iter()
+        .map(|c| (c.label.clone().unwrap_or_default(), c.entity_path.clone()))
+        .collect()
+}
+
+#[test]
+fn three_level_entity_instantiation() {
+    let root = build(
+        "lib",
+        "
+entity leaf is end entity;
+architecture rtl of leaf is begin end architecture;
+
+entity middle is end entity;
+architecture rtl of middle is
+begin
+    leaf_inst : entity work.leaf;
+end architecture;
+
+entity top is end entity;
+architecture rtl of top is
+begin
+    middle_inst : entity work.middle;
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "top").expect("hierarchy");
+    assert_eq!(tree.entity_path, "lib.top");
+    assert_eq!(tree.architecture.as_deref(), Some("rtl"));
+    assert_eq!(tree.kind, HierarchyKind::Top);
+
+    assert_eq!(child_summary(&tree), vec![("middle_inst".into(), "lib.middle".into())]);
+    let middle = &tree.children[0];
+    assert_eq!(middle.kind, HierarchyKind::DirectEntity);
+    assert_eq!(child_summary(middle), vec![("leaf_inst".into(), "lib.leaf".into())]);
+
+    let leaf = &middle.children[0];
+    assert!(leaf.children.is_empty());
+}
+
+#[test]
+fn component_default_binding() {
+    // The parser only recognises `inst : name` as a component instantiation
+    // when followed by `port map` or `generic map`, so the component must
+    // declare at least one port to be instantiable in this form.
+    let root = build(
+        "lib",
+        "
+entity leaf is
+    port (i : bit);
+end entity;
+architecture rtl of leaf is begin end architecture;
+
+entity top is end entity;
+architecture rtl of top is
+    component leaf is
+        port (i : bit);
+    end component;
+    signal s : bit;
+begin
+    leaf_inst : leaf port map (i => s);
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "top").expect("hierarchy");
+    let child = &tree.children[0];
+    assert_eq!(child.kind, HierarchyKind::BoundComponent);
+    assert_eq!(child.entity_path, "lib.leaf");
+    assert!(child.notes.is_empty(), "bound component should have no warnings");
+}
+
+#[test]
+fn component_unbound_when_no_matching_entity() {
+    let root = build(
+        "lib",
+        "
+entity top is end entity;
+architecture rtl of top is
+    component nowhere is
+        port (i : bit);
+    end component;
+    signal s : bit;
+begin
+    inst : nowhere port map (i => s);
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "top").expect("hierarchy");
+    let child = &tree.children[0];
+    assert_eq!(child.kind, HierarchyKind::UnboundComponent);
+    assert_eq!(child.entity_path, "lib.nowhere");
+    assert!(
+        child.notes.iter().any(|n| n.contains("no matching entity")),
+        "expected unbound-component note, got {:?}",
+        child.notes
+    );
+}
+
+#[test]
+fn multiple_architectures_prefers_rtl() {
+    let root = build(
+        "lib",
+        "
+entity leaf is end entity;
+architecture sim of leaf is begin end architecture;
+architecture rtl of leaf is begin end architecture;
+
+entity top is end entity;
+architecture rtl of top is
+begin
+    leaf_inst : entity work.leaf;
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "top").expect("hierarchy");
+    let leaf = &tree.children[0];
+    assert_eq!(leaf.architecture.as_deref(), Some("rtl"));
+    assert!(
+        leaf.notes
+            .iter()
+            .any(|n| n.contains("multiple architectures") && n.contains("rtl")),
+        "expected multi-arch note, got {:?}",
+        leaf.notes
+    );
+}
+
+#[test]
+fn multiple_architectures_falls_back_to_alphabetical() {
+    let root = build(
+        "lib",
+        "
+entity leaf is end entity;
+architecture zeta of leaf is begin end architecture;
+architecture alpha of leaf is begin end architecture;
+
+entity top is end entity;
+architecture rtl of top is
+begin
+    leaf_inst : entity work.leaf;
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "top").expect("hierarchy");
+    let leaf = &tree.children[0];
+    assert_eq!(leaf.architecture.as_deref(), Some("alpha"));
+}
+
+#[test]
+fn cycle_detection_does_not_loop() {
+    // 'a' instantiates 'b' as a direct entity; 'b' (illegal for synthesis
+    // but accepted by parsing) instantiates 'a'. Confirm the walker does
+    // not stack-overflow and tags the recursion.
+    let root = build(
+        "lib",
+        "
+entity a is end entity;
+entity b is end entity;
+
+architecture rtl of a is
+begin
+    b_inst : entity work.b;
+end architecture;
+
+architecture rtl of b is
+begin
+    a_inst : entity work.a;
+end architecture;
+",
+    );
+
+    let tree = compute_design_hierarchy(&root, "lib", "a").expect("hierarchy");
+    let b = &tree.children[0];
+    assert_eq!(b.entity_path, "lib.b");
+    let a_again = &b.children[0];
+    assert_eq!(a_again.entity_path, "lib.a");
+    assert!(a_again.children.is_empty(), "cycle stops further recursion");
+    assert!(
+        a_again.notes.iter().any(|n| n.contains("cyclic")),
+        "expected cycle note, got {:?}",
+        a_again.notes
+    );
+}
+
+#[test]
+fn unknown_library_lists_known_libraries() {
+    let root = build("lib", "entity foo is end entity;");
+    let err = compute_design_hierarchy(&root, "missing", "foo").unwrap_err();
+    match err {
+        HierarchyError::UnknownLibrary { library, known } => {
+            assert_eq!(library, "missing");
+            assert!(known.contains(&"lib".to_string()));
+        }
+        other => panic!("expected UnknownLibrary, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_entity_lists_entities_in_library() {
+    let root = build(
+        "lib",
+        "
+entity foo is end entity;
+entity bar is end entity;
+",
+    );
+    let err = compute_design_hierarchy(&root, "lib", "missing").unwrap_err();
+    match err {
+        HierarchyError::UnknownEntity {
+            library,
+            entity,
+            known,
+        } => {
+            assert_eq!(library, "lib");
+            assert_eq!(entity, "missing");
+            assert!(known.contains(&"foo".to_string()));
+            assert!(known.contains(&"bar".to_string()));
+        }
+        other => panic!("expected UnknownEntity, got {other:?}"),
+    }
+}
+
+#[test]
+fn list_candidates_ranks_real_top_first() {
+    let root = build(
+        "lib",
+        "
+entity leaf is end entity;
+architecture rtl of leaf is begin end architecture;
+
+entity middle is end entity;
+architecture rtl of middle is
+begin
+    l : entity work.leaf;
+end architecture;
+
+entity top is end entity;
+architecture rtl of top is
+begin
+    m : entity work.middle;
+end architecture;
+
+entity orphan is end entity;
+architecture rtl of orphan is begin end architecture;
+",
+    );
+
+    let candidates = list_top_candidates(&root);
+    let by_name: std::collections::HashMap<String, _> = candidates
+        .iter()
+        .map(|c| (format!("{}.{}", c.library, c.entity), c))
+        .collect();
+
+    // top has depth 3, orphan has depth 1; both are roots.
+    let top = by_name["lib.top"];
+    let orphan = by_name["lib.orphan"];
+    let middle = by_name["lib.middle"];
+    let leaf = by_name["lib.leaf"];
+
+    assert!(top.is_root, "top has no incoming instantiations");
+    assert!(orphan.is_root, "orphan has no incoming instantiations");
+    assert!(!middle.is_root);
+    assert!(!leaf.is_root);
+
+    assert_eq!(top.depth, 3);
+    assert_eq!(middle.depth, 2);
+    assert_eq!(leaf.depth, 1);
+    assert_eq!(orphan.depth, 1);
+
+    assert_eq!(top.instance_count, 0);
+    assert_eq!(middle.instance_count, 1);
+    assert_eq!(leaf.instance_count, 1);
+
+    // Order: roots first (deepest first), then non-roots (deepest first).
+    let order: Vec<&str> = candidates
+        .iter()
+        .map(|c| c.entity.as_str())
+        .collect();
+    assert_eq!(order, vec!["top", "orphan", "middle", "leaf"]);
+}

--- a/vhdl_lang/src/analysis/tests/mod.rs
+++ b/vhdl_lang/src/analysis/tests/mod.rs
@@ -11,6 +11,7 @@ mod context_clause;
 mod custom_attributes;
 mod declarations;
 mod deferred_constant;
+mod design_hierarchy;
 mod discrete_ranges;
 mod external_names;
 mod hierarchy;

--- a/vhdl_lang/src/hierarchy.rs
+++ b/vhdl_lang/src/hierarchy.rs
@@ -1,0 +1,682 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Design instantiation hierarchy.
+//!
+//! Given a top entity, [`compute_design_hierarchy`] walks
+//! [`InstantiationStatement`](crate::ast::InstantiationStatement)s inside the
+//! entity's architecture(s), resolves entity / component / configuration
+//! bindings via the analyzer's named-entity model, and recurses into bound
+//! entities to produce a [`DesignHierarchyNode`] tree describing the
+//! elaborated design.
+//!
+//! [`list_top_candidates`] enumerates every entity in the design with its
+//! in-degree and subtree depth, suitable for a "pick a top" UI: roots (no
+//! incoming instantiations) sort first, deepest first.
+//!
+//! Limitations of the current implementation:
+//!
+//! * For-/if-/case-generate statements are visited once: each instance shows
+//!   up at the point it is written, not multiplied by the elaborated count.
+//! * Direct configuration instantiations (`: configuration cfg`) appear as
+//!   leaves; the bound entity is not chased through the configuration's
+//!   block-configuration tree.
+//! * When an entity has multiple architectures, the architecture named
+//!   `rtl` is preferred; otherwise the alphabetically first architecture
+//!   wins, with a note recorded on the node.
+
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
+
+use crate::analysis::{DesignRoot, Library, LockedUnit};
+use crate::ast::search::{
+    DeclarationItem, FoundDeclaration, NotFinished, Search, SearchState, Searcher,
+};
+use crate::ast::{
+    AnyDesignUnit, AnySecondaryUnit, ConcurrentStatement, Designator, InstantiatedUnit,
+    LabeledConcurrentStatement,
+};
+use crate::data::Symbol;
+use crate::named_entity::{AnyEntKind, Design, EntRef, EntityId, HasEntityId};
+use crate::syntax::{HasTokenSpan, TokenAccess};
+use crate::SrcPos;
+
+/// One node in the design hierarchy tree.
+#[derive(Debug, Clone)]
+pub struct DesignHierarchyNode {
+    /// Instance label (`None` for the top node and for instances declared
+    /// without an explicit label, which is illegal VHDL but possible in the
+    /// presence of parse errors).
+    pub label: Option<String>,
+    /// `library.entity` (or `library.component` for unbound components) of
+    /// the unit at this node.
+    pub entity_path: String,
+    /// Architecture selected for this entity, when known.
+    pub architecture: Option<String>,
+    /// How this child was reached from its parent.
+    pub kind: HierarchyKind,
+    /// Source position of the instantiation statement (`None` for the top).
+    pub instance_pos: Option<SrcPos>,
+    /// Source position of the entity (or component) declaration.
+    pub entity_pos: Option<SrcPos>,
+    pub children: Vec<DesignHierarchyNode>,
+    /// Diagnostic notes for this node (e.g. multiple architectures, unbound
+    /// component, cyclic instantiation).
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HierarchyKind {
+    /// Root of the tree.
+    Top,
+    /// Direct entity instantiation (`: entity work.foo`).
+    DirectEntity,
+    /// Component instantiation that bound to an entity by default binding.
+    BoundComponent,
+    /// Component instantiation with no matching entity in scope.
+    UnboundComponent,
+    /// Configuration instantiation (`: configuration cfg`); binding is not
+    /// chased.
+    Configuration,
+    /// Instantiation target could not be resolved by analysis.
+    Unresolved,
+}
+
+#[derive(Debug)]
+pub enum HierarchyError {
+    UnknownLibrary {
+        library: String,
+        known: Vec<String>,
+    },
+    UnknownEntity {
+        library: String,
+        entity: String,
+        known: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for HierarchyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HierarchyError::UnknownLibrary { library, known } => {
+                write!(f, "library '{library}' not found")?;
+                if !known.is_empty() {
+                    write!(f, " (known: {})", known.join(", "))?;
+                }
+                Ok(())
+            }
+            HierarchyError::UnknownEntity {
+                library,
+                entity,
+                known,
+            } => {
+                write!(f, "entity '{entity}' not found in library '{library}'")?;
+                if !known.is_empty() {
+                    write!(f, " (known: {})", known.join(", "))?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for HierarchyError {}
+
+/// Resolve `library.entity` and walk its instantiation tree.
+pub fn compute_design_hierarchy(
+    root: &DesignRoot,
+    library_name: &str,
+    entity_name: &str,
+) -> Result<DesignHierarchyNode, HierarchyError> {
+    let lib_sym = root.symbol_utf8(library_name);
+    let library = root
+        .get_lib(&lib_sym)
+        .ok_or_else(|| HierarchyError::UnknownLibrary {
+            library: library_name.to_string(),
+            known: known_libraries(root),
+        })?;
+
+    let ent_sym = root.symbol_utf8(entity_name);
+    let top_ent = find_entity(root, library, &ent_sym).ok_or_else(|| {
+        HierarchyError::UnknownEntity {
+            library: library_name.to_string(),
+            entity: entity_name.to_string(),
+            known: known_entities(root, library),
+        }
+    })?;
+
+    let mut visiting: HashSet<EntityId> = HashSet::new();
+    Ok(walk_entity(
+        root,
+        top_ent,
+        None,
+        None,
+        HierarchyKind::Top,
+        &mut visiting,
+    ))
+}
+
+fn known_libraries(root: &DesignRoot) -> Vec<String> {
+    let mut names: Vec<String> = root.libraries().map(|l| l.name().name_utf8()).collect();
+    names.sort();
+    names
+}
+
+fn known_entities(root: &DesignRoot, library: &Library) -> Vec<String> {
+    let mut names: Vec<String> = library
+        .units()
+        .filter_map(|locked| {
+            let data = locked.unit.expect_analyzed();
+            let primary = match *data.deref() {
+                AnyDesignUnit::Primary(ref p) => p,
+                _ => return None,
+            };
+            let id = primary.ent_id()?;
+            let ent = root.get_ent(id);
+            if !matches!(ent.kind(), AnyEntKind::Design(Design::Entity(..))) {
+                return None;
+            }
+            match ent.designator() {
+                Designator::Identifier(s) => Some(s.name_utf8()),
+                _ => None,
+            }
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+fn find_entity<'a>(
+    root: &'a DesignRoot,
+    library: &Library,
+    entity: &Symbol,
+) -> Option<EntRef<'a>> {
+    for locked in library.units() {
+        let data = locked.unit.expect_analyzed();
+        let AnyDesignUnit::Primary(ref primary) = *data.deref() else {
+            continue;
+        };
+        let Some(id) = primary.ent_id() else { continue };
+        let ent = root.get_ent(id);
+        if matches!(ent.kind(), AnyEntKind::Design(Design::Entity(..)))
+            && matches!(ent.designator(), Designator::Identifier(s) if s == entity)
+        {
+            return Some(ent);
+        }
+    }
+    None
+}
+
+/// Pick a single architecture for an entity.
+///
+/// Behaviour: prefer the architecture literally named `rtl` (case-sensitive
+/// to the analyzer, which means latin-1 case-insensitive comparison via
+/// `Symbol`). If that is absent, fall back to alphabetical order so the
+/// pick is deterministic across runs. The list of all candidates is also
+/// returned so the caller can record a note when more than one was found.
+fn select_architecture<'a>(architectures: Vec<EntRef<'a>>) -> (Option<EntRef<'a>>, Vec<String>) {
+    let mut named: Vec<(String, EntRef<'a>)> = architectures
+        .into_iter()
+        .filter_map(|e| match e.designator() {
+            Designator::Identifier(s) => Some((s.name_utf8(), e)),
+            _ => None,
+        })
+        .collect();
+    named.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let names: Vec<String> = named.iter().map(|(n, _)| n.clone()).collect();
+    let pick = named
+        .iter()
+        .find(|(n, _)| n == "rtl")
+        .or_else(|| named.first())
+        .map(|(_, e)| *e);
+    (pick, names)
+}
+
+fn walk_entity<'a>(
+    root: &'a DesignRoot,
+    entity: EntRef<'a>,
+    label: Option<String>,
+    instance_pos: Option<SrcPos>,
+    kind: HierarchyKind,
+    visiting: &mut HashSet<EntityId>,
+) -> DesignHierarchyNode {
+    let library_name = entity
+        .library_name()
+        .map(|s| s.name_utf8())
+        .unwrap_or_else(|| "?".into());
+    let entity_text = match entity.designator() {
+        Designator::Identifier(s) => s.name_utf8(),
+        d => format!("{d}"),
+    };
+    let entity_path = format!("{library_name}.{entity_text}");
+
+    let mut node = DesignHierarchyNode {
+        label,
+        entity_path,
+        architecture: None,
+        kind,
+        instance_pos,
+        entity_pos: entity.decl_pos().cloned(),
+        children: Vec::new(),
+        notes: Vec::new(),
+    };
+
+    if !visiting.insert(entity.id()) {
+        node.notes
+            .push("cyclic instantiation - traversal stopped".into());
+        return node;
+    }
+
+    let architectures: Vec<EntRef<'a>> = root
+        .find_implementation(entity)
+        .into_iter()
+        .filter(|e| matches!(e.kind(), AnyEntKind::Design(Design::Architecture(..))))
+        .collect();
+
+    let arch_count = architectures.len();
+    let (arch_ent, arch_names) = select_architecture(architectures);
+
+    if let Some(arch) = arch_ent {
+        if let Designator::Identifier(s) = arch.designator() {
+            node.architecture = Some(s.name_utf8());
+        }
+    }
+
+    match arch_count {
+        0 => node
+            .notes
+            .push("no architecture found for this entity".into()),
+        1 => {}
+        _ => {
+            let chosen = node.architecture.as_deref().unwrap_or("?");
+            node.notes.push(format!(
+                "multiple architectures ({}); using {}",
+                arch_names.join(", "),
+                chosen,
+            ));
+        }
+    }
+
+    if let Some(arch) = arch_ent {
+        let lib_sym = entity.library_name().expect("entity has library");
+        let library = root.get_lib(lib_sym).expect("library exists");
+        for raw in collect_instances_for_arch(library, arch) {
+            node.children.push(resolve_instance(root, raw, visiting));
+        }
+    }
+
+    visiting.remove(&entity.id());
+    node
+}
+
+fn resolve_instance<'a>(
+    root: &'a DesignRoot,
+    raw: RawInstance,
+    visiting: &mut HashSet<EntityId>,
+) -> DesignHierarchyNode {
+    let RawInstance {
+        label,
+        instance_pos,
+        target_id,
+        target_kind,
+    } = raw;
+
+    let unresolved = |label: Option<String>, kind: HierarchyKind, note: &str| {
+        DesignHierarchyNode {
+            label,
+            entity_path: "<unresolved>".into(),
+            architecture: None,
+            kind,
+            instance_pos: Some(instance_pos.clone()),
+            entity_pos: None,
+            children: Vec::new(),
+            notes: vec![note.into()],
+        }
+    };
+
+    let Some(id) = target_id else {
+        return unresolved(
+            label,
+            HierarchyKind::Unresolved,
+            "instantiation target was not resolved by analysis",
+        );
+    };
+
+    let target = root.get_ent(id);
+    match target.kind() {
+        AnyEntKind::Design(Design::Entity(..)) => {
+            let kind = match target_kind {
+                TargetKind::Entity => HierarchyKind::DirectEntity,
+                TargetKind::Component => HierarchyKind::BoundComponent,
+                // entity_reference() of a Configuration instantiation
+                // returns the configuration entity itself, not a Design::Entity,
+                // so this arm is unreachable in practice.
+                TargetKind::Configuration => HierarchyKind::DirectEntity,
+            };
+            walk_entity(root, target, label, Some(instance_pos), kind, visiting)
+        }
+        AnyEntKind::Component(_) => follow_component(root, target, label, instance_pos, visiting),
+        AnyEntKind::Design(Design::Configuration) => leaf_for_design(
+            target,
+            label,
+            instance_pos,
+            HierarchyKind::Configuration,
+            "configuration binding not traversed",
+        ),
+        _ => unresolved(
+            label,
+            HierarchyKind::Unresolved,
+            "instantiation target is not an entity, component, or configuration",
+        ),
+    }
+}
+
+fn follow_component<'a>(
+    root: &'a DesignRoot,
+    component: EntRef<'a>,
+    label: Option<String>,
+    instance_pos: SrcPos,
+    visiting: &mut HashSet<EntityId>,
+) -> DesignHierarchyNode {
+    // Default binding: find_implementation(component) returns the entity
+    // with the same name in the same library, if any.
+    let bound = root
+        .find_implementation(component)
+        .into_iter()
+        .find(|e| matches!(e.kind(), AnyEntKind::Design(Design::Entity(..))));
+
+    if let Some(entity) = bound {
+        walk_entity(
+            root,
+            entity,
+            label,
+            Some(instance_pos),
+            HierarchyKind::BoundComponent,
+            visiting,
+        )
+    } else {
+        leaf_for_design(
+            component,
+            label,
+            instance_pos,
+            HierarchyKind::UnboundComponent,
+            "component has no matching entity in its library",
+        )
+    }
+}
+
+fn leaf_for_design(
+    target: EntRef<'_>,
+    label: Option<String>,
+    instance_pos: SrcPos,
+    kind: HierarchyKind,
+    note: &str,
+) -> DesignHierarchyNode {
+    let name = match target.designator() {
+        Designator::Identifier(s) => s.name_utf8(),
+        d => format!("{d}"),
+    };
+    let lib = target
+        .library_name()
+        .map(|s| s.name_utf8())
+        .unwrap_or_else(|| "?".into());
+    DesignHierarchyNode {
+        label,
+        entity_path: format!("{lib}.{name}"),
+        architecture: None,
+        kind,
+        instance_pos: Some(instance_pos),
+        entity_pos: target.decl_pos().cloned(),
+        children: Vec::new(),
+        notes: vec![note.into()],
+    }
+}
+
+#[derive(Debug)]
+struct RawInstance {
+    label: Option<String>,
+    instance_pos: SrcPos,
+    target_id: Option<EntityId>,
+    target_kind: TargetKind,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum TargetKind {
+    Entity,
+    Component,
+    Configuration,
+}
+
+fn collect_instances_for_arch(library: &Library, arch_ent: EntRef<'_>) -> Vec<RawInstance> {
+    let arch_id = arch_ent.id();
+    for locked in library.units() {
+        let data = locked.unit.expect_analyzed();
+        if let AnyDesignUnit::Secondary(AnySecondaryUnit::Architecture(ref arch)) = *data.deref() {
+            if arch.ident.decl.get() == Some(arch_id) {
+                drop(data);
+                return collect_from_locked(locked);
+            }
+        }
+    }
+    Vec::new()
+}
+
+fn collect_from_locked(locked: &LockedUnit) -> Vec<RawInstance> {
+    let mut searcher = InstanceCollector {
+        instances: Vec::new(),
+    };
+    let _ = locked
+        .unit
+        .expect_analyzed()
+        .search(&locked.tokens, &mut searcher);
+    searcher.instances
+}
+
+struct InstanceCollector {
+    instances: Vec<RawInstance>,
+}
+
+impl Searcher for InstanceCollector {
+    fn search_decl(&mut self, ctx: &dyn TokenAccess, decl: FoundDeclaration<'_>) -> SearchState {
+        if let DeclarationItem::ConcurrentStatement(labeled) = decl.ast {
+            if let Some(raw) = make_raw_instance(ctx, labeled) {
+                self.instances.push(raw);
+            }
+        }
+        NotFinished
+    }
+}
+
+fn make_raw_instance(
+    ctx: &dyn TokenAccess,
+    labeled: &LabeledConcurrentStatement,
+) -> Option<RawInstance> {
+    let ConcurrentStatement::Instance(ref inst) = labeled.statement.item else {
+        return None;
+    };
+
+    let label = labeled
+        .label
+        .tree
+        .as_ref()
+        .map(|ident| ident.item.name_utf8());
+    let instance_pos = match labeled.label.tree {
+        Some(ref ident) => ident.pos(ctx).clone(),
+        None => inst.get_pos(ctx),
+    };
+
+    let target_kind = match inst.unit {
+        InstantiatedUnit::Entity(..) => TargetKind::Entity,
+        InstantiatedUnit::Component(..) => TargetKind::Component,
+        InstantiatedUnit::Configuration(..) => TargetKind::Configuration,
+    };
+
+    Some(RawInstance {
+        label,
+        instance_pos,
+        target_id: inst.entity_reference(),
+        target_kind,
+    })
+}
+
+// --- Candidate enumeration ----------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct TopCandidate {
+    pub library: String,
+    pub entity: String,
+    pub entity_pos: Option<SrcPos>,
+    /// Number of times this entity is instantiated anywhere in the design,
+    /// after default-binding components to entities.
+    pub instance_count: u32,
+    /// Height of the subtree rooted at this entity (1 == leaf, no instances).
+    pub depth: u32,
+    /// `true` when no other entity instantiates this one - i.e. a real top.
+    pub is_root: bool,
+}
+
+/// Enumerate every entity in the design and rank it as a hierarchy-top
+/// candidate. Output is sorted: roots first (deepest first, then by
+/// `library.entity` name), followed by non-roots (deepest first, then by
+/// name).
+pub fn list_top_candidates(root: &DesignRoot) -> Vec<TopCandidate> {
+    let entities: Vec<(EntityId, String, String)> = collect_all_entities(root);
+
+    let mut children_of: HashMap<EntityId, Vec<EntityId>> = HashMap::new();
+    let mut in_deg: HashMap<EntityId, u32> = HashMap::new();
+    for (eid, _, _) in &entities {
+        in_deg.entry(*eid).or_insert(0);
+    }
+    for (eid, _, _) in &entities {
+        let ent = root.get_ent(*eid);
+        let children = entity_children(root, ent);
+        for child in &children {
+            *in_deg.entry(*child).or_insert(0) += 1;
+        }
+        children_of.insert(*eid, children);
+    }
+
+    let mut depth_cache: HashMap<EntityId, u32> = HashMap::new();
+    let mut on_stack: HashSet<EntityId> = HashSet::new();
+    for (eid, _, _) in &entities {
+        compute_depth(*eid, &children_of, &mut depth_cache, &mut on_stack);
+    }
+
+    let mut out: Vec<TopCandidate> = entities
+        .into_iter()
+        .map(|(eid, library, entity)| {
+            let ent = root.get_ent(eid);
+            TopCandidate {
+                library,
+                entity,
+                entity_pos: ent.decl_pos().cloned(),
+                instance_count: *in_deg.get(&eid).unwrap_or(&0),
+                depth: *depth_cache.get(&eid).unwrap_or(&1),
+                is_root: in_deg.get(&eid).copied().unwrap_or(0) == 0,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| {
+        b.is_root
+            .cmp(&a.is_root)
+            .then_with(|| b.depth.cmp(&a.depth))
+            .then_with(|| a.library.cmp(&b.library))
+            .then_with(|| a.entity.cmp(&b.entity))
+    });
+    out
+}
+
+fn collect_all_entities(root: &DesignRoot) -> Vec<(EntityId, String, String)> {
+    let mut out = Vec::new();
+    for library in root.libraries() {
+        let lib_name = library.name().name_utf8();
+        for locked in library.units() {
+            let data = locked.unit.expect_analyzed();
+            let AnyDesignUnit::Primary(ref primary) = *data.deref() else {
+                continue;
+            };
+            let Some(id) = primary.ent_id() else { continue };
+            let ent = root.get_ent(id);
+            if !matches!(ent.kind(), AnyEntKind::Design(Design::Entity(..))) {
+                continue;
+            }
+            let name = match ent.designator() {
+                Designator::Identifier(s) => s.name_utf8(),
+                d => format!("{d}"),
+            };
+            out.push((id, lib_name.clone(), name));
+        }
+    }
+    out
+}
+
+fn entity_children(root: &DesignRoot, entity: EntRef<'_>) -> Vec<EntityId> {
+    let Some(lib_sym) = entity.library_name() else {
+        return Vec::new();
+    };
+    let Some(library) = root.get_lib(lib_sym) else {
+        return Vec::new();
+    };
+
+    let architectures: Vec<EntRef<'_>> = root
+        .find_implementation(entity)
+        .into_iter()
+        .filter(|e| matches!(e.kind(), AnyEntKind::Design(Design::Architecture(..))))
+        .collect();
+    let (arch_ent, _) = select_architecture(architectures);
+    let Some(arch) = arch_ent else {
+        return Vec::new();
+    };
+
+    let mut children = Vec::new();
+    for raw in collect_instances_for_arch(library, arch) {
+        let Some(id) = raw.target_id else { continue };
+        let target = root.get_ent(id);
+        match target.kind() {
+            AnyEntKind::Design(Design::Entity(..)) => children.push(id),
+            AnyEntKind::Component(_) => {
+                if let Some(bound) = root
+                    .find_implementation(target)
+                    .into_iter()
+                    .find(|e| matches!(e.kind(), AnyEntKind::Design(Design::Entity(..))))
+                {
+                    children.push(bound.id());
+                }
+            }
+            _ => {}
+        }
+    }
+    children
+}
+
+fn compute_depth(
+    eid: EntityId,
+    children_of: &HashMap<EntityId, Vec<EntityId>>,
+    cache: &mut HashMap<EntityId, u32>,
+    on_stack: &mut HashSet<EntityId>,
+) -> u32 {
+    if let Some(d) = cache.get(&eid) {
+        return *d;
+    }
+    if !on_stack.insert(eid) {
+        // Cycle: treat as height 1 to avoid infinite recursion. Do not
+        // cache, since the value depends on the call stack.
+        return 1;
+    }
+    let mut max_child = 0u32;
+    if let Some(children) = children_of.get(&eid) {
+        for c in children {
+            let d = compute_depth(*c, children_of, cache, on_stack);
+            if d > max_child {
+                max_child = d;
+            }
+        }
+    }
+    on_stack.remove(&eid);
+    let d = 1 + max_child;
+    cache.insert(eid, d);
+    d
+}

--- a/vhdl_lang/src/lib.rs
+++ b/vhdl_lang/src/lib.rs
@@ -25,6 +25,7 @@ mod syntax;
 
 mod completion;
 mod formatting;
+mod hierarchy;
 mod standard;
 
 pub use crate::config::{Case, Config};
@@ -46,4 +47,8 @@ pub use crate::syntax::{
 };
 
 pub use completion::{list_completion_options, CompletionItem};
+pub use hierarchy::{
+    compute_design_hierarchy, list_top_candidates, DesignHierarchyNode, HierarchyError,
+    HierarchyKind, TopCandidate,
+};
 pub use standard::VHDLStandard;

--- a/vhdl_lang/src/main.rs
+++ b/vhdl_lang/src/main.rs
@@ -4,14 +4,15 @@
 //
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use itertools::Itertools;
+use serde::Serialize;
 use std::iter::zip;
 use std::path::{Path, PathBuf};
 use vhdl_lang::ast::DesignFile;
 use vhdl_lang::{
-    Config, Diagnostic, MessagePrinter, Project, Severity, SeverityMap, Source, VHDLFormatter,
-    VHDLParser, VHDLStandard,
+    Config, DesignHierarchyNode, Diagnostic, HierarchyKind, MessagePrinter, Project, Severity,
+    SeverityMap, Source, SrcPos, VHDLFormatter, VHDLParser, VHDLStandard,
 };
 
 #[derive(Debug, clap::Args)]
@@ -28,6 +29,12 @@ pub struct Group {
     format: Option<String>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum HierarchyFormat {
+    Text,
+    Json,
+}
+
 /// Run vhdl analysis
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -41,13 +48,44 @@ struct Args {
     #[arg(short = 'l', long)]
     libraries: Option<String>,
 
+    /// Print the design instantiation hierarchy starting at the given top
+    /// entity. Accepts `library.entity`. A bare `entity` is resolved against
+    /// the project's libraries: if exactly one user library is configured,
+    /// or if a library named `work` is present, that one is used; otherwise
+    /// the known libraries are listed and the command exits non-zero.
+    /// Requires `--config`.
+    #[arg(long, value_name = "[LIB.]ENTITY")]
+    hierarchy: Option<String>,
+
+    /// Output format for `--hierarchy`.
+    #[arg(long, value_enum, default_value_t = HierarchyFormat::Text)]
+    hierarchy_format: HierarchyFormat,
+
+    /// Suppress diagnostics output when running `--hierarchy`. The hierarchy
+    /// is still printed even if analysis produced errors.
+    #[arg(long)]
+    hierarchy_quiet: bool,
+
     #[clap(flatten)]
     group: Group,
 }
 
 fn main() {
     let args = Args::parse();
-    if let Some(config_path) = args.group.config {
+    if let Some(top) = args.hierarchy.clone() {
+        let config_path = args.group.config.clone().unwrap_or_else(|| {
+            eprintln!("--hierarchy requires --config");
+            std::process::exit(2);
+        });
+        run_hierarchy(
+            &config_path,
+            args.num_threads,
+            args.libraries.as_ref(),
+            &top,
+            args.hierarchy_format,
+            args.hierarchy_quiet,
+        );
+    } else if let Some(config_path) = args.group.config {
         parse_and_analyze_project(&config_path, args.num_threads, args.libraries.as_ref());
     } else if let Some(format) = args.group.format {
         format_file(format);
@@ -134,6 +172,228 @@ fn parse_and_analyze_project(
         std::process::exit(1);
     } else {
         std::process::exit(0);
+    }
+}
+
+fn run_hierarchy(
+    config_path: &str,
+    num_threads: Option<usize>,
+    libraries: Option<&String>,
+    top: &str,
+    fmt: HierarchyFormat,
+    quiet: bool,
+) {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads.unwrap_or(0))
+        .build_global()
+        .ok();
+
+    let mut config = Config::default();
+    let mut msg_printer = MessagePrinter::default();
+    config.load_external_config(&mut msg_printer, libraries.cloned());
+    config.append(
+        &Config::read_file_path(Path::new(config_path)).expect("Failed to read config file"),
+        &mut msg_printer,
+    );
+
+    let severity_map = *config.severities();
+    let mut project = Project::from_config(config, &mut msg_printer);
+    let diagnostics = project.analyse();
+
+    if !quiet {
+        show_diagnostics(&diagnostics, &severity_map);
+    }
+
+    let (lib, ent) = match top.split_once('.') {
+        Some((l, e)) => (l.to_string(), e.to_string()),
+        None => match resolve_default_library(&project) {
+            Ok(l) => (l, top.to_string()),
+            Err(err) => {
+                eprintln!("hierarchy error: {err}");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    match project.design_hierarchy(&lib, &ent) {
+        Ok(node) => {
+            let out = match fmt {
+                HierarchyFormat::Text => format_hierarchy_text(&node),
+                HierarchyFormat::Json => format_hierarchy_json(&node),
+            };
+            print!("{out}");
+            std::process::exit(0);
+        }
+        Err(err) => {
+            eprintln!("hierarchy error: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Pick a default library when the user passes a bare entity name.
+///
+/// Strategy:
+/// * if a library named `work` is configured, use it;
+/// * else if there is exactly one user library, use it;
+/// * else fail and list the known libraries.
+///
+/// "User libraries" excludes the standard libraries (`std`, `ieee`, `vunit_lib`)
+/// that the analyzer always loads, since those are never sensible defaults.
+fn resolve_default_library(project: &Project) -> Result<String, String> {
+    let all = project.library_names();
+    if all.iter().any(|n| n == "work") {
+        return Ok("work".into());
+    }
+    let user: Vec<String> = all
+        .iter()
+        .filter(|n| !is_standard_library(n))
+        .cloned()
+        .collect();
+    match user.len() {
+        1 => Ok(user.into_iter().next().unwrap()),
+        0 => Err(format!(
+            "no user libraries configured (only standard libraries: {})",
+            all.join(", ")
+        )),
+        _ => Err(format!(
+            "ambiguous library: prefix the entity with one of [{}]",
+            user.join(", ")
+        )),
+    }
+}
+
+fn is_standard_library(name: &str) -> bool {
+    matches!(name, "std" | "ieee" | "vunit_lib" | "vunit_libs")
+}
+
+// --- Hierarchy text & JSON rendering -----------------------------------------
+
+fn format_hierarchy_text(node: &DesignHierarchyNode) -> String {
+    let mut out = String::new();
+    write_text(node, &mut out, "", true, true);
+    out
+}
+
+fn write_text(
+    node: &DesignHierarchyNode,
+    out: &mut String,
+    prefix: &str,
+    is_last: bool,
+    is_root: bool,
+) {
+    use std::fmt::Write;
+
+    let connector = if is_root {
+        ""
+    } else if is_last {
+        "`- "
+    } else {
+        "+- "
+    };
+    let _ = write!(out, "{prefix}{connector}");
+
+    if let Some(label) = &node.label {
+        let _ = write!(out, "{label} : ");
+    }
+    let _ = write!(out, "{}", node.entity_path);
+    if let Some(arch) = &node.architecture {
+        let _ = write!(out, "({arch})");
+    }
+    let suffix = match node.kind {
+        HierarchyKind::Top | HierarchyKind::DirectEntity | HierarchyKind::BoundComponent => "",
+        HierarchyKind::UnboundComponent => "  [component, unbound]",
+        HierarchyKind::Configuration => "  [configuration]",
+        HierarchyKind::Unresolved => "  [unresolved]",
+    };
+    let _ = write!(out, "{suffix}");
+
+    let pos = node.instance_pos.as_ref().or(node.entity_pos.as_ref());
+    if let Some(pos) = pos {
+        let _ = write!(out, "  @{}", format_pos(pos));
+    }
+    out.push('\n');
+
+    let note_prefix = format!(
+        "{prefix}{}",
+        if is_root || is_last { "   " } else { "|  " }
+    );
+    for note in &node.notes {
+        let _ = writeln!(out, "{note_prefix}# {note}");
+    }
+    let child_prefix = format!(
+        "{prefix}{}",
+        if is_root {
+            ""
+        } else if is_last {
+            "   "
+        } else {
+            "|  "
+        }
+    );
+    for (i, child) in node.children.iter().enumerate() {
+        write_text(
+            child,
+            out,
+            &child_prefix,
+            i + 1 == node.children.len(),
+            false,
+        );
+    }
+}
+
+fn format_pos(pos: &SrcPos) -> String {
+    format!(
+        "{}:{}:{}",
+        pos.source.file_name().display(),
+        pos.range.start.line + 1,
+        pos.range.start.character + 1,
+    )
+}
+
+fn format_hierarchy_json(node: &DesignHierarchyNode) -> String {
+    let serializable = SerNode::from(node);
+    let mut s = serde_json::to_string_pretty(&serializable).expect("serialize hierarchy");
+    s.push('\n');
+    s
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+struct SerNode<'a> {
+    label: Option<&'a str>,
+    entity: &'a str,
+    architecture: Option<&'a str>,
+    kind: &'static str,
+    instance_pos: Option<String>,
+    entity_pos: Option<String>,
+    notes: &'a [String],
+    children: Vec<SerNode<'a>>,
+}
+
+impl<'a> From<&'a DesignHierarchyNode> for SerNode<'a> {
+    fn from(node: &'a DesignHierarchyNode) -> SerNode<'a> {
+        SerNode {
+            label: node.label.as_deref(),
+            entity: &node.entity_path,
+            architecture: node.architecture.as_deref(),
+            kind: kind_str(node.kind),
+            instance_pos: node.instance_pos.as_ref().map(format_pos),
+            entity_pos: node.entity_pos.as_ref().map(format_pos),
+            notes: &node.notes,
+            children: node.children.iter().map(SerNode::from).collect(),
+        }
+    }
+}
+
+fn kind_str(k: HierarchyKind) -> &'static str {
+    match k {
+        HierarchyKind::Top => "top",
+        HierarchyKind::DirectEntity => "entity",
+        HierarchyKind::BoundComponent => "bound_component",
+        HierarchyKind::UnboundComponent => "unbound_component",
+        HierarchyKind::Configuration => "configuration",
+        HierarchyKind::Unresolved => "unresolved",
     }
 }
 

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -364,6 +364,32 @@ impl Project {
     pub fn entity_id_from_raw(&self, raw: usize) -> Option<EntityId> {
         self.root.entity_id_from_raw(raw)
     }
+
+    /// Compute the design instantiation hierarchy starting at `library.entity`.
+    pub fn design_hierarchy(
+        &self,
+        library_name: &str,
+        entity_name: &str,
+    ) -> Result<crate::DesignHierarchyNode, crate::HierarchyError> {
+        crate::compute_design_hierarchy(&self.root, library_name, entity_name)
+    }
+
+    /// Enumerate every entity in the design with its instance count and
+    /// subtree depth, ranked roots-first / deepest-first.
+    pub fn design_hierarchy_candidates(&self) -> Vec<crate::TopCandidate> {
+        crate::list_top_candidates(&self.root)
+    }
+
+    /// Sorted list of library names known to the project.
+    pub fn library_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .root
+            .libraries()
+            .map(|lib| lib.name().name_utf8())
+            .collect();
+        names.sort();
+        names
+    }
 }
 
 /// Multiply cloneable value by cloning

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -248,6 +248,44 @@ impl ConnectionRpcChannel {
             Err(request) => request,
         };
 
+        // Custom request: vhdl/designHierarchyCandidates
+        if request.method == "vhdl/designHierarchyCandidates" {
+            let id = request.id.clone();
+            let response = server.design_hierarchy_candidates();
+            self.send_response(lsp_server::Response::new_ok(id, response));
+            return;
+        }
+
+        // Custom request: vhdl/designHierarchy
+        if request.method == "vhdl/designHierarchy" {
+            use crate::vhdl_server::hierarchy::DesignHierarchyParams;
+            let id = request.id.clone();
+            let params: DesignHierarchyParams = match serde_json::from_value(request.params) {
+                Ok(p) => p,
+                Err(err) => {
+                    self.send_response(lsp_server::Response::new_err(
+                        id,
+                        lsp_server::ErrorCode::InvalidParams as i32,
+                        format!("Invalid params for vhdl/designHierarchy: {err}"),
+                    ));
+                    return;
+                }
+            };
+            match server.design_hierarchy(&params) {
+                Ok(tree) => {
+                    self.send_response(lsp_server::Response::new_ok(id, tree));
+                }
+                Err(err) => {
+                    self.send_response(lsp_server::Response::new_err(
+                        id,
+                        lsp_server::ErrorCode::InvalidRequest as i32,
+                        format!("{err}"),
+                    ));
+                }
+            }
+            return;
+        }
+
         debug!("Unhandled request: {request:?}");
         self.send_response(lsp_server::Response::new_err(
             request.id,

--- a/vhdl_ls/src/vhdl_server.rs
+++ b/vhdl_ls/src/vhdl_server.rs
@@ -6,6 +6,7 @@
 
 mod completion;
 mod diagnostics;
+pub(crate) mod hierarchy;
 mod lifecycle;
 mod rename;
 pub(crate) mod semantic_tokens;

--- a/vhdl_ls/src/vhdl_server/hierarchy.rs
+++ b/vhdl_ls/src/vhdl_server/hierarchy.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Custom LSP request `vhdl/designHierarchy`.
+//!
+//! Given a `library.entity`, returns the design instantiation tree as JSON
+//! with LSP `Location`s, ready for a VS Code TreeView.
+
+use lsp_types::Location;
+use serde::{Deserialize, Serialize};
+
+use super::{srcpos_to_location, VHDLServer};
+use vhdl_lang::{DesignHierarchyNode, HierarchyError, HierarchyKind, TopCandidate};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesignHierarchyParams {
+    pub library: String,
+    pub entity: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HierarchyResponseNode {
+    pub label: Option<String>,
+    pub entity: String,
+    pub architecture: Option<String>,
+    pub kind: &'static str,
+    pub instance_location: Option<Location>,
+    pub entity_location: Option<Location>,
+    pub notes: Vec<String>,
+    pub children: Vec<HierarchyResponseNode>,
+}
+
+impl VHDLServer {
+    pub fn design_hierarchy(
+        &self,
+        params: &DesignHierarchyParams,
+    ) -> Result<HierarchyResponseNode, HierarchyError> {
+        let node = self
+            .project
+            .design_hierarchy(&params.library, &params.entity)?;
+        Ok(convert(node))
+    }
+
+    pub fn design_hierarchy_candidates(&self) -> CandidatesResponse {
+        let candidates = self
+            .project
+            .design_hierarchy_candidates()
+            .into_iter()
+            .map(convert_candidate)
+            .collect();
+        CandidatesResponse { candidates }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidatesResponse {
+    pub candidates: Vec<CandidateItem>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidateItem {
+    pub library: String,
+    pub entity: String,
+    pub depth: u32,
+    pub instance_count: u32,
+    pub is_root: bool,
+    pub entity_location: Option<Location>,
+}
+
+fn convert_candidate(c: TopCandidate) -> CandidateItem {
+    CandidateItem {
+        library: c.library,
+        entity: c.entity,
+        depth: c.depth,
+        instance_count: c.instance_count,
+        is_root: c.is_root,
+        entity_location: c.entity_pos.as_ref().map(srcpos_to_location),
+    }
+}
+
+fn convert(node: DesignHierarchyNode) -> HierarchyResponseNode {
+    HierarchyResponseNode {
+        label: node.label,
+        entity: node.entity_path,
+        architecture: node.architecture,
+        kind: kind_str(node.kind),
+        instance_location: node.instance_pos.as_ref().map(srcpos_to_location),
+        entity_location: node.entity_pos.as_ref().map(srcpos_to_location),
+        notes: node.notes,
+        children: node.children.into_iter().map(convert).collect(),
+    }
+}
+
+fn kind_str(k: HierarchyKind) -> &'static str {
+    match k {
+        HierarchyKind::Top => "top",
+        HierarchyKind::DirectEntity => "entity",
+        HierarchyKind::BoundComponent => "boundComponent",
+        HierarchyKind::UnboundComponent => "unboundComponent",
+        HierarchyKind::Configuration => "configuration",
+        HierarchyKind::Unresolved => "unresolved",
+    }
+}


### PR DESCRIPTION
## Summary

Adds a walker over the analyzer's named-entity model that, given a top entity, produces the elaborated design instantiation tree, plus a candidate enumerator for "pick a top" UIs. Both are exposed as a CLI flag on `vhdl_lang` and as two custom LSP requests on `vhdl_ls`.

Companion PR for the official VS Code extension: VHDL-LS/rust_hdl_vscode (will link once opened).

## Why

Hardware engineers routinely need a hierarchical overview of their design (top entity -> instantiated children, recursively). The analyzer already binds instantiations and resolves component default-binding; this PR turns that information into a public, well-typed tree and surfaces it via the LSP so editors can render a hierarchy view. A blank "type the entity name" prompt is unhelpful on a fresh project; the candidates query lets a UI pre-populate the picker with real top candidates first.

## What's added

### `vhdl_lang`

- New module `hierarchy` exposing:
  - `compute_design_hierarchy(root, library, entity) -> Result<DesignHierarchyNode, HierarchyError>`
  - `list_top_candidates(root) -> Vec<TopCandidate>`
  - Types `DesignHierarchyNode`, `HierarchyKind`, `HierarchyError`, `TopCandidate`
- `Project::design_hierarchy`, `design_hierarchy_candidates`, `library_names` thin wrappers
- CLI flags: `--hierarchy [LIB.]ENTITY`, `--hierarchy-format text|json`, `--hierarchy-quiet`. JSON output is rendered via `serde_json::to_string_pretty` (new direct deps: `serde`, `serde_json`).
- A bare entity name resolves against the project's libraries: prefers `work`, otherwise the single user library, otherwise lists known libraries and exits non-zero.

### `vhdl_ls`

Two custom JSON-RPC requests (documented in README):

- `vhdl/designHierarchyCandidates` -> `{ candidates: [{ library, entity, depth, instanceCount, isRoot, entityLocation }] }`. Sorted roots-first / deepest-first.
- `vhdl/designHierarchy` with params `{ library, entity }` -> tree of `{ label, entity, architecture, kind, instanceLocation, entityLocation, notes, children }`. `kind` is one of `top`, `entity`, `boundComponent`, `unboundComponent`, `configuration`, `unresolved`. Unknown library or entity yields `InvalidRequest` with a message listing the known names.

### Behaviour notes

- Component instantiations are followed through default binding to the bound entity.
- Configuration instantiations appear as leaves (the configuration's block-configuration tree is not chased in this PR).
- For-/if-/case-generate statements are visited once: each instance shows up at the source-text point it is written, not multiplied by the elaborated count.
- When an entity has multiple architectures, the architecture named `rtl` is preferred; otherwise the alphabetically first architecture, with a note recorded on the node.
- Cycles are detected and truncated with a note rather than recursing.

## Tests

Nine new tests under `analysis::tests::design_hierarchy` covering: three-level entity nesting, component default-binding, unbound component, multi-architecture preference for `rtl`, alphabetical fallback, cycle protection, error messages with known-name lists, and candidate ranking. Full suite still passes (1417 + 9 = 1426 tests).

## Test plan

- [x] `cargo test --release -p vhdl_lang` passes (1417 prior + 9 new)
- [x] CLI smoke test on a real project (~20 entities, 4 levels deep): tree renders correctly in both text and JSON
- [x] LSP smoke test (Python script): `vhdl/designHierarchy` and `vhdl/designHierarchyCandidates` round-trip end-to-end against a stdio-launched `vhdl_ls`
- [x] `--hierarchy gev` (no library prefix) on a project with multiple user libraries errors out and lists them; the same on a project with a single user library auto-resolves correctly