### PR TITLE
VHDL Syntax: Add text mod and byte offset <-> source location mapping

### DIFF
--- a/vhdl_syntax/src/fmt/encoding.rs
+++ b/vhdl_syntax/src/fmt/encoding.rs
@@ -8,7 +8,7 @@
 //! UTF-8 characters while only using the ASCII subset in code
 //! (ASCII is shared between UTF-8 and Latin-1, the default VHDL encoding).
 
-use std::{borrow::Cow, convert::Infallible, str::Utf8Error};
+use std::{borrow::Cow, convert::Infallible, ops::Deref, str::Utf8Error};
 
 use crate::latin_1::Latin1Str;
 
@@ -79,6 +79,14 @@ impl Replacements {
 
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+}
+
+impl Deref for Replacements {
+    type Target = [Replacement];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries
     }
 }
 

--- a/vhdl_syntax/src/latin_1.rs
+++ b/vhdl_syntax/src/latin_1.rs
@@ -494,6 +494,10 @@ impl<'a> Iterator for Chars<'a> {
         self.iter.count()
     }
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
     fn last(self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -501,6 +505,8 @@ impl<'a> Iterator for Chars<'a> {
         self.iter.last().map(|byte| *byte as char)
     }
 }
+
+impl <'a> ExactSizeIterator for Chars<'a> {}
 
 impl Latin1Str {
     pub fn new(bytes: &[u8]) -> &Latin1Str {

--- a/vhdl_syntax/src/latin_1.rs
+++ b/vhdl_syntax/src/latin_1.rs
@@ -506,7 +506,7 @@ impl<'a> Iterator for Chars<'a> {
     }
 }
 
-impl <'a> ExactSizeIterator for Chars<'a> {}
+impl<'a> ExactSizeIterator for Chars<'a> {}
 
 impl Latin1Str {
     pub fn new(bytes: &[u8]) -> &Latin1Str {

--- a/vhdl_syntax/src/latin_1.rs
+++ b/vhdl_syntax/src/latin_1.rs
@@ -508,7 +508,7 @@ impl<'a> Iterator for Chars<'a> {
 
 impl<'a> ExactSizeIterator for Chars<'a> {}
 
-impl <'a> DoubleEndedIterator for Chars<'a> {
+impl<'a> DoubleEndedIterator for Chars<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|byte| *byte as char)
     }

--- a/vhdl_syntax/src/latin_1.rs
+++ b/vhdl_syntax/src/latin_1.rs
@@ -508,6 +508,12 @@ impl<'a> Iterator for Chars<'a> {
 
 impl<'a> ExactSizeIterator for Chars<'a> {}
 
+impl <'a> DoubleEndedIterator for Chars<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|byte| *byte as char)
+    }
+}
+
 impl Latin1Str {
     pub fn new(bytes: &[u8]) -> &Latin1Str {
         // SAFETY: Latin1Str is a transparent newtype wrapper around [u8],

--- a/vhdl_syntax/src/latin_1.rs
+++ b/vhdl_syntax/src/latin_1.rs
@@ -467,6 +467,41 @@ fn iso_8859_1_uppercase(chr: u8) -> u8 {
     }
 }
 
+/// An iterator over the chars of a Latin-1 encoded string
+pub struct Chars<'a> {
+    iter: slice::Iter<'a, u8>,
+}
+
+impl<'a> Chars<'a> {
+    pub fn new(value: &'a Latin1Str) -> Chars<'a> {
+        Chars {
+            iter: value.inner.iter(),
+        }
+    }
+}
+
+impl<'a> Iterator for Chars<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|byte| *byte as char)
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.iter.count()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.iter.last().map(|byte| *byte as char)
+    }
+}
+
 impl Latin1Str {
     pub fn new(bytes: &[u8]) -> &Latin1Str {
         // SAFETY: Latin1Str is a transparent newtype wrapper around [u8],
@@ -492,8 +527,8 @@ impl Latin1Str {
         Latin1String::from(&self.inner)
     }
 
-    pub fn chars(&self) -> slice::Iter<'_, u8> {
-        self.inner.iter()
+    pub fn chars(&self) -> Chars<'_> {
+        Chars::new(self)
     }
 
     pub fn len(&self) -> usize {

--- a/vhdl_syntax/src/lib.rs
+++ b/vhdl_syntax/src/lib.rs
@@ -12,5 +12,6 @@ pub mod parser;
 pub mod serde;
 pub mod standard;
 pub mod syntax;
+pub mod text;
 mod token_interning;
 pub mod tokens;

--- a/vhdl_syntax/src/text/char_encoding.rs
+++ b/vhdl_syntax/src/text/char_encoding.rs
@@ -1,0 +1,49 @@
+//! Target encoding definitions for column-width measurement.
+//!
+//! A [`CharEncoding`] answers "how many code units does this character occupy
+//! in a given encoding?" This is used by [`super::source_loc::SourceLocConverter`]
+//! to translate byte offsets into columns that match a client's expected encoding
+//! (e.g., UTF-16 for LSP).
+
+/// Measures the width of a `char` in a target encoding's code units.
+///
+/// This is the number of code units the target system uses to represent
+/// this character, *not* the byte width in the source file.
+/// This is *not* the byte width in the source file.
+pub trait CharEncoding {
+    fn char_len(ch: char) -> usize;
+}
+
+/// UTF-8: 1–4 code units (bytes) per character.
+pub struct Utf8;
+impl CharEncoding for Utf8 {
+    fn char_len(ch: char) -> usize {
+        ch.len_utf8()
+    }
+}
+
+/// UTF-16: 1–2 code units (16-bit) per character. This is the LSP default.
+pub struct Utf16;
+impl CharEncoding for Utf16 {
+    fn char_len(ch: char) -> usize {
+        ch.len_utf16()
+    }
+}
+
+/// UTF-32 / code point index: always 1 unit per character.
+pub struct Utf32;
+impl CharEncoding for Utf32 {
+    fn char_len(_ch: char) -> usize {
+        1
+    }
+}
+
+/// Latin-1: always 1 unit per character.
+/// Identical to [`Utf32`] for column measurement since every Latin-1
+/// character is a single code point.
+pub struct Latin1;
+impl CharEncoding for Latin1 {
+    fn char_len(_ch: char) -> usize {
+        1
+    }
+}

--- a/vhdl_syntax/src/text/char_encoding.rs
+++ b/vhdl_syntax/src/text/char_encoding.rs
@@ -12,18 +12,12 @@
 /// This is *not* the byte width in the source file.
 pub trait CharEncoding {
     fn char_len(ch: char) -> usize;
-
-    fn byte_len(ch: char) -> usize;
 }
 
 /// UTF-8: 1–4 code units (bytes) per character.
 pub struct Utf8;
 impl CharEncoding for Utf8 {
     fn char_len(ch: char) -> usize {
-        ch.len_utf8()
-    }
-
-    fn byte_len(ch: char) -> usize {
         ch.len_utf8()
     }
 }
@@ -34,10 +28,6 @@ impl CharEncoding for Utf16 {
     fn char_len(ch: char) -> usize {
         ch.len_utf16()
     }
-
-    fn byte_len(ch: char) -> usize {
-        ch.len_utf16() * 2
-    }
 }
 
 /// UTF-32 / code point index: always 1 unit per character.
@@ -45,10 +35,6 @@ pub struct Utf32;
 impl CharEncoding for Utf32 {
     fn char_len(_ch: char) -> usize {
         1
-    }
-
-    fn byte_len(_ch: char) -> usize {
-        4
     }
 }
 
@@ -58,10 +44,6 @@ impl CharEncoding for Utf32 {
 pub struct Latin1;
 impl CharEncoding for Latin1 {
     fn char_len(_ch: char) -> usize {
-        1
-    }
-
-    fn byte_len(_ch: char) -> usize {
         1
     }
 }

--- a/vhdl_syntax/src/text/char_encoding.rs
+++ b/vhdl_syntax/src/text/char_encoding.rs
@@ -12,12 +12,18 @@
 /// This is *not* the byte width in the source file.
 pub trait CharEncoding {
     fn char_len(ch: char) -> usize;
+
+    fn byte_len(ch: char) -> usize;
 }
 
 /// UTF-8: 1–4 code units (bytes) per character.
 pub struct Utf8;
 impl CharEncoding for Utf8 {
     fn char_len(ch: char) -> usize {
+        ch.len_utf8()
+    }
+
+    fn byte_len(ch: char) -> usize {
         ch.len_utf8()
     }
 }
@@ -28,6 +34,10 @@ impl CharEncoding for Utf16 {
     fn char_len(ch: char) -> usize {
         ch.len_utf16()
     }
+
+    fn byte_len(ch: char) -> usize {
+        ch.len_utf16() * 2
+    }
 }
 
 /// UTF-32 / code point index: always 1 unit per character.
@@ -35,6 +45,10 @@ pub struct Utf32;
 impl CharEncoding for Utf32 {
     fn char_len(_ch: char) -> usize {
         1
+    }
+
+    fn byte_len(_ch: char) -> usize {
+        4
     }
 }
 
@@ -44,6 +58,10 @@ impl CharEncoding for Utf32 {
 pub struct Latin1;
 impl CharEncoding for Latin1 {
     fn char_len(_ch: char) -> usize {
+        1
+    }
+
+    fn byte_len(_ch: char) -> usize {
         1
     }
 }

--- a/vhdl_syntax/src/text/char_iter.rs
+++ b/vhdl_syntax/src/text/char_iter.rs
@@ -1,0 +1,27 @@
+//! Byte-position–aware character iteration over encoded strings.
+
+use crate::latin_1::Latin1Str;
+
+/// Iterates characters together with their byte offset within the string.
+///
+/// This is the bridge between [`crate::fmt::encoding::Encoder::Str`] and
+/// [`super::source_loc::SourceLocConverter`]: the converter needs to walk
+/// characters while tracking byte positions so it can compute the byte width
+/// of each character as the gap between consecutive offsets.
+pub trait CharIter {
+    /// Return an iterator yielding the byte position and the character
+    fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)>;
+}
+
+impl CharIter for &str {
+    fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)> {
+        self.char_indices()
+    }
+}
+
+impl CharIter for &Latin1Str {
+    fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)> {
+        // Every byte is one character in Latin-1, so byte index == char index.
+        self.chars().enumerate()
+    }
+}

--- a/vhdl_syntax/src/text/char_iter.rs
+++ b/vhdl_syntax/src/text/char_iter.rs
@@ -11,11 +11,21 @@ use crate::latin_1::Latin1Str;
 pub trait CharIter {
     /// Return an iterator yielding the byte position and the character
     fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)>;
+
+    /// Returns the total number of bytes this iterator will iterate over
+    fn byte_count(&self) -> usize;
 }
 
-impl CharIter for &str {
+impl<T> CharIter for T
+where
+    T: AsRef<str>,
+{
     fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)> {
-        self.char_indices()
+        self.as_ref().char_indices()
+    }
+
+    fn byte_count(&self) -> usize {
+        self.as_ref().len()
     }
 }
 
@@ -23,5 +33,9 @@ impl CharIter for &Latin1Str {
     fn iter_chars_indices(&self) -> impl Iterator<Item = (usize, char)> {
         // Every byte is one character in Latin-1, so byte index == char index.
         self.chars().enumerate()
+    }
+
+    fn byte_count(&self) -> usize {
+        self.len()
     }
 }

--- a/vhdl_syntax/src/text/mod.rs
+++ b/vhdl_syntax/src/text/mod.rs
@@ -1,0 +1,12 @@
+//! Utilities for mapping between byte offsets and source locations (line/column).
+//!
+//! The key abstraction is [`source_loc::SourceLocConverter`], which builds a
+//! line index from a syntax tree and translates byte offsets to
+//! `(line, column)` pairs in a target encoding.
+//!
+//! Source and target encoding are independent: a file may be stored as UTF-8
+//! on disk while the LSP client expects UTF-16 column offsets.
+
+pub mod char_encoding;
+pub mod char_iter;
+pub mod source_loc;

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
 use crate::{
-    fmt::encoding::Encoder, latin_1::Latin1Str, syntax::node::SyntaxNode, text::{char_encoding::CharEncoding, char_iter::CharIter}, tokens::TriviaPiece
+    fmt::encoding::Encoder,
+    latin_1::Latin1Str,
+    syntax::node::SyntaxNode,
+    text::{char_encoding::CharEncoding, char_iter::CharIter},
+    tokens::TriviaPiece,
 };
 
 /// A zero-based `(line, column)` position in source text.
@@ -220,5 +224,184 @@ fn record_str<C: CharEncoding>(
                 target_len: char_width,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fmt::encoding::{Latin1Encoder, Utf8Encoder};
+    use crate::parser::parse;
+    use crate::text::char_encoding::{Utf16, Utf32, Utf8};
+
+    fn converter<E: Encoder, C: CharEncoding>(input: &str) -> SourceLocConverter
+    where
+        for<'a> E::Str<'a>: CharIter,
+        E::Err: std::fmt::Debug,
+    {
+        let (design_file, _) = parse(input);
+        SourceLocConverter::new::<E, C>(&design_file.0).unwrap()
+    }
+
+    fn utf8_utf16(input: &str) -> SourceLocConverter {
+        converter::<Utf8Encoder, Utf16>(input)
+    }
+
+    fn loc(conv: &SourceLocConverter, offset: usize) -> (usize, usize) {
+        let l = conv.source_loc(offset);
+        (l.line, l.col)
+    }
+
+    // ASCII-only (all encodings agree)
+
+    #[test]
+    fn single_line_ascii() {
+        let conv = utf8_utf16("entity e is end;");
+        assert_eq!(loc(&conv, 0), (0, 0));
+        assert_eq!(loc(&conv, 7), (0, 7));
+    }
+
+    #[test]
+    fn multi_line_ascii() {
+        // "entity e is\nend;\n"
+        let input = "entity e is\nend;\n";
+        let conv = utf8_utf16(input);
+        assert_eq!(loc(&conv, 0), (0, 0));
+        // offset 11 = last char of first line ('s')
+        assert_eq!(loc(&conv, 11), (0, 11));
+        // offset 12 = first char of second line ('e' in "end")
+        assert_eq!(loc(&conv, 12), (1, 0));
+        assert_eq!(loc(&conv, 15), (1, 3));
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let input = "entity e is\r\nend;\r\n";
+        let conv = utf8_utf16(input);
+        // After \r\n (2 bytes), second line starts at offset 13
+        assert_eq!(loc(&conv, 13), (1, 0));
+        assert_eq!(loc(&conv, 16), (1, 3));
+    }
+
+    // Line comment with non-ASCII (UTF-8 source, UTF-16 target)
+
+    #[test]
+    fn line_comment_with_umlaut() {
+        // ä is 2 bytes in UTF-8, 1 unit in UTF-16
+        // Layout: "--" (2) + " " (1) + "ä" (2) + "\n" (1) = 6 bytes on line 0
+        let input = "-- ä\nentity e is end;";
+        let conv = utf8_utf16(input);
+
+        // byte 2 = space after "--", col 2
+        assert_eq!(loc(&conv, 2), (0, 2));
+        // byte 3 = start of ä, col 3
+        assert_eq!(loc(&conv, 3), (0, 3));
+        // byte 4 = inside ä (second UTF-8 byte), clamps to ä start = col 3
+        assert_eq!(loc(&conv, 4), (0, 3));
+        // "entity" starts at byte 6 (after \n)
+        assert_eq!(loc(&conv, 6), (1, 0));
+    }
+
+    #[test]
+    fn line_comment_with_emoji() {
+        // 💣 is 4 bytes in UTF-8, 2 units in UTF-16
+        let input = "-- 💣\nentity e is end;";
+        let conv = utf8_utf16(input);
+        // "-- " = 3 bytes, "💣" = 4 bytes, "\n" = 1 byte => line 1 starts at offset 8
+        assert_eq!(loc(&conv, 8), (1, 0));
+        // byte 3 = start of 💣, UTF-16 col = 3
+        assert_eq!(loc(&conv, 3), (0, 3));
+        // byte 5 = inside 💣 (4-byte char), should clamp to start = col 3
+        assert_eq!(loc(&conv, 5), (0, 3));
+    }
+
+    // Block comment spanning multiple lines
+
+    #[test]
+    fn block_comment_multiline() {
+        let input = "/* line1\nline2 */\nentity e is end;";
+        let conv = utf8_utf16(input);
+        // "/*" = 2, " line1\n" = 7 bytes => line 1 starts at offset 9
+        assert_eq!(loc(&conv, 9), (1, 0));
+        // "line2 */" = 8, "\n" = 1 => line 2 starts at offset 18
+        assert_eq!(loc(&conv, 18), (2, 0));
+    }
+
+    // Offset clamping
+
+    #[test]
+    fn offset_beyond_end_is_clamped() {
+        let input = "entity e is end;";
+        let conv = utf8_utf16(input);
+        let clamped = conv.source_loc(9999);
+        let end = conv.source_loc(input.len());
+        assert_eq!(clamped.line, end.line);
+        assert_eq!(clamped.col, end.col);
+    }
+
+    #[test]
+    fn offset_zero() {
+        let input = "entity e is end;";
+        let conv = utf8_utf16(input);
+        assert_eq!(loc(&conv, 0), (0, 0));
+    }
+
+    // UTF-8 source, UTF-32 target (code point columns)
+
+    #[test]
+    fn utf32_target_counts_code_points() {
+        let input = "-- 💣x\nentity e is end;";
+        let conv = converter::<Utf8Encoder, Utf32>(input);
+        // 💣 is 1 code point, x is 1 code point
+        // byte 3 = start of 💣, UTF-32 col = 3
+        assert_eq!(loc(&conv, 3), (0, 3));
+        // byte 7 = 'x' (after 4-byte 💣), UTF-32 col = 4
+        assert_eq!(loc(&conv, 7), (0, 4));
+    }
+
+    // UTF-8 source, UTF-8 target (byte columns, no wide chars)
+
+    #[test]
+    fn utf8_target_matches_byte_offset() {
+        let input = "-- ä💣\nentity e is end;";
+        let conv = converter::<Utf8Encoder, Utf8>(input);
+        // With UTF-8 target, col == byte offset within line since source is also UTF-8
+        assert_eq!(loc(&conv, 3), (0, 3)); // start of ä
+        assert_eq!(loc(&conv, 5), (0, 5)); // start of 💣
+        assert_eq!(loc(&conv, 9), (0, 9)); // past 💣
+    }
+
+    // Latin-1 source, UTF-16 target
+
+    #[test]
+    fn latin1_source_utf16_target() {
+        // All ASCII, so Latin-1 and UTF-16 agree: every byte is 1 column unit.
+        let input = "-- hello\nentity e is end;";
+        let conv = converter::<Latin1Encoder, Utf16>(input);
+        assert_eq!(loc(&conv, 0), (0, 0));
+        assert_eq!(loc(&conv, 9), (1, 0));
+    }
+
+    // Multiple wide chars on the same line
+
+    #[test]
+    fn multiple_wide_chars_same_line() {
+        // Two umlauts: each 2 bytes UTF-8, 1 unit UTF-16
+        let input = "-- äö\nentity e is end;";
+        let conv = utf8_utf16(input);
+        // byte 3 = ä (2 bytes), byte 5 = ö (2 bytes)
+        // UTF-16 col of ä = 3, of ö = 4
+        assert_eq!(loc(&conv, 3), (0, 3));
+        assert_eq!(loc(&conv, 5), (0, 4));
+        // byte 7 = \n, so line 1 starts at byte 8
+        assert_eq!(loc(&conv, 8), (1, 0));
+    }
+
+    // Empty input
+
+    #[test]
+    fn empty_input() {
+        let conv = utf8_utf16("");
+        assert_eq!(loc(&conv, 0), (0, 0));
     }
 }

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashMap, ops::Range};
+use std::{collections::BTreeMap, ops::Range};
 
 use crate::{
-    fmt::encoding::{BytePreservingEncoder, Encoder, LossyEncoder, Replacements},
+    fmt::encoding::{BytePreservingEncoder, Encoder, LossyEncoder, Replacement},
     latin_1::Latin1Str,
     syntax::node::SyntaxNode,
     text::{char_encoding::CharEncoding, char_iter::CharIter},
@@ -65,7 +65,7 @@ impl WideChar {
 pub struct SourceLocConverter {
     line_starts: Vec<usize>,
     text_len: usize,
-    wide_char_lines: HashMap<usize, Vec<WideChar>>,
+    wide_char_lines: BTreeMap<usize, Vec<WideChar>>,
 }
 
 impl SourceLocConverter {
@@ -81,7 +81,7 @@ impl SourceLocConverter {
         for<'a> E::Str<'a>: CharIter,
     {
         let mut line_starts = vec![0usize];
-        let mut wide_char_lines = HashMap::new();
+        let mut wide_char_lines = BTreeMap::new();
         let mut cursor = 0usize;
 
         let mut tok = root.first_token();
@@ -109,7 +109,7 @@ impl SourceLocConverter {
         for<'a> E::Str<'a>: CharIter,
     {
         let mut line_starts = vec![0usize];
-        let mut wide_char_lines = HashMap::new();
+        let mut wide_char_lines = BTreeMap::new();
         let mut cursor = 0usize;
 
         let mut tok = root.first_token();
@@ -210,16 +210,16 @@ fn record_text<C: CharEncoding>(
     text: &Latin1Str,
     cursor: usize,
     line_starts: &mut Vec<usize>,
-    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    wide_char_lines: &mut BTreeMap<usize, Vec<WideChar>>,
 ) {
-    record_str::<C>(text, line_starts, wide_char_lines, cursor);
+    record_str::<C>(text, &[], line_starts, wide_char_lines, cursor);
 }
 
 fn record_piece<E: Encoder, C: CharEncoding>(
     piece: &TriviaPiece,
     cursor: usize,
     line_starts: &mut Vec<usize>,
-    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    wide_char_lines: &mut BTreeMap<usize, Vec<WideChar>>,
 ) -> Result<(), E::Err>
 where
     for<'a> E::Str<'a>: CharIter,
@@ -241,58 +241,39 @@ where
         // Note: In theory, `LineComment`s don't need the special newline handling, it's just included here for simplicity.
         // If performance ever becomes a bottleneck, this can be split.
         TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
-            record_str::<C>(c.encode::<E>()?, line_starts, wide_char_lines, cursor + 2);
+            record_str::<C>(
+                c.encode::<E>()?,
+                &[],
+                line_starts,
+                wide_char_lines,
+                cursor + 2,
+            );
+        }
+        TriviaPiece::NonBreakingSpaces(n) => {
+            let target_len = C::char_len('\u{00A0}');
+            if target_len != 1 {
+                let line = line_starts.len() - 1;
+                let line_start = line_starts[line];
+                for i in 0..*n {
+                    let abs_offset = cursor + i;
+                    wide_char_lines.entry(line).or_default().push(WideChar {
+                        offset: abs_offset - line_start,
+                        byte_len: 1,
+                        target_len,
+                    });
+                }
+            }
         }
         _ => {}
     }
     Ok(())
 }
 
-fn record_str<C: CharEncoding>(
-    str: impl CharIter,
-    line_starts: &mut Vec<usize>,
-    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
-    cursor: usize,
-) {
-    let mut line = line_starts.len() - 1;
-    let mut itr = str.iter_chars_indices().peekable();
-    let byte_len = str.byte_count();
-    while let Some((pos, ch)) = itr.next() {
-        if ch == '\n' {
-            line_starts.push(cursor + pos + 1);
-            line += 1;
-            continue;
-        }
-        if ch == '\r' {
-            if itr.peek().is_some_and(|(_, ch)| *ch == '\n') {
-                let _ = itr.next();
-                line_starts.push(cursor + pos + 2);
-            } else {
-                line_starts.push(cursor + pos + 1);
-            }
-            line += 1;
-            continue;
-        }
-        let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
-        let byte_width = next_pos - pos;
-        let char_width = C::char_len(ch);
-        if byte_width != 1 || byte_width != char_width {
-            let abs_offset = cursor + pos;
-            let line_start = line_starts[line];
-            wide_char_lines.entry(line).or_default().push(WideChar {
-                offset: abs_offset - line_start,
-                byte_len: byte_width,
-                target_len: char_width,
-            });
-        }
-    }
-}
-
 fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
     piece: &TriviaPiece,
     cursor: usize,
     line_starts: &mut Vec<usize>,
-    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    wide_char_lines: &mut BTreeMap<usize, Vec<WideChar>>,
 ) where
     for<'a> E::Str<'a>: CharIter,
 {
@@ -312,7 +293,7 @@ fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
         }
         TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
             let (encoded, replacements) = c.encode_lossy::<E>();
-            record_str_with_replacements::<C>(
+            record_str::<C>(
                 encoded,
                 &replacements,
                 line_starts,
@@ -320,26 +301,35 @@ fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
                 cursor + 2,
             );
         }
+        TriviaPiece::NonBreakingSpaces(n) => {
+            let target_len = C::char_len('\u{00A0}');
+            if target_len != 1 {
+                let line = line_starts.len() - 1;
+                let line_start = line_starts[line];
+                for i in 0..*n {
+                    let abs_offset = cursor + i;
+                    wide_char_lines.entry(line).or_default().push(WideChar {
+                        offset: abs_offset - line_start,
+                        byte_len: 1,
+                        target_len,
+                    });
+                }
+            }
+        }
         _ => {}
     }
 }
 
-fn record_str_with_replacements<C: CharEncoding>(
+fn record_str<C: CharEncoding>(
     encoded: impl CharIter,
-    replacements: &Replacements,
+    replacements: &[Replacement],
     line_starts: &mut Vec<usize>,
-    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    wide_char_lines: &mut BTreeMap<usize, Vec<WideChar>>,
     cursor: usize,
 ) {
-    if replacements.is_empty() {
-        record_str::<C>(encoded, line_starts, wide_char_lines, cursor);
-        return;
-    }
-
     let mut line = line_starts.len() - 1;
     let mut itr = encoded.iter_chars_indices().peekable();
     let byte_len = encoded.byte_count();
-    let entries = replacements.entries();
     let mut repl_idx = 0;
     // Accumulated difference between encoded and source positions.
     // encoded_pos = source_pos + delta
@@ -369,10 +359,10 @@ fn record_str_with_replacements<C: CharEncoding>(
         let target_width = C::char_len(ch);
 
         let at_replacement =
-            repl_idx < entries.len() && source_pos == entries[repl_idx].source_offset;
+            repl_idx < replacements.len() && source_pos == replacements[repl_idx].source_offset;
 
         if at_replacement {
-            let r = &entries[repl_idx];
+            let r = &replacements[repl_idx];
             let source_byte_width = r.source_bytes;
             if source_byte_width != target_width {
                 let abs_offset = cursor + source_pos;
@@ -648,5 +638,36 @@ mod tests {
     fn empty_input() {
         let conv = utf8_utf16("");
         assert_eq!(loc(&conv, 0), (0, 0));
+    }
+
+    // Non-breaking spaces (U+00A0)
+
+    #[test]
+    fn non_breaking_space_latin1_to_utf8() {
+        // \xA0 = non-breaking space, 1 byte in Latin-1, 2 bytes in UTF-8
+        // Layout: "\xA0" (1) + "entity e is end;" (16)
+        let input: &[u8] = b"\xA0entity e is end;";
+        let conv = converter::<Latin1Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0); // start of NBSP
+        assert_eq!(conv.convert_byte_offset(1), 2); // 'e' in entity (delta +1)
+    }
+
+    #[test]
+    fn non_breaking_space_latin1_to_utf16() {
+        // \xA0 is 1 byte Latin-1, 1 code unit UTF-16 — no expansion
+        let input: &[u8] = b"\xA0entity e is end;";
+        let conv = converter::<Latin1Encoder, Utf16>(input);
+        assert_eq!(loc(&conv, 0), (0, 0));
+        assert_eq!(loc(&conv, 1), (0, 1));
+    }
+
+    #[test]
+    fn multiple_non_breaking_spaces_latin1_to_utf8() {
+        // Two consecutive NBSPs before a token
+        let input: &[u8] = b"\xA0\xA0entity e is end;";
+        let conv = converter::<Latin1Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0); // first NBSP
+        assert_eq!(conv.convert_byte_offset(1), 2); // second NBSP (delta +1)
+        assert_eq!(conv.convert_byte_offset(2), 4); // 'e' in entity (delta +2)
     }
 }

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -13,6 +13,7 @@ use crate::{
 /// The column is expressed in the target encoding's code units, not bytes.
 /// For example, with [`super::char_encoding::Utf16`] as the target, `col` counts
 /// UTF-16 code units — matching what LSP clients expect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SourceLoc {
     /// Zero-based line number.
     pub line: usize,
@@ -212,6 +213,16 @@ fn record_str<C: CharEncoding>(
             line += 1;
             continue;
         }
+        if ch == '\r' {
+            if itr.peek().is_some_and(|(_, ch)| *ch == '\n') {
+                let _ = itr.next();
+                line_starts.push(cursor + pos + 2);
+            } else {
+                line_starts.push(cursor + pos + 1);
+            }
+            line += 1;
+            continue;
+        }
         let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
         let byte_width = next_pos - pos;
         let char_width = C::char_len(ch);
@@ -325,6 +336,26 @@ mod tests {
         assert_eq!(loc(&conv, 9), (1, 0));
         // "line2 */" = 8, "\n" = 1 => line 2 starts at offset 18
         assert_eq!(loc(&conv, 18), (2, 0));
+    }
+
+    #[test]
+    fn block_comment_multiline_carriage_return() {
+        let input = "/* line1\rline2 */\rentity e is end;";
+        let conv = utf8_utf16(input);
+        // "/*" = 2, " line1\r" = 7 bytes => line 1 starts at offset 9
+        assert_eq!(loc(&conv, 9), (1, 0));
+        // "line2 */" = 8, "\r" = 1 => line 2 starts at offset 18
+        assert_eq!(loc(&conv, 18), (2, 0));
+    }
+
+    #[test]
+    fn block_comment_multiline_carriage_return_line_feed() {
+        let input = "/* line1\r\nline2 */\r\nentity e is end;";
+        let conv = utf8_utf16(input);
+        // "/*" = 2, " line1\r\n" = 7 bytes => line 1 starts at offset 9
+        assert_eq!(loc(&conv, 10), (1, 0));
+        // "line2 */" = 8, "\r\n" = 1 => line 2 starts at offset 18
+        assert_eq!(loc(&conv, 20), (2, 0));
     }
 
     // Offset clamping

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -225,19 +225,6 @@ where
     for<'a> E::Str<'a>: CharIter,
 {
     match piece {
-        TriviaPiece::LineFeeds(n)
-        | TriviaPiece::CarriageReturns(n)
-        | TriviaPiece::FormFeeds(n)
-        | TriviaPiece::VerticalTabs(n) => {
-            for i in 0..*n {
-                line_starts.push(cursor + i + 1);
-            }
-        }
-        TriviaPiece::CarriageReturnLineFeeds(n) => {
-            for i in 0..*n {
-                line_starts.push(cursor + (i + 1) * 2);
-            }
-        }
         // Note: In theory, `LineComment`s don't need the special newline handling, it's just included here for simplicity.
         // If performance ever becomes a bottleneck, this can be split.
         TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
@@ -249,22 +236,9 @@ where
                 cursor + 2,
             );
         }
-        TriviaPiece::NonBreakingSpaces(n) => {
-            let target_len = C::char_len('\u{00A0}');
-            if target_len != 1 {
-                let line = line_starts.len() - 1;
-                let line_start = line_starts[line];
-                for i in 0..*n {
-                    let abs_offset = cursor + i;
-                    wide_char_lines.entry(line).or_default().push(WideChar {
-                        offset: abs_offset - line_start,
-                        byte_len: 1,
-                        target_len,
-                    });
-                }
-            }
+        other => {
+            record_non_comment_trivia::<C>(other, cursor, line_starts, wide_char_lines);
         }
-        _ => {}
     }
     Ok(())
 }
@@ -277,6 +251,29 @@ fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
 ) where
     for<'a> E::Str<'a>: CharIter,
 {
+    match piece {
+        TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
+            let (encoded, replacements) = c.encode_lossy::<E>();
+            record_str::<C>(
+                encoded,
+                &replacements,
+                line_starts,
+                wide_char_lines,
+                cursor + 2,
+            );
+        }
+        other => {
+            record_non_comment_trivia::<C>(other, cursor, line_starts, wide_char_lines);
+        }
+    }
+}
+
+fn record_non_comment_trivia<C: CharEncoding>(
+    piece: &TriviaPiece,
+    cursor: usize,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut BTreeMap<usize, Vec<WideChar>>,
+) {
     match piece {
         TriviaPiece::LineFeeds(n)
         | TriviaPiece::CarriageReturns(n)
@@ -292,14 +289,7 @@ fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
             }
         }
         TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
-            let (encoded, replacements) = c.encode_lossy::<E>();
-            record_str::<C>(
-                encoded,
-                &replacements,
-                line_starts,
-                wide_char_lines,
-                cursor + 2,
-            );
+            unreachable!("Handled by specific branch");
         }
         TriviaPiece::NonBreakingSpaces(n) => {
             let target_len = C::char_len('\u{00A0}');

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Range};
 
 use crate::{
     fmt::encoding::Encoder,
@@ -21,6 +21,7 @@ pub struct SourceLoc {
     pub col: usize,
 }
 
+#[derive(Debug)]
 struct WideChar {
     // Byte offset relative to line start
     offset: usize,
@@ -148,6 +149,33 @@ impl SourceLocConverter {
             col: target_col,
         }
     }
+
+    /// Convert a compiler-issued byte-offset to a byte-offset under the given character encoding.
+    /// For example, a Latin-1 "ä" character occupies one byte but it occupies two bytes
+    /// using UTF-8. This function correctly returns the beginning of the UTF-8 offset
+    /// (if the encoder was constructed using a UTF-8 char encoding)
+    pub fn convert_byte_offset(&self, offset: usize) -> usize {
+        let mut wide_adapt = 0usize;
+        for (line, wide_chars) in &self.wide_char_lines {
+            let line_start = self.line_starts[*line];
+            for wide in wide_chars {
+                if wide.offset + line_start >= offset + wide_adapt {
+                    break;
+                }
+                wide_adapt = wide_adapt + wide.byte_len;
+            }
+        }
+        offset + wide_adapt as usize
+    }
+
+    pub fn convert_byte_span(&self, span: &Range<usize>) -> Range<usize> {
+        self.convert_byte_offset(span.start)..self.convert_byte_offset(span.end)
+    }
+
+    /// Returns the byte offset of the line at index.
+    pub fn line_start(&self, index: usize) -> usize {
+        self.line_starts[index]
+    }
 }
 
 fn record_text<C: CharEncoding>(
@@ -156,7 +184,7 @@ fn record_text<C: CharEncoding>(
     line_starts: &mut Vec<usize>,
     wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
 ) {
-    record_str::<C>(text, line_starts, wide_char_lines, cursor, text.len());
+    record_str::<C>(text, line_starts, wide_char_lines, cursor);
 }
 
 fn record_piece<E: Encoder, C: CharEncoding>(
@@ -189,8 +217,7 @@ where
                 c.encode::<E>()?,
                 line_starts,
                 wide_char_lines,
-                cursor + 2,
-                c.byte_len(),
+                cursor + 2
             );
         }
         _ => {}
@@ -203,10 +230,10 @@ fn record_str<C: CharEncoding>(
     line_starts: &mut Vec<usize>,
     wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
     cursor: usize,
-    byte_len: usize,
 ) {
     let mut line = line_starts.len() - 1;
     let mut itr = str.iter_chars_indices().peekable();
+    let byte_len = str.byte_count();
     while let Some((pos, ch)) = itr.next() {
         if ch == '\n' {
             line_starts.push(cursor + pos + 1);
@@ -226,7 +253,7 @@ fn record_str<C: CharEncoding>(
         let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
         let byte_width = next_pos - pos;
         let char_width = C::char_len(ch);
-        if byte_width != char_width {
+        if byte_width != 1 || byte_width != char_width {
             let abs_offset = cursor + pos;
             let line_start = line_starts[line];
             wide_char_lines.entry(line).or_default().push(WideChar {
@@ -238,14 +265,30 @@ fn record_str<C: CharEncoding>(
     }
 }
 
+fn check<E: Encoder>(bytes: &[u8]) -> Result<(), E::Err> where for <'a> E::Str<'a> : AsRef<[u8]> + CharIter {
+    let res = E::encode(bytes)?;
+    let byte_len = res.byte_count();
+    if res.as_ref() != bytes {
+        let mut itr = res.iter_chars_indices().peekable();
+        while let Some((pos, el)) = itr.next() {
+            let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
+            let byte_width = next_pos - pos;
+
+            
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fmt::encoding::{Latin1Encoder, Utf8Encoder};
+    use crate::fmt::encoding::{Latin1Encoder, LossyUtf8Encoder, Utf8Encoder};
     use crate::parser::parse;
     use crate::text::char_encoding::{Utf16, Utf32, Utf8};
+    use crate::tokens::TokenStream;
 
-    fn converter<E: Encoder, C: CharEncoding>(input: &str) -> SourceLocConverter
+    fn converter<E: Encoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
     where
         for<'a> E::Str<'a>: CharIter,
         E::Err: std::fmt::Debug,
@@ -411,6 +454,38 @@ mod tests {
         let conv = converter::<Latin1Encoder, Utf16>(input);
         assert_eq!(loc(&conv, 0), (0, 0));
         assert_eq!(loc(&conv, 9), (1, 0));
+    }
+
+    #[test]
+    fn latin1_source_utf8_target_codepoint() {
+        let input: &[u8] = b"use \xE4 foo";
+        let conv = converter::<Latin1Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0);
+        assert_eq!(conv.convert_byte_offset(4), 4);
+        assert_eq!(conv.convert_byte_offset(5), 6);
+    }
+
+    #[test]
+    fn latin1_source_utf8_target_codepoint_twice() {
+        let input: &[u8] = b"use \xE4\xE4 foo";
+        let conv = converter::<Latin1Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0);
+        assert_eq!(conv.convert_byte_offset(4), 4);
+        assert_eq!(conv.convert_byte_offset(5), 6);
+        assert_eq!(conv.convert_byte_offset(6), 8);
+        assert_eq!(conv.convert_byte_offset(7), 9);
+    }
+
+    #[test]
+    fn lossy_utf8_to_utf8() {
+        let input: &[u8] = b"/*\xE4\xE4*/ foo";
+        let conv = converter::<LossyUtf8Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0);
+        assert_eq!(conv.convert_byte_offset(1), 1);
+        assert_eq!(conv.convert_byte_offset(2), 2);
+        assert_eq!(conv.convert_byte_offset(3), 6);
+        assert_eq!(conv.convert_byte_offset(4), 9);
+        assert_eq!(conv.convert_byte_offset(5), 11);
     }
 
     // Multiple wide chars on the same line

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use crate::{
-    fmt::encoding::Encoder,
+    fmt::encoding::{BytePreservingEncoder, Encoder, LossyEncoder, Replacements},
     latin_1::Latin1Str,
     syntax::node::SyntaxNode,
     text::{char_encoding::CharEncoding, char_iter::CharIter},
@@ -74,7 +74,7 @@ impl SourceLocConverter {
     /// `E` determines how comment bytes are decoded into characters.
     /// `C` determines how each character's column width is measured.
     /// Returns `Err` if a comment body cannot be decoded under `E`.
-    pub fn new<E: Encoder, C: CharEncoding>(root: &SyntaxNode) -> Result<SourceLocConverter, E::Err>
+    pub fn new<E: BytePreservingEncoder, C: CharEncoding>(root: &SyntaxNode) -> Result<SourceLocConverter, E::Err>
     where
         for<'a> E::Str<'a>: CharIter,
     {
@@ -100,6 +100,32 @@ impl SourceLocConverter {
             text_len: cursor,
             wide_char_lines,
         })
+    }
+
+    pub fn new_lossy<E: LossyEncoder, C: CharEncoding>(root: &SyntaxNode) -> SourceLocConverter
+    where
+        for<'a> E::Str<'a>: CharIter,
+    {
+        let mut line_starts = vec![0usize];
+        let mut wide_char_lines = HashMap::new();
+        let mut cursor = 0usize;
+
+        let mut tok = root.first_token();
+        while let Some(t) = tok {
+            for piece in t.leading_trivia() {
+                record_piece_lossy::<E, C>(piece, cursor, &mut line_starts, &mut wide_char_lines);
+                cursor += piece.byte_len();
+            }
+            record_text::<C>(t.text(), cursor, &mut line_starts, &mut wide_char_lines);
+            cursor += t.text().len();
+            tok = t.next_token();
+        }
+
+        SourceLocConverter {
+            line_starts,
+            text_len: cursor,
+            wide_char_lines,
+        }
     }
 
     /// Convert a byte offset into a [`SourceLoc`].
@@ -155,17 +181,17 @@ impl SourceLocConverter {
     /// using UTF-8. This function correctly returns the beginning of the UTF-8 offset
     /// (if the encoder was constructed using a UTF-8 char encoding)
     pub fn convert_byte_offset(&self, offset: usize) -> usize {
-        let mut wide_adapt = 0usize;
+        let mut delta = 0usize;
         for (line, wide_chars) in &self.wide_char_lines {
             let line_start = self.line_starts[*line];
             for wide in wide_chars {
-                if wide.offset + line_start >= offset + wide_adapt {
+                if wide.offset + line_start >= offset {
                     break;
                 }
-                wide_adapt = wide_adapt + wide.byte_len;
+                delta += wide.target_len - wide.byte_len;
             }
         }
-        offset + wide_adapt as usize
+        offset + delta
     }
 
     pub fn convert_byte_span(&self, span: &Range<usize>) -> Range<usize> {
@@ -265,19 +291,115 @@ fn record_str<C: CharEncoding>(
     }
 }
 
-fn check<E: Encoder>(bytes: &[u8]) -> Result<(), E::Err> where for <'a> E::Str<'a> : AsRef<[u8]> + CharIter {
-    let res = E::encode(bytes)?;
-    let byte_len = res.byte_count();
-    if res.as_ref() != bytes {
-        let mut itr = res.iter_chars_indices().peekable();
-        while let Some((pos, el)) = itr.next() {
-            let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
-            let byte_width = next_pos - pos;
+fn record_piece_lossy<E: LossyEncoder, C: CharEncoding>(
+    piece: &TriviaPiece,
+    cursor: usize,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+) where
+    for<'a> E::Str<'a>: CharIter,
+{
+    match piece {
+        TriviaPiece::LineFeeds(n)
+        | TriviaPiece::CarriageReturns(n)
+        | TriviaPiece::FormFeeds(n)
+        | TriviaPiece::VerticalTabs(n) => {
+            for i in 0..*n {
+                line_starts.push(cursor + i + 1);
+            }
+        }
+        TriviaPiece::CarriageReturnLineFeeds(n) => {
+            for i in 0..*n {
+                line_starts.push(cursor + (i + 1) * 2);
+            }
+        }
+        TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
+            let (encoded, replacements) = c.encode_lossy::<E>();
+            record_str_with_replacements::<C>(
+                encoded,
+                &replacements,
+                line_starts,
+                wide_char_lines,
+                cursor + 2,
+            );
+        }
+        _ => {}
+    }
+}
 
-            
+fn record_str_with_replacements<C: CharEncoding>(
+    encoded: impl CharIter,
+    replacements: &Replacements,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    cursor: usize,
+) {
+    if replacements.is_empty() {
+        record_str::<C>(encoded, line_starts, wide_char_lines, cursor);
+        return;
+    }
+
+    let mut line = line_starts.len() - 1;
+    let mut itr = encoded.iter_chars_indices().peekable();
+    let byte_len = encoded.byte_count();
+    let entries = replacements.entries();
+    let mut repl_idx = 0;
+    // Accumulated difference between encoded and source positions.
+    // encoded_pos = source_pos + delta
+    let mut delta: usize = 0;
+
+    while let Some((enc_pos, ch)) = itr.next() {
+        let source_pos = enc_pos - delta;
+
+        if ch == '\n' {
+            line_starts.push(cursor + source_pos + 1);
+            line += 1;
+            continue;
+        }
+        if ch == '\r' {
+            if itr.peek().is_some_and(|(_, ch)| *ch == '\n') {
+                let _ = itr.next();
+                line_starts.push(cursor + source_pos + 2);
+            } else {
+                line_starts.push(cursor + source_pos + 1);
+            }
+            line += 1;
+            continue;
+        }
+
+        let enc_next = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
+        let enc_byte_width = enc_next - enc_pos;
+        let target_width = C::char_len(ch);
+
+        let at_replacement = repl_idx < entries.len()
+            && source_pos == entries[repl_idx].source_offset;
+
+        if at_replacement {
+            let r = &entries[repl_idx];
+            let source_byte_width = r.source_bytes;
+            if source_byte_width != target_width {
+                let abs_offset = cursor + source_pos;
+                let line_start = line_starts[line];
+                wide_char_lines.entry(line).or_default().push(WideChar {
+                    offset: abs_offset - line_start,
+                    byte_len: source_byte_width,
+                    target_len: target_width,
+                });
+            }
+            delta += r.target_bytes - r.source_bytes;
+            repl_idx += 1;
+        } else {
+            if enc_byte_width != 1 || enc_byte_width != target_width {
+                let abs_offset = cursor + source_pos;
+                let line_start = line_starts[line];
+                wide_char_lines.entry(line).or_default().push(WideChar {
+                    offset: abs_offset - line_start,
+                    byte_len: enc_byte_width,
+                    target_len: target_width,
+                });
+            }
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -288,13 +410,21 @@ mod tests {
     use crate::text::char_encoding::{Utf16, Utf32, Utf8};
     use crate::tokens::TokenStream;
 
-    fn converter<E: Encoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
+    fn converter<E: BytePreservingEncoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
     where
         for<'a> E::Str<'a>: CharIter,
         E::Err: std::fmt::Debug,
     {
         let (design_file, _) = parse(input);
         SourceLocConverter::new::<E, C>(&design_file.0).unwrap()
+    }
+
+    fn lossy_converter<E: LossyEncoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
+    where
+        for<'a> E::Str<'a>: CharIter
+    {
+        let (design_file, _) = parse(input);
+        SourceLocConverter::new_lossy::<E, C>(&design_file.0)
     }
 
     fn utf8_utf16(input: &str) -> SourceLocConverter {
@@ -458,34 +588,42 @@ mod tests {
 
     #[test]
     fn latin1_source_utf8_target_codepoint() {
-        let input: &[u8] = b"use \xE4 foo";
+        // \xE4 = Latin-1 'ä' (1 byte source, 2 bytes UTF-8 target)
+        // Layout: "--" (2) + "\xE4" (1) + "\n" (1) + "entity e is end;" (16)
+        let input: &[u8] = b"--\xE4\nentity e is end;";
         let conv = converter::<Latin1Encoder, Utf8>(input);
         assert_eq!(conv.convert_byte_offset(0), 0);
-        assert_eq!(conv.convert_byte_offset(4), 4);
-        assert_eq!(conv.convert_byte_offset(5), 6);
+        assert_eq!(conv.convert_byte_offset(2), 2); // start of ä
+        assert_eq!(conv.convert_byte_offset(3), 4); // \n (after ä: delta +1)
+        assert_eq!(conv.convert_byte_offset(4), 5); // 'e' in entity
     }
 
     #[test]
     fn latin1_source_utf8_target_codepoint_twice() {
-        let input: &[u8] = b"use \xE4\xE4 foo";
+        // Two consecutive \xE4 in a line comment
+        // Layout: "--" (2) + "\xE4\xE4" (2) + "\n" (1) + "entity e is end;" (16)
+        let input: &[u8] = b"--\xE4\xE4\nentity e is end;";
         let conv = converter::<Latin1Encoder, Utf8>(input);
         assert_eq!(conv.convert_byte_offset(0), 0);
-        assert_eq!(conv.convert_byte_offset(4), 4);
-        assert_eq!(conv.convert_byte_offset(5), 6);
-        assert_eq!(conv.convert_byte_offset(6), 8);
-        assert_eq!(conv.convert_byte_offset(7), 9);
+        assert_eq!(conv.convert_byte_offset(2), 2); // start of first ä
+        assert_eq!(conv.convert_byte_offset(3), 4); // start of second ä (delta +1)
+        assert_eq!(conv.convert_byte_offset(4), 6); // \n (delta +2)
+        assert_eq!(conv.convert_byte_offset(5), 7); // 'e' in entity
     }
 
     #[test]
     fn lossy_utf8_to_utf8() {
-        let input: &[u8] = b"/*\xE4\xE4*/ foo";
-        let conv = converter::<LossyUtf8Encoder, Utf8>(input);
-        assert_eq!(conv.convert_byte_offset(0), 0);
-        assert_eq!(conv.convert_byte_offset(1), 1);
-        assert_eq!(conv.convert_byte_offset(2), 2);
-        assert_eq!(conv.convert_byte_offset(3), 6);
-        assert_eq!(conv.convert_byte_offset(4), 9);
-        assert_eq!(conv.convert_byte_offset(5), 11);
+        // Two invalid UTF-8 bytes in a block comment, each replaced with U+FFFD (3 bytes)
+        // Layout: "/*" (2) + "\xE4\xE4" (2) + "*/" (2) + "entity e is end;" (16)
+        let input: &[u8] = b"/*\xE4\xE4*/entity e is end;";
+        let conv = lossy_converter::<LossyUtf8Encoder, Utf8>(input);
+        assert_eq!(conv.convert_byte_offset(0), 0); // '/'
+        assert_eq!(conv.convert_byte_offset(1), 1); // '*'
+        assert_eq!(conv.convert_byte_offset(2), 2); // first \xE4 → FFFD start
+        assert_eq!(conv.convert_byte_offset(3), 5); // second \xE4 → FFFD start (delta +2)
+        assert_eq!(conv.convert_byte_offset(4), 8); // '*' of */ (delta +4)
+        assert_eq!(conv.convert_byte_offset(5), 9); // '/' of */
+        assert_eq!(conv.convert_byte_offset(6), 10); // 'e' in entity
     }
 
     // Multiple wide chars on the same line

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,0 +1,224 @@
+use std::collections::HashMap;
+
+use crate::{
+    fmt::encoding::Encoder, latin_1::Latin1Str, syntax::node::SyntaxNode, text::{char_encoding::CharEncoding, char_iter::CharIter}, tokens::TriviaPiece
+};
+
+/// A zero-based `(line, column)` position in source text.
+///
+/// The column is expressed in the target encoding's code units, not bytes.
+/// For example, with [`super::char_encoding::Utf16`] as the target, `col` counts
+/// UTF-16 code units — matching what LSP clients expect.
+pub struct SourceLoc {
+    /// Zero-based line number.
+    pub line: usize,
+    /// Zero-based column in target-encoding code units.
+    pub col: usize,
+}
+
+struct WideChar {
+    // Byte offset relative to line start
+    offset: usize,
+    // how many bytes this char occupies in source
+    byte_len: usize,
+    // how many units in the target encoding
+    target_len: usize,
+}
+
+impl WideChar {
+    fn end(&self) -> usize {
+        self.offset + self.byte_len
+    }
+}
+
+/// Translates byte offsets in a syntax tree to [`SourceLoc`] positions.
+///
+/// Built once from a [`SyntaxNode`] root, it indexes line boundaries and
+/// characters whose byte width differs from their target-encoding width.
+/// Lookups are O(log lines + wide chars on that line).
+///
+/// # Type parameters (on [`Self::new`])
+///
+/// - `E`: [`Encoder`] — the source encoding used to interpret comment bytes
+///   (e.g., [`Utf8Encoder`](crate::fmt::encoding::Utf8Encoder) or
+///   [`Latin1Encoder`](crate::fmt::encoding::Latin1Encoder)).
+/// - `C`: [`CharEncoding`] — the target encoding for column measurement
+///   (e.g., [`Utf16`](super::char_encoding::Utf16) for LSP).
+///
+/// # Example
+///
+/// ```ignore
+/// use vhdl_syntax::text::source_loc::SourceLocConverter;
+/// use vhdl_syntax::text::char_encoding::Utf16;
+/// use vhdl_syntax::fmt::encoding::Utf8Encoder;
+///
+/// let converter = SourceLocConverter::new::<Utf8Encoder, Utf16>(&root).unwrap();
+/// let loc = converter.source_loc(42);
+/// // loc.line and loc.col are zero-based, with col in UTF-16 code units.
+/// ```
+pub struct SourceLocConverter {
+    line_starts: Vec<usize>,
+    text_len: usize,
+    wide_char_lines: HashMap<usize, Vec<WideChar>>,
+}
+
+impl SourceLocConverter {
+    /// Build the index by walking all tokens and trivia in the tree.
+    ///
+    /// `E` determines how comment bytes are decoded into characters.
+    /// `C` determines how each character's column width is measured.
+    /// Returns `Err` if a comment body cannot be decoded under `E`.
+    pub fn new<E: Encoder, C: CharEncoding>(root: &SyntaxNode) -> Result<SourceLocConverter, E::Err>
+    where
+        for<'a> E::Str<'a>: CharIter,
+    {
+        let mut line_starts = vec![0usize];
+        let mut wide_char_lines = HashMap::new();
+        let mut cursor = 0usize;
+
+        let mut tok = root.first_token();
+        while let Some(t) = tok {
+            for piece in t.leading_trivia() {
+                record_piece::<E, C>(piece, cursor, &mut line_starts, &mut wide_char_lines)?;
+                cursor += piece.byte_len();
+            }
+            // Text could contain newlines for unterminated inputs or characters that are multiple byte-offsets in the target encoding.
+            // Record it as well
+            record_text::<C>(t.text(), cursor, &mut line_starts, &mut wide_char_lines);
+            cursor += t.text().len();
+            tok = t.next_token();
+        }
+
+        Ok(SourceLocConverter {
+            line_starts,
+            text_len: cursor,
+            wide_char_lines,
+        })
+    }
+
+    /// Convert a byte offset into a [`SourceLoc`].
+    ///
+    /// Offsets beyond the end of the text are clamped. An offset that falls
+    /// inside a multi-byte character is snapped to the character's start.
+    pub fn source_loc(&self, offset: usize) -> SourceLoc {
+        let offset = offset.min(self.text_len);
+
+        let i = match self.line_starts.binary_search(&offset) {
+            Ok(i) => i,
+            Err(i) => i - 1,
+        };
+        let line_start = self.line_starts[i];
+        let byte_col = offset - line_start;
+
+        let mut target_col: usize = 0;
+        let mut prev_end: usize = 0;
+
+        if let Some(wides) = self.wide_char_lines.get(&i) {
+            for wide in wides {
+                if wide.offset >= byte_col {
+                    break;
+                }
+                // non-wide bytes between previous wide char and this one: 1:1 mapping
+                target_col += wide.offset - prev_end;
+
+                if wide.end() <= byte_col {
+                    target_col += wide.target_len;
+                    prev_end = wide.end();
+                } else {
+                    // offset falls inside a multi-byte character; clamp to
+                    // the character's start, matching LSP convention.
+                    return SourceLoc {
+                        line: i,
+                        col: target_col,
+                    };
+                }
+            }
+        }
+
+        // remaining non-wide bytes after the last wide char
+        target_col += byte_col - prev_end;
+
+        SourceLoc {
+            line: i,
+            col: target_col,
+        }
+    }
+}
+
+fn record_text<C: CharEncoding>(
+    text: &Latin1Str,
+    cursor: usize,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+) {
+    record_str::<C>(text, line_starts, wide_char_lines, cursor, text.len());
+}
+
+fn record_piece<E: Encoder, C: CharEncoding>(
+    piece: &TriviaPiece,
+    cursor: usize,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+) -> Result<(), E::Err>
+where
+    for<'a> E::Str<'a>: CharIter,
+{
+    match piece {
+        TriviaPiece::LineFeeds(n)
+        | TriviaPiece::CarriageReturns(n)
+        | TriviaPiece::FormFeeds(n)
+        | TriviaPiece::VerticalTabs(n) => {
+            for i in 0..*n {
+                line_starts.push(cursor + i + 1);
+            }
+        }
+        TriviaPiece::CarriageReturnLineFeeds(n) => {
+            for i in 0..*n {
+                line_starts.push(cursor + (i + 1) * 2);
+            }
+        }
+        // Note: In theory, `LineComment`s don't need the special newline handling, it's just included here for simplicity.
+        // If performance ever becomes a bottleneck, this can be split.
+        TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
+            record_str::<C>(
+                c.encode::<E>()?,
+                line_starts,
+                wide_char_lines,
+                cursor + 2,
+                c.byte_len(),
+            );
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn record_str<C: CharEncoding>(
+    str: impl CharIter,
+    line_starts: &mut Vec<usize>,
+    wide_char_lines: &mut HashMap<usize, Vec<WideChar>>,
+    cursor: usize,
+    byte_len: usize,
+) {
+    let mut line = line_starts.len() - 1;
+    let mut itr = str.iter_chars_indices().peekable();
+    while let Some((pos, ch)) = itr.next() {
+        if ch == '\n' {
+            line_starts.push(cursor + pos + 1);
+            line += 1;
+            continue;
+        }
+        let next_pos = itr.peek().map(|(p, _)| *p).unwrap_or(byte_len);
+        let byte_width = next_pos - pos;
+        let char_width = C::char_len(ch);
+        if byte_width != char_width {
+            let abs_offset = cursor + pos;
+            let line_start = line_starts[line];
+            wide_char_lines.entry(line).or_default().push(WideChar {
+                offset: abs_offset - line_start,
+                byte_len: byte_width,
+                target_len: char_width,
+            });
+        }
+    }
+}

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -74,7 +74,9 @@ impl SourceLocConverter {
     /// `E` determines how comment bytes are decoded into characters.
     /// `C` determines how each character's column width is measured.
     /// Returns `Err` if a comment body cannot be decoded under `E`.
-    pub fn new<E: BytePreservingEncoder, C: CharEncoding>(root: &SyntaxNode) -> Result<SourceLocConverter, E::Err>
+    pub fn new<E: BytePreservingEncoder, C: CharEncoding>(
+        root: &SyntaxNode,
+    ) -> Result<SourceLocConverter, E::Err>
     where
         for<'a> E::Str<'a>: CharIter,
     {
@@ -239,12 +241,7 @@ where
         // Note: In theory, `LineComment`s don't need the special newline handling, it's just included here for simplicity.
         // If performance ever becomes a bottleneck, this can be split.
         TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
-            record_str::<C>(
-                c.encode::<E>()?,
-                line_starts,
-                wide_char_lines,
-                cursor + 2
-            );
+            record_str::<C>(c.encode::<E>()?, line_starts, wide_char_lines, cursor + 2);
         }
         _ => {}
     }
@@ -371,8 +368,8 @@ fn record_str_with_replacements<C: CharEncoding>(
         let enc_byte_width = enc_next - enc_pos;
         let target_width = C::char_len(ch);
 
-        let at_replacement = repl_idx < entries.len()
-            && source_pos == entries[repl_idx].source_offset;
+        let at_replacement =
+            repl_idx < entries.len() && source_pos == entries[repl_idx].source_offset;
 
         if at_replacement {
             let r = &entries[repl_idx];
@@ -410,7 +407,9 @@ mod tests {
     use crate::text::char_encoding::{Utf16, Utf32, Utf8};
     use crate::tokens::TokenStream;
 
-    fn converter<E: BytePreservingEncoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
+    fn converter<E: BytePreservingEncoder, C: CharEncoding>(
+        input: impl Into<TokenStream>,
+    ) -> SourceLocConverter
     where
         for<'a> E::Str<'a>: CharIter,
         E::Err: std::fmt::Debug,
@@ -419,9 +418,11 @@ mod tests {
         SourceLocConverter::new::<E, C>(&design_file.0).unwrap()
     }
 
-    fn lossy_converter<E: LossyEncoder, C: CharEncoding>(input: impl Into<TokenStream>) -> SourceLocConverter
+    fn lossy_converter<E: LossyEncoder, C: CharEncoding>(
+        input: impl Into<TokenStream>,
+    ) -> SourceLocConverter
     where
-        for<'a> E::Str<'a>: CharIter
+        for<'a> E::Str<'a>: CharIter,
     {
         let (design_file, _) = parse(input);
         SourceLocConverter::new_lossy::<E, C>(&design_file.0)

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::Range};
+use std::{collections::BTreeMap, convert::Infallible, ops::Range};
 
 use crate::{
     fmt::encoding::{BytePreservingEncoder, Encoder, LossyEncoder, Replacement},
@@ -69,17 +69,15 @@ pub struct SourceLocConverter {
 }
 
 impl SourceLocConverter {
-    /// Build the index by walking all tokens and trivia in the tree.
-    ///
-    /// `E` determines how comment bytes are decoded into characters.
-    /// `C` determines how each character's column width is measured.
-    /// Returns `Err` if a comment body cannot be decoded under `E`.
-    pub fn new<E: BytePreservingEncoder, C: CharEncoding>(
+    fn build<C: CharEncoding, Err>(
         root: &SyntaxNode,
-    ) -> Result<SourceLocConverter, E::Err>
-    where
-        for<'a> E::Str<'a>: CharIter,
-    {
+        mut handle_piece: impl FnMut(
+            &TriviaPiece,
+            usize,
+            &mut Vec<usize>,
+            &mut BTreeMap<usize, Vec<WideChar>>,
+        ) -> Result<(), Err>,
+    ) -> Result<SourceLocConverter, Err> {
         let mut line_starts = vec![0usize];
         let mut wide_char_lines = BTreeMap::new();
         let mut cursor = 0usize;
@@ -87,11 +85,9 @@ impl SourceLocConverter {
         let mut tok = root.first_token();
         while let Some(t) = tok {
             for piece in t.leading_trivia() {
-                record_piece::<E, C>(piece, cursor, &mut line_starts, &mut wide_char_lines)?;
+                handle_piece(piece, cursor, &mut line_starts, &mut wide_char_lines)?;
                 cursor += piece.byte_len();
             }
-            // Text could contain newlines for unterminated inputs or characters that are multiple byte-offsets in the target encoding.
-            // Record it as well
             record_text::<C>(t.text(), cursor, &mut line_starts, &mut wide_char_lines);
             cursor += t.text().len();
             tok = t.next_token();
@@ -104,30 +100,31 @@ impl SourceLocConverter {
         })
     }
 
+    /// Build the index by walking all tokens and trivia in the tree.
+    ///
+    /// `E` determines how comment bytes are decoded into characters.
+    /// `C` determines how each character's column width is measured.
+    /// Returns `Err` if a comment body cannot be decoded under `E`.
+    pub fn new<E: BytePreservingEncoder, C: CharEncoding>(
+        root: &SyntaxNode,
+    ) -> Result<SourceLocConverter, E::Err>
+    where
+        for<'a> E::Str<'a>: CharIter,
+    {
+        Self::build::<C, _>(root, |piece, cursor, line_starts, wide_char_lines| {
+            record_piece::<E, C>(piece, cursor, line_starts, wide_char_lines)
+        })
+    }
+
     pub fn new_lossy<E: LossyEncoder, C: CharEncoding>(root: &SyntaxNode) -> SourceLocConverter
     where
         for<'a> E::Str<'a>: CharIter,
     {
-        let mut line_starts = vec![0usize];
-        let mut wide_char_lines = BTreeMap::new();
-        let mut cursor = 0usize;
-
-        let mut tok = root.first_token();
-        while let Some(t) = tok {
-            for piece in t.leading_trivia() {
-                record_piece_lossy::<E, C>(piece, cursor, &mut line_starts, &mut wide_char_lines);
-                cursor += piece.byte_len();
-            }
-            record_text::<C>(t.text(), cursor, &mut line_starts, &mut wide_char_lines);
-            cursor += t.text().len();
-            tok = t.next_token();
-        }
-
-        SourceLocConverter {
-            line_starts,
-            text_len: cursor,
-            wide_char_lines,
-        }
+        Self::build::<C, Infallible>(root, |piece, cursor, line_starts, wide_char_lines| {
+            record_piece_lossy::<E, C>(piece, cursor, line_starts, wide_char_lines);
+            Ok(())
+        })
+        .unwrap()
     }
 
     /// Convert a byte offset into a [`SourceLoc`].

--- a/vhdl_syntax/src/text/source_loc.rs
+++ b/vhdl_syntax/src/text/source_loc.rs
@@ -288,7 +288,7 @@ fn record_non_comment_trivia<C: CharEncoding>(
                 line_starts.push(cursor + (i + 1) * 2);
             }
         }
-        TriviaPiece::BlockComment(c) | TriviaPiece::LineComment(c) => {
+        TriviaPiece::BlockComment(_) | TriviaPiece::LineComment(_) => {
             unreachable!("Handled by specific branch");
         }
         TriviaPiece::NonBreakingSpaces(n) => {


### PR DESCRIPTION
Branched out from #471

This PR adds a new mod: `vhdl_syntax/text` for conversions between byte-offsets and source location as required by a linter or LSP.

The converter can be used with any comment encoding and any target encoding (LSP wants UTF-16; linters likely want UTF-8).