### PR TITLE
Add goto_type_definition and reload the project if a file was created/renamed/deleted

### DIFF
--- a/vhdl_lang/src/analysis/root.rs
+++ b/vhdl_lang/src/analysis/root.rs
@@ -457,6 +457,15 @@ impl DesignRoot {
         }
     }
 
+    pub fn find_type_definition_of<'a>(&'a self, decl: EntRef<'a>) -> Option<EntRef<'a>> {
+        match decl.kind() {
+            AnyEntKind::Object(obj) => Some(obj.subtype.type_mark.inner()),
+            AnyEntKind::File(file) => Some(file.type_mark.inner()),
+            AnyEntKind::ElementDeclaration(elem) => Some(elem.type_mark.inner()),
+            _ => None,
+        }
+    }
+
     pub fn find_implementation<'a>(&'a self, ent: EntRef<'a>) -> Vec<EntRef<'a>> {
         if let Designator::Identifier(ident) = ent.designator() {
             if let Some(library_name) = ent.library_name() {

--- a/vhdl_lang/src/analysis/tests/hierarchy.rs
+++ b/vhdl_lang/src/analysis/tests/hierarchy.rs
@@ -327,6 +327,42 @@ end architecture;
 }
 
 #[test]
+fn test_find_type_definition() {
+    let mut builder = LibraryBuilder::new();
+    let code = builder.code(
+        "libname",
+        "
+package pack is
+    type test_type is (idle);
+end package pack;
+
+use work.pack.all;
+
+entity e is
+end entity e;
+
+architecture a of e is
+    signal test_signal : test_type;
+begin
+
+end architecture a;
+      ",
+    );
+
+    let (root, diagnostics) = builder.get_analyzed_root();
+    check_no_diagnostics(&diagnostics);
+
+    let t = root
+        .search_reference(code.source(), code.s1("test_type ").start())
+        .unwrap();
+    let signal = root
+        .search_reference(code.source(), code.s1("test_signal ").start())
+        .unwrap();
+
+    assert_eq!(root.find_type_definition_of(signal), Some(t));
+}
+
+#[test]
 fn exit_and_next_outside_of_loop() {
     let mut builder = LibraryBuilder::new();
     let code = builder.code(

--- a/vhdl_lang/src/project.rs
+++ b/vhdl_lang/src/project.rs
@@ -282,6 +282,11 @@ impl Project {
         Some(ent.declaration())
     }
 
+    pub fn find_type_definition(&self, source: &Source, cursor: Position) -> Option<EntRef<'_>> {
+        let ent = self.root.search_reference(source, cursor)?;
+        self.root.find_type_definition_of(ent)
+    }
+
     pub fn item_at_cursor(
         &self,
         source: &Source,

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -150,6 +150,14 @@ impl ConnectionRpcChannel {
             }
             Err(request) => request,
         };
+        let request = match extract::<request::GotoTypeDefinition>(request) {
+            Ok((id, params)) => {
+                let result = server.text_document_type_definition(&params.text_document_position_params);
+                self.send_response(lsp_server::Response::new_ok(id, result));
+                return;
+            }
+            Err(request) => request,
+        };
         let request = match extract::<request::GotoImplementation>(request) {
             Ok((id, params)) => {
                 let result =

--- a/vhdl_ls/src/stdio_server.rs
+++ b/vhdl_ls/src/stdio_server.rs
@@ -152,7 +152,8 @@ impl ConnectionRpcChannel {
         };
         let request = match extract::<request::GotoTypeDefinition>(request) {
             Ok((id, params)) => {
-                let result = server.text_document_type_definition(&params.text_document_position_params);
+                let result =
+                    server.text_document_type_definition(&params.text_document_position_params);
                 self.send_response(lsp_server::Response::new_ok(id, result));
                 return;
             }
@@ -295,6 +296,18 @@ impl ConnectionRpcChannel {
         // workspace.didChangeWatchedFiles
         let notification = match extract::<notification::DidChangeWatchedFiles>(notification) {
             Ok(params) => return server.workspace_did_change_watched_files(&params),
+            Err(notification) => notification,
+        };
+        let notification = match extract::<notification::DidCreateFiles>(notification) {
+            Ok(params) => return server.workspace_did_create_files(&params),
+            Err(notification) => notification,
+        };
+        let notification = match extract::<notification::DidRenameFiles>(notification) {
+            Ok(params) => return server.workspace_did_rename_files(&params),
+            Err(notification) => notification,
+        };
+        let notification = match extract::<notification::DidDeleteFiles>(notification) {
+            Ok(params) => return server.workspace_did_delete_files(&params),
             Err(notification) => notification,
         };
 

--- a/vhdl_ls/src/vhdl_server/lifecycle.rs
+++ b/vhdl_ls/src/vhdl_server/lifecycle.rs
@@ -59,6 +59,16 @@ impl VHDLServer {
         self.init_params = Some(init_params);
         let trigger_chars: Vec<String> = r"'.".chars().map(|ch| ch.to_string()).collect();
 
+        let file_ops = Some(FileOperationRegistrationOptions {
+            filters: vec![FileOperationFilter {
+                pattern: FileOperationPattern {
+                    glob: "**/*.{vhd,vhdl}".into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        });
+
         let capabilities = ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(
                 TextDocumentSyncKind::INCREMENTAL,
@@ -92,6 +102,15 @@ impl VHDLServer {
                 trigger_characters: Some(trigger_chars),
                 completion_item: Some(CompletionOptionsCompletionItem {
                     label_details_support: Some(true),
+                }),
+                ..Default::default()
+            }),
+            workspace: Some(WorkspaceServerCapabilities {
+                file_operations: Some(WorkspaceFileOperationsServerCapabilities {
+                    did_create: file_ops.clone(),
+                    did_rename: file_ops.clone(),
+                    did_delete: file_ops.clone(),
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),

--- a/vhdl_ls/src/vhdl_server/lifecycle.rs
+++ b/vhdl_ls/src/vhdl_server/lifecycle.rs
@@ -65,6 +65,7 @@ impl VHDLServer {
             )),
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
+            type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),
             implementation_provider: Some(ImplementationProviderCapability::Simple(true)),

--- a/vhdl_ls/src/vhdl_server/text_document.rs
+++ b/vhdl_ls/src/vhdl_server/text_document.rs
@@ -83,6 +83,20 @@ impl VHDLServer {
         Some(srcpos_to_location(ent.decl_pos()?))
     }
 
+    pub fn text_document_type_definition(
+        &mut self,
+        params: &TextDocumentPositionParams,
+    ) -> Option<Location> {
+        let source = self
+            .project
+            .get_source(&uri_to_file_name(&params.text_document.uri))?;
+
+        let ent = self
+            .project
+            .find_type_definition(&source, from_lsp_pos(params.position))?;
+        Some(srcpos_to_location(ent.decl_pos()?))
+    }
+
     pub fn text_document_implementation(
         &mut self,
         params: &TextDocumentPositionParams,

--- a/vhdl_ls/src/vhdl_server/workspace.rs
+++ b/vhdl_ls/src/vhdl_server/workspace.rs
@@ -1,8 +1,8 @@
 use crate::vhdl_server::{srcpos_to_location, to_symbol_kind, uri_to_file_name, VHDLServer};
 use fuzzy_matcher::FuzzyMatcher;
 use lsp_types::{
-    DidChangeWatchedFilesParams, OneOf, WorkspaceSymbol, WorkspaceSymbolParams,
-    WorkspaceSymbolResponse,
+    CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams, OneOf, RenameFilesParams,
+    WorkspaceSymbol, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -20,13 +20,7 @@ impl VHDLServer {
                 self.message(Message::log(
                     "Configuration file has changed, reloading project...",
                 ));
-                let config = self.load_config();
-                self.severity_map = *config.severities();
-                self.case_transform = config.preferred_case();
-
-                self.project
-                    .update_config(config, &mut self.message_filter());
-                self.publish_diagnostics();
+                self.reload_project();
             }
         }
     }
@@ -108,5 +102,42 @@ impl VHDLServer {
             .rev()
             .map(|wsws| wsws.symbol)
             .collect()
+    }
+
+    fn reload_project(&mut self) {
+        let config = self.load_config();
+        self.severity_map = *config.severities();
+        self.case_transform = config.preferred_case();
+
+        self.project
+            .update_config(config, &mut self.message_filter());
+        self.publish_diagnostics();
+    }
+
+    pub fn workspace_did_create_files(&mut self, params: &CreateFilesParams) {
+        self.message(Message::log(format!(
+            "Created file {:?}, reloading project",
+            params.files
+        )));
+
+        self.reload_project();
+    }
+
+    pub fn workspace_did_rename_files(&mut self, params: &RenameFilesParams) {
+        self.message(Message::log(format!(
+            "Renamed files: {:?}, reloading project",
+            params.files
+        )));
+
+        self.reload_project();
+    }
+
+    pub fn workspace_did_delete_files(&mut self, params: &DeleteFilesParams) {
+        self.message(Message::log(format!(
+            "Deleted files: {:?}, reloading project",
+            params.files
+        )));
+
+        self.reload_project();
     }
 }


### PR DESCRIPTION
When using vhdl_ls I came across a few issues that should be fixed with this PR:
- goto_type_definition support: allow to go from a name/selected name to go directly to the type of the signal or variable
- handling Did{Rename,Create,Delete}File so that these events cause a reload of the project, so adding or renaming of files does not require a restart of the language server to have the diagnostics working in the new file