### PR TITLE
Thread flexing errors through the parser

### DIFF
--- a/vhdl_syntax/src/parser/error.rs
+++ b/vhdl_syntax/src/parser/error.rs
@@ -6,7 +6,8 @@
 
 use std::ops::Range;
 
-use crate::tokens::TokenKind;
+use crate::tokens::tokenizer::{LexErr, LexErrKind, LexErrPos, UnterminatedKind};
+use crate::tokens::{Token, TokenKind};
 
 pub type Span = Range<usize>;
 
@@ -17,6 +18,8 @@ pub enum SyntaxErrKind {
     Expected(Box<[TokenKind]>),
     /// A token was seen that was not expected in some context
     Unexpected(TokenKind),
+    /// A token or error that was unterminated
+    Unterminated(UnterminatedKind),
 }
 
 /// Syntax error that may occur when parsing a VHDL source file
@@ -46,5 +49,91 @@ impl SyntaxErr {
     /// The error kind that occured
     pub fn err(&self) -> &SyntaxErrKind {
         &self.error
+    }
+
+    /// Convert a lexer error into a [`SyntaxErr`]
+    pub fn from_lex_err(err: LexErr, token: &Token, token_start: usize) -> SyntaxErr {
+        let trivia = token.leading_trivia();
+        let span = match err.pos {
+            LexErrPos::Token => {
+                // `token.byte_len()` includes the leading trivia, so use `text_len()`
+                // for the width of the token itself.
+                let start = token_start + trivia.byte_len();
+                start..start + token.text_len()
+            }
+            LexErrPos::Trivia(index) => {
+                // Byte offset of the erroring piece is the sum of all pieces before it.
+                let offset: usize = trivia[..index].iter().map(|piece| piece.byte_len()).sum();
+                let start = token_start + offset;
+                start..start + trivia[index].byte_len()
+            }
+        };
+
+        let kind = match err.err {
+            LexErrKind::Unterminated(kind) => SyntaxErrKind::Unterminated(kind),
+            LexErrKind::IllegalInput => SyntaxErrKind::Unexpected(TokenKind::Unknown),
+        };
+
+        SyntaxErr::new(span, kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokens::tokenizer::Tokenize;
+
+    /// Returns the first token that carries a lexer error, together with that error.
+    fn first_lex_err(input: &str) -> (Token, LexErr) {
+        input
+            .tokenize()
+            .find_map(|(tok, err)| err.map(|err| (tok, err)))
+            .expect("expected a lexer error")
+    }
+
+    #[test]
+    fn illegal_input_maps_to_unexpected_unknown_at_token() {
+        // Two leading spaces (trivia), then the illegal `$`.
+        let (tok, err) = first_lex_err("  $");
+        let syntax_err = SyntaxErr::from_lex_err(err, &tok, 0);
+        assert_eq!(*syntax_err.span(), 2..3);
+        assert_eq!(
+            *syntax_err.err(),
+            SyntaxErrKind::Unexpected(TokenKind::Unknown)
+        );
+    }
+
+    #[test]
+    fn unterminated_string_maps_at_token() {
+        // One leading space, then the unterminated string literal `"abc`.
+        let (tok, err) = first_lex_err(" \"abc");
+        let syntax_err = SyntaxErr::from_lex_err(err, &tok, 0);
+        assert_eq!(*syntax_err.span(), 1..5);
+        assert_eq!(
+            *syntax_err.err(),
+            SyntaxErrKind::Unterminated(UnterminatedKind::StringLiteral)
+        );
+    }
+
+    #[test]
+    fn unterminated_block_comment_span_skips_leading_trivia() {
+        // Regression: two spaces precede the unterminated block comment (which is
+        // leading trivia of the EOF token), so the span must start at byte 2, not 0.
+        let (tok, err) = first_lex_err("  /* unterminated");
+        let syntax_err = SyntaxErr::from_lex_err(err, &tok, 0);
+        assert_eq!(syntax_err.span().start, 2);
+        assert_eq!(
+            *syntax_err.err(),
+            SyntaxErrKind::Unterminated(UnterminatedKind::BlockComment)
+        );
+    }
+
+    #[test]
+    fn token_start_offset_is_applied() {
+        // The same error, but the token does not start at the beginning of the
+        // source: the resolved span must be shifted by `token_start`.
+        let (tok, err) = first_lex_err(" \"abc");
+        let syntax_err = SyntaxErr::from_lex_err(err, &tok, 10);
+        assert_eq!(*syntax_err.span(), 11..15);
     }
 }

--- a/vhdl_syntax/src/parser/mod.rs
+++ b/vhdl_syntax/src/parser/mod.rs
@@ -26,7 +26,7 @@ pub mod productions;
 pub struct Parser {
     token_stream: TokenStream,
     builder: builder::NodeBuilder,
-    diagnostics: Vec<error::SyntaxErr>,
+    errors: Vec<error::SyntaxErr>,
     unexpected_eof: bool,
     standard: VHDLStandard,
 }
@@ -36,7 +36,7 @@ impl Parser {
         Parser {
             token_stream,
             builder: builder::NodeBuilder::new(),
-            diagnostics: Vec::default(),
+            errors: Vec::default(),
             unexpected_eof: false,
             standard,
         }

--- a/vhdl_syntax/src/parser/util.rs
+++ b/vhdl_syntax/src/parser/util.rs
@@ -9,7 +9,8 @@ use crate::parser::error::{SyntaxErr, SyntaxErrKind};
 use crate::parser::Parser;
 use crate::syntax::green::GreenNode;
 use crate::syntax::node_kind::NodeKind;
-use crate::tokens::{Keyword, TokenKind};
+use crate::tokens::tokenizer::LexErr;
+use crate::tokens::{Keyword, Token, TokenKind};
 
 /// Allows match-style syntax for tokens.
 /// This function does not consume the next token.
@@ -72,8 +73,17 @@ pub enum LookaheadError {
 }
 
 impl Parser {
+    fn push_opt_lex_err(&mut self, err: Option<LexErr>, token: &Token, token_start: usize) {
+        if let Some(err) = err {
+            self.errors
+                .push(SyntaxErr::from_lex_err(err, token, token_start));
+        }
+    }
+
     pub(crate) fn skip(&mut self) {
-        if let Some(token) = self.token_stream.next() {
+        let start = self.builder.current_pos();
+        if let Some((token, err)) = self.token_stream.next() {
+            self.push_opt_lex_err(err, &token, start);
             self.builder.push(token);
         }
     }
@@ -92,7 +102,9 @@ impl Parser {
     }
 
     pub(crate) fn expect_token(&mut self, kind: TokenKind) {
-        if let Some(token) = self.token_stream.next_if(|token| token.kind() == kind) {
+        let start = self.builder.current_pos();
+        if let Some((token, err)) = self.token_stream.next_if(|token| token.kind() == kind) {
+            self.push_opt_lex_err(err, &token, start);
             self.builder.push(token);
             return;
         }
@@ -153,7 +165,9 @@ impl Parser {
     }
 
     pub(crate) fn opt_token(&mut self, kind: TokenKind) -> bool {
-        if let Some(token) = self.token_stream.next_if(|token| token.kind() == kind) {
+        let start = self.builder.current_pos();
+        if let Some((token, err)) = self.token_stream.next_if(|token| token.kind() == kind) {
+            self.push_opt_lex_err(err, &token, start);
             self.builder.push(token);
             true
         } else {
@@ -165,10 +179,12 @@ impl Parser {
         &mut self,
         kinds: [TokenKind; N],
     ) -> Option<TokenKind> {
-        if let Some(token) = self
+        let start = self.builder.current_pos();
+        if let Some((token, err)) = self
             .token_stream
             .next_if(|token| kinds.contains(&token.kind()))
         {
+            self.push_opt_lex_err(err, &token, start);
             let kind = token.kind();
             self.builder.push(token);
             Some(kind)
@@ -201,14 +217,14 @@ impl Parser {
     }
 
     pub(crate) fn expect_tokens_err(&mut self, tokens: impl Into<Box<[TokenKind]>>) {
-        self.diagnostics.push(SyntaxErr::new(
+        self.errors.push(SyntaxErr::new(
             self.builder.current_pos()..self.builder.current_pos(),
             SyntaxErrKind::Expected(tokens.into()),
         ));
     }
 
     pub(crate) fn end(self) -> (GreenNode, Vec<SyntaxErr>) {
-        (self.builder.end(), self.diagnostics)
+        (self.builder.end(), self.errors)
     }
 
     pub(crate) fn lookahead_max_token_index<const N: usize>(

--- a/vhdl_syntax/src/syntax/node.rs
+++ b/vhdl_syntax/src/syntax/node.rs
@@ -575,7 +575,10 @@ mod tests {
 
     #[test]
     fn no_rewrite_is_noop() {
-        let orig_tokens = "entity foo is end foo".tokenize().collect::<Vec<_>>();
+        let orig_tokens = "entity foo is end foo"
+            .tokenize()
+            .map(|(tok, _)| tok)
+            .collect::<Vec<_>>();
         let mut data = GreenNodeData::new(EntityDeclaration);
         data.push_tokens(orig_tokens.clone());
         let node = SyntaxNode::new_root(GreenNode::new(data));
@@ -590,7 +593,7 @@ mod tests {
     #[test]
     fn rewrite_tokens() {
         let mut data = GreenNodeData::new(EntityDeclaration);
-        data.push_tokens("entity foo is end foo;".tokenize());
+        data.push_tokens("entity foo is end foo;".tokenize().map(|(tok, _)| tok));
         let node = SyntaxNode::new_root(GreenNode::new(data));
         let new_node = node.rewrite_tokens(|tok| {
             if tok.text() == "foo" {
@@ -605,13 +608,19 @@ mod tests {
             .collect::<VecDeque<_>>();
         assert_eq!(
             new_tokens,
-            "entity bar is end bar;".tokenize().collect::<Vec<_>>()
+            "entity bar is end bar;"
+                .tokenize()
+                .map(|(tok, _)| tok)
+                .collect::<Vec<_>>()
         );
     }
 
     #[test]
     fn rewrite_does_not_modify_self() {
-        let orig_tokens = "entity foo is end foo".tokenize().collect::<Vec<_>>();
+        let orig_tokens = "entity foo is end foo"
+            .tokenize()
+            .map(|(tok, _)| tok)
+            .collect::<Vec<_>>();
         let mut data = GreenNodeData::new(EntityDeclaration);
         data.push_tokens(orig_tokens.clone());
         let node = SyntaxNode::new_root(GreenNode::new(data));

--- a/vhdl_syntax/src/tokens/token_kind.rs
+++ b/vhdl_syntax/src/tokens/token_kind.rs
@@ -62,10 +62,6 @@ pub enum TokenKind {
     CharacterLiteral,
     ToolDirective,
 
-    // Erroneous input
-    /// String, extended identifier or based integer without final quotation char
-    Unterminated,
-
     /// Unknown input
     ///
     /// Produced, for example, when there is an unknown char or illegal bit string

--- a/vhdl_syntax/src/tokens/token_stream.rs
+++ b/vhdl_syntax/src/tokens/token_stream.rs
@@ -4,25 +4,108 @@
 //
 // Copyright (c)  2024, Lukas Scheller lukasscheller@icloud.com
 
-use crate::tokens::{Token, Tokenizer};
+use crate::latin_1::{Latin1Str, Latin1String};
+use crate::tokens::tokenizer::LexErr;
+use crate::tokens::{Token, TokenKind, Tokenizer};
 use std::collections::VecDeque;
+
+/// Returns `true` if `text` is a valid VHDL bit-string base specifier.
+fn is_base_specifier(text: &Latin1Str) -> bool {
+    matches!(
+        text.to_lowercase().as_bytes(),
+        b"b" | b"o" | b"x" | b"d" | b"sb" | b"ub" | b"so" | b"uo" | b"sx" | b"ux"
+    )
+}
+
+/// Merge adjacent tokens that form a bit-string literal.
+///
+/// VHDL bit-string literals have the form `[integer] base_specifier " bit_value "`,
+/// e.g., `10ub"0101"` or `x"FF"`. The tokenizer produces these as separate tokens
+/// (`AbstractLiteral`, `Identifier`, `StringLiteral`) because resolving the ambiguity
+/// at the lexer level causes problems (e.g., `10s` being swallowed instead of being
+/// treated as `AbstractLiteral` + `Identifier`).
+///
+/// This pass recognizes two patterns and merges them into a single `BitStringLiteral` token:
+/// - `Identifier StringLiteral` where the identifier is a base specifier (e.g., `b"0101"`)
+/// - `AbstractLiteral Identifier StringLiteral` where the identifier is a base specifier
+///   (e.g., `10ub"0101"`)
+///
+/// Merging only occurs when there is no trivia (whitespace/comments) between the tokens.
+fn merge_bit_string_literals(
+    mut tokens: VecDeque<(Token, Option<LexErr>)>,
+) -> VecDeque<(Token, Option<LexErr>)> {
+    let mut result = VecDeque::with_capacity(tokens.len());
+
+    while let Some((tok, diag)) = tokens.pop_front() {
+        match tok.kind() {
+            // Pattern: Identifier StringLiteral (e.g., b"0101", sx"FF")
+            TokenKind::Identifier if is_base_specifier(tok.text()) => {
+                if let Some((next, _)) = tokens.front() {
+                    if next.kind() == TokenKind::StringLiteral && next.leading_trivia().is_empty() {
+                        let (string_tok, string_diag) = tokens.pop_front().unwrap();
+                        let mut merged_text = Latin1String::from(tok.text());
+                        merged_text.extend(string_tok.text());
+                        let merged = Token::new(
+                            TokenKind::BitStringLiteral,
+                            merged_text,
+                            tok.leading_trivia.clone(),
+                        );
+                        result.push_back((merged, diag.or(string_diag)));
+                        continue;
+                    }
+                }
+                result.push_back((tok, diag));
+            }
+            // Pattern: AbstractLiteral Identifier StringLiteral (e.g., 10ub"0101")
+            TokenKind::AbstractLiteral => {
+                if let (Some((ident, _)), Some((string, _))) = (tokens.front(), tokens.get(1)) {
+                    if ident.kind() == TokenKind::Identifier
+                        && ident.leading_trivia().is_empty()
+                        && is_base_specifier(ident.text())
+                        && string.kind() == TokenKind::StringLiteral
+                        && string.leading_trivia().is_empty()
+                    {
+                        let (ident_tok, ident_diag) = tokens.pop_front().unwrap();
+                        let (string_tok, string_diag) = tokens.pop_front().unwrap();
+                        let mut merged_text = Latin1String::from(tok.text());
+                        merged_text.extend(ident_tok.text());
+                        merged_text.extend(string_tok.text());
+                        let merged = Token::new(
+                            TokenKind::BitStringLiteral,
+                            merged_text,
+                            tok.leading_trivia.clone(),
+                        );
+                        result.push_back((merged, diag.or(ident_diag).or(string_diag)));
+                        continue;
+                    }
+                }
+                result.push_back((tok, diag));
+            }
+            _ => result.push_back((tok, diag)),
+        }
+    }
+
+    result
+}
 
 /// A Token stream is similar to an `Iterator`, however the stream has arbitrary amount of
 /// lookahead by using [TokenStream::peek]
 pub struct TokenStream {
     // OPTIMIZATION: This is likely inefficient and should be replaced by a more ergonomic implementation.
-    inner: VecDeque<Token>,
+    inner: VecDeque<(Token, Option<LexErr>)>,
 }
 
 impl TokenStream {
-    fn new(tokens: VecDeque<Token>) -> TokenStream {
-        TokenStream { inner: tokens }
+    fn new(tokens: VecDeque<(Token, Option<LexErr>)>) -> TokenStream {
+        TokenStream {
+            inner: merge_bit_string_literals(tokens),
+        }
     }
 
     /// Peek `n` tokens in advance where `n == 0` means the next token
     /// (i.e., the token that would be returned by `next`)
     pub fn peek(&self, n: usize) -> Option<&Token> {
-        self.inner.get(n)
+        self.inner.get(n).map(|(tok, _)| tok)
     }
 
     /// Peek the next token.
@@ -37,7 +120,10 @@ impl TokenStream {
 
     /// Returns the next token if a given precondition is `true` for the next token.
     /// Returns `None`, if the precondition is `false` or the tokenizer is at EOF
-    pub fn next_if(&mut self, cond: impl FnOnce(&Token) -> bool) -> Option<Token> {
+    pub fn next_if(
+        &mut self,
+        cond: impl FnOnce(&Token) -> bool,
+    ) -> Option<(Token, Option<LexErr>)> {
         if cond(self.peek_next()?) {
             self.next()
         } else {
@@ -47,7 +133,7 @@ impl TokenStream {
 }
 
 impl Iterator for TokenStream {
-    type Item = Token;
+    type Item = (Token, Option<LexErr>);
 
     /// Consumes and returns the next token.
     /// Returns `None`, if the tokenizer is empty, i.e., there are
@@ -57,8 +143,8 @@ impl Iterator for TokenStream {
     }
 }
 
-impl FromIterator<Token> for TokenStream {
-    fn from_iter<T: IntoIterator<Item = Token>>(iter: T) -> Self {
+impl FromIterator<(Token, Option<LexErr>)> for TokenStream {
+    fn from_iter<T: IntoIterator<Item = (Token, Option<LexErr>)>>(iter: T) -> Self {
         TokenStream::new(iter.into_iter().collect())
     }
 }
@@ -84,5 +170,140 @@ impl From<&str> for TokenStream {
 impl From<String> for TokenStream {
     fn from(value: String) -> Self {
         TokenStream::from(value.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream_kinds(input: &str) -> Vec<TokenKind> {
+        let stream = TokenStream::from(input);
+        stream.inner.iter().map(|(tok, _)| tok.kind()).collect()
+    }
+
+    fn stream_first_text(input: &str) -> String {
+        let stream = TokenStream::from(input);
+        stream.inner[0].0.text().to_string()
+    }
+
+    #[test]
+    fn merge_bare_base_specifier_string() {
+        // b"0101" → single BitStringLiteral
+        assert_eq!(
+            stream_kinds("b\"0101\""),
+            vec![TokenKind::BitStringLiteral, TokenKind::Eof]
+        );
+        assert_eq!(stream_first_text("b\"0101\""), "b\"0101\"");
+    }
+
+    #[test]
+    fn merge_signed_base_specifier_string() {
+        assert_eq!(
+            stream_kinds("sx\"FF\""),
+            vec![TokenKind::BitStringLiteral, TokenKind::Eof]
+        );
+        assert_eq!(stream_first_text("sx\"FF\""), "sx\"FF\"");
+    }
+
+    #[test]
+    fn merge_length_prefixed_bit_string() {
+        // 10ub"0101" → single BitStringLiteral
+        assert_eq!(
+            stream_kinds("10ub\"0101\""),
+            vec![TokenKind::BitStringLiteral, TokenKind::Eof]
+        );
+        assert_eq!(stream_first_text("10ub\"0101\""), "10ub\"0101\"");
+    }
+
+    #[test]
+    fn no_merge_with_trivia_between() {
+        // b "0101" has a space → no merge
+        assert_eq!(
+            stream_kinds("b \"0101\""),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::StringLiteral,
+                TokenKind::Eof
+            ]
+        );
+        // 10 b"0101" has a space before identifier → no merge
+        assert_eq!(
+            stream_kinds("10 b\"0101\""),
+            vec![
+                TokenKind::AbstractLiteral,
+                TokenKind::BitStringLiteral,
+                TokenKind::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn no_merge_non_base_specifier() {
+        // foo"bar" — foo is not a base specifier
+        assert_eq!(
+            stream_kinds("foo\"bar\""),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::StringLiteral,
+                TokenKind::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn no_merge_number_followed_by_identifier() {
+        // 10s — not followed by a string, no merge
+        assert_eq!(
+            stream_kinds("10s"),
+            vec![
+                TokenKind::AbstractLiteral,
+                TokenKind::Identifier,
+                TokenKind::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_case_insensitive_base_specifier() {
+        assert_eq!(
+            stream_kinds("X\"FF\""),
+            vec![TokenKind::BitStringLiteral, TokenKind::Eof]
+        );
+        assert_eq!(
+            stream_kinds("UB\"01\""),
+            vec![TokenKind::BitStringLiteral, TokenKind::Eof]
+        );
+    }
+
+    #[test]
+    fn merge_all_base_specifiers() {
+        for base in ["b", "o", "x", "d", "sb", "so", "sx", "ub", "uo", "ux"] {
+            let input = format!("{base}\"01\"");
+            assert_eq!(
+                stream_kinds(&input),
+                vec![TokenKind::BitStringLiteral, TokenKind::Eof],
+                "failed for base specifier: {base}"
+            );
+
+            let upper = input.to_uppercase();
+            assert_eq!(
+                stream_kinds(&upper),
+                vec![TokenKind::BitStringLiteral, TokenKind::Eof],
+                "failed for uppercase base specifier: {base}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_all_base_specifiers_with_length() {
+        for base in ["b", "o", "x", "d", "sb", "so", "sx", "ub", "uo", "ux"] {
+            let input = format!("8{base}\"01\"");
+            assert_eq!(
+                stream_kinds(&input),
+                vec![TokenKind::BitStringLiteral, TokenKind::Eof],
+                "failed for length-prefixed base specifier: {base}"
+            );
+        }
     }
 }

--- a/vhdl_syntax/src/tokens/tokenizer.rs
+++ b/vhdl_syntax/src/tokens/tokenizer.rs
@@ -13,7 +13,7 @@ use crate::tokens::{Token, TokenKind};
 use std::iter::Peekable;
 use std::mem::replace;
 
-/// describes the kind if a token was unterminated
+/// describes the kind of a token was unterminated
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnterminatedKind {
     StringLiteral,
@@ -322,7 +322,7 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
     }
 
     /// Parse a quoted string.
-    /// Returns [Unterminated], if the quote string was not seen at the end.
+    /// Returns [LexErr::Unterminated], if the quote string was not seen at the end.
     /// In VHDL, escaping the quotation mark is performed by repeating it.
     fn quoted(
         &mut self,

--- a/vhdl_syntax/src/tokens/tokenizer.rs
+++ b/vhdl_syntax/src/tokens/tokenizer.rs
@@ -13,57 +13,108 @@ use crate::tokens::{Token, TokenKind};
 use std::iter::Peekable;
 use std::mem::replace;
 
+/// describes the kind if a token was unterminated
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnterminatedKind {
+    StringLiteral,
+    BasedLiteral,
+    ExtendedIdentifier,
+    BlockComment,
+}
+
+/// Error kind that occurs when lexing
+#[derive(Clone, Copy, Debug)]
+pub enum LexErrKind {
+    /// A token (string, comment, e.t.c.) was not terminated properly
+    Unterminated(UnterminatedKind),
+    IllegalInput,
+}
+
+/// Token errors are always attached to raw tokens.
+/// Given that each token may include additional trivia, this enum
+/// defines whether the error refers to the token itself, or leading trivia
+/// of that token
+#[derive(Copy, Clone, Debug)]
+pub enum LexErrPos {
+    /// Refers to the token
+    Token,
+    /// Refers to the trivia attached to the token at the given index
+    Trivia(usize),
+}
+
+#[derive(Debug)]
+pub struct LexErr {
+    pub err: LexErrKind,
+    pub pos: LexErrPos,
+}
+
+impl LexErr {
+    pub fn token(err: LexErrKind) -> LexErr {
+        LexErr {
+            err,
+            pos: LexErrPos::Token,
+        }
+    }
+
+    pub fn trivia(index: usize, err: LexErrKind) -> LexErr {
+        LexErr {
+            err,
+            pos: LexErrPos::Trivia(index),
+        }
+    }
+}
+
 pub trait Tokenize {
-    fn tokenize(&self) -> impl Iterator<Item = Token>;
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)>;
 }
 
 impl Tokenize for &str {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.bytes())
     }
 }
 
 impl Tokenize for String {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.bytes())
     }
 }
 
 impl Tokenize for &Latin1Str {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.as_bytes().iter().copied())
     }
 }
 
 impl Tokenize for Latin1String {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.as_bytes().iter().copied())
     }
 }
 
 impl Tokenize for &[u8] {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.iter().copied())
     }
 }
 
 impl Tokenize for Vec<u8> {
-    fn tokenize(&self) -> impl Iterator<Item = Token> {
+    fn tokenize(&self) -> impl Iterator<Item = (Token, Option<LexErr>)> {
         Tokenizer::from(self.iter().copied())
     }
 }
 
 /// The Tokenizer is an iterator that consumes some char iterator (i.e., an iterator that
-/// produces u8 items) and generates tokens.
+/// produces u8 items) and generates tokens and optionally an error associated to that token.
 /// All iterators that implement `IntoIter<Item = u8>` can be used for this purpose. For example.
 /// ```
 /// use vhdl_syntax::tokens::{Keyword, TokenKind, Tokenizer};
 /// // &str implements IntoIter<u8>, therefore it can be converted to a tokenizer
 /// let mut tokenizer = Tokenizer::from("entity foo".bytes());
-/// assert_eq!(tokenizer.next().unwrap().kind(), TokenKind::Keyword(Keyword::Entity));
-/// assert_eq!(tokenizer.next().unwrap().kind(), TokenKind::Identifier);
-/// assert_eq!(tokenizer.next().unwrap().kind(), TokenKind::Eof);
-/// assert_eq!(tokenizer.next(), None);
+/// assert_eq!(tokenizer.next().unwrap().0.kind(), TokenKind::Keyword(Keyword::Entity));
+/// assert_eq!(tokenizer.next().unwrap().0.kind(), TokenKind::Identifier);
+/// assert_eq!(tokenizer.next().unwrap().0.kind(), TokenKind::Eof);
+/// assert!(tokenizer.next().is_none());
 /// ```
 ///
 /// The [Tokenize] trait enables syntactic sugar to work with tokenizers using iterators:
@@ -71,7 +122,7 @@ impl Tokenize for Vec<u8> {
 /// use vhdl_syntax::tokens::tokenizer::Tokenize;
 /// use vhdl_syntax::tokens::TokenKind;
 ///
-/// let tokens = "a ?> b".tokenize().map(|tok| tok.kind()).collect::<Vec<_>>();
+/// let tokens = "a ?> b".tokenize().map(|(tok, _)| tok.kind()).collect::<Vec<_>>();
 /// assert_eq!(tokens, vec![TokenKind::Identifier, TokenKind::QueGT, TokenKind::Identifier, TokenKind::Eof])
 /// ```
 pub struct Tokenizer<I: Iterator<Item = u8>> {
@@ -113,6 +164,28 @@ where
 {
     fn from(value: T) -> Self {
         Tokenizer::new(value.into_iter())
+    }
+}
+
+#[derive(Copy, Clone)]
+enum QuoteKind {
+    QuotationMark,      // "
+    ExtendedIdentifier, // \
+}
+
+impl QuoteKind {
+    pub fn unterminated_kind(&self) -> UnterminatedKind {
+        match self {
+            QuoteKind::QuotationMark => UnterminatedKind::StringLiteral,
+            QuoteKind::ExtendedIdentifier => UnterminatedKind::ExtendedIdentifier,
+        }
+    }
+
+    pub fn token_kind(&self) -> TokenKind {
+        match self {
+            QuoteKind::QuotationMark => StringLiteral,
+            QuoteKind::ExtendedIdentifier => Identifier,
+        }
     }
 }
 
@@ -158,23 +231,19 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
         self.fill_buffer_while(buf, |ch| !matches!(ch, b'\n' | b'\r'))
     }
 
-    /// Tokenize an identifier, keyword or Bit String Literal.
-    fn identifier_keyword_or_bistring_literal(
+    /// Tokenize an identifier or keyword.
+    fn identifier_or_keyword(
         &mut self,
         buf: &mut Latin1String,
-    ) -> Option<TokenKind> {
+    ) -> (TokenKind, Option<LexErr>) {
         self.fill_buffer_while(
             buf,
             |ch| matches!(ch, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'),
         );
-        if self.current == Some(b'"') {
-            if self.quoted(buf) == Unterminated {
-                Some(Unterminated)
-            } else {
-                Some(BitStringLiteral)
-            }
+        if let Some(kw) = Kw::from_latin1(buf).filter(|kw| kw.introduced_in() <= self.standard) {
+            (Keyword(kw), None)
         } else {
-            None
+            (Identifier, None)
         }
     }
 
@@ -219,7 +288,8 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
     /// extended_digit ::= digit | letter
     /// bit_value ::= graphic_character { [ underline ] graphic_character }
     /// ```
-    fn abstract_literal(&mut self, buf: &mut Latin1String) -> TokenKind {
+    fn abstract_literal(&mut self, buf: &mut Latin1String) -> (TokenKind, Option<LexErr>) {
+        let mut diag = None;
         self.integer(buf);
         match self.current {
             Some(b'.') => {
@@ -239,34 +309,26 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
                 if self.skip_if_eq(ch) {
                     buf.push(ch);
                 } else {
-                    return Unterminated;
+                    diag = Some(LexErr::token(LexErrKind::Unterminated(
+                        UnterminatedKind::BasedLiteral,
+                    )));
                 }
                 self.opt_exponent(buf);
             }
             Some(b'e' | b'E') => self.opt_exponent(buf),
-            _ => {
-                return self.opt_bit_string_literal(buf).unwrap_or(AbstractLiteral);
-            }
+            _ => {}
         }
-        AbstractLiteral
-    }
-
-    fn opt_bit_string_literal(&mut self, buf: &mut Latin1String) -> Option<TokenKind> {
-        match self.current?.to_ascii_lowercase() {
-            b's' | b'u' | b'b' | b'o' | b'x' | b'd' => {
-                match self.identifier_keyword_or_bistring_literal(buf) {
-                    Some(kind @ Unterminated | kind @ BitStringLiteral) => Some(kind),
-                    _ => Some(Unknown),
-                }
-            }
-            _ => None,
-        }
+        (AbstractLiteral, diag)
     }
 
     /// Parse a quoted string.
     /// Returns [Unterminated], if the quote string was not seen at the end.
     /// In VHDL, escaping the quotation mark is performed by repeating it.
-    fn quoted(&mut self, buf: &mut Latin1String) -> TokenKind {
+    fn quoted(
+        &mut self,
+        buf: &mut Latin1String,
+        quote_kind: QuoteKind,
+    ) -> (TokenKind, Option<LexErr>) {
         let quote = self.skip().expect("Input empty while tokenizing quoted");
         buf.push(quote);
         let mut found_end = false;
@@ -282,15 +344,14 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
                 }
             }
         }
-        if !found_end {
-            Unterminated
-        } else if quote == b'"' {
-            StringLiteral
-        } else if quote == b'\\' {
-            Identifier
+        let err = if !found_end {
+            Some(LexErr::token(LexErrKind::Unterminated(
+                quote_kind.unterminated_kind(),
+            )))
         } else {
-            Unknown
-        }
+            None
+        };
+        (quote_kind.token_kind(), err)
     }
 
     /// Consume a trivia piece (i.e., whitespace, newline, comments, ...)
@@ -298,7 +359,7 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
     // Instead, the comment encoding should be user-configurable to avoid
     // panicking and support different use-cases.
     // VHDL allows comments to have a different encoding (NOTE 2 in 15.9) and we should respect that.
-    fn consume_trivia_piece(&mut self) -> Option<TriviaPiece> {
+    fn consume_trivia_piece(&mut self) -> Option<(TriviaPiece, Option<LexErrKind>)> {
         macro_rules! count_chars {
             ($ch:literal) => {{
                 let mut count = 0;
@@ -309,9 +370,9 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
             }};
         }
         Some(match self.current? {
-            b'\t' => TriviaPiece::HorizontalTabs(count_chars!(b'\t')),
+            b'\t' => (TriviaPiece::HorizontalTabs(count_chars!(b'\t')), None),
             /*vertical tab*/
-            0x0B => TriviaPiece::VerticalTabs(count_chars!(0x0B)),
+            0x0B => (TriviaPiece::VerticalTabs(count_chars!(0x0B)), None),
             b'\r' => {
                 if self.peek() == Some(b'\n') {
                     let mut count = 0;
@@ -320,14 +381,14 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
                         self.skip();
                         count += 1;
                     }
-                    TriviaPiece::CarriageReturnLineFeeds(count)
+                    (TriviaPiece::CarriageReturnLineFeeds(count), None)
                 } else {
-                    TriviaPiece::CarriageReturns(count_chars!(b'\r'))
+                    (TriviaPiece::CarriageReturns(count_chars!(b'\r')), None)
                 }
             }
-            0x0C => TriviaPiece::FormFeeds(count_chars!(0x0C)),
-            b'\n' => TriviaPiece::LineFeeds(count_chars!(b'\n')),
-            b' ' => TriviaPiece::Spaces(count_chars!(b' ')),
+            0x0C => (TriviaPiece::FormFeeds(count_chars!(0x0C)), None),
+            b'\n' => (TriviaPiece::LineFeeds(count_chars!(b'\n')), None),
+            b' ' => (TriviaPiece::Spaces(count_chars!(b' ')), None),
             b'-' if self.peek() == Some(b'-') => {
                 self.skip();
                 self.skip();
@@ -335,7 +396,7 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
                 while let Some(ch) = self.skip_if(|ch| !matches!(ch, b'\r' | b'\n')) {
                     bytes.push(ch);
                 }
-                TriviaPiece::LineComment(Comment::new(bytes))
+                (TriviaPiece::LineComment(Comment::new(bytes)), None)
             }
             b'/' if self.peek() == Some(b'*') => {
                 self.skip();
@@ -347,56 +408,62 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
                         self.skip();
                         break;
                     }
-                    let Some(ch) = self.skip() else { break };
+                    let Some(ch) = self.skip() else {
+                        return Some((
+                            TriviaPiece::BlockComment(Comment::new(bytes)),
+                            Some(LexErrKind::Unterminated(UnterminatedKind::BlockComment)),
+                        ));
+                    };
                     bytes.push(ch)
                 }
-                TriviaPiece::BlockComment(Comment::new(bytes))
+                (TriviaPiece::BlockComment(Comment::new(bytes)), None)
             }
             /*non breaking spaces*/
-            0xA0 => TriviaPiece::NonBreakingSpaces(count_chars!(0xA0)),
+            0xA0 => (TriviaPiece::NonBreakingSpaces(count_chars!(0xA0)), None),
             _ => return None,
         })
     }
 
     /// Consumes all trivia.
-    fn consume_trivia(&mut self) -> Trivia {
+    fn consume_trivia(&mut self) -> (Trivia, Option<LexErr>) {
         let mut trivia = Trivia::default();
-        while let Some(piece) = self.consume_trivia_piece() {
+        // Note: we currently only allow one error. This is fine because an unterminated input will consume everything.
+        // If we ever decide against this, the design must change.
+        while let Some((piece, err)) = self.consume_trivia_piece() {
             trivia.push(piece);
+            if let Some(err) = err {
+                let idx = trivia.len() - 1;
+                return (trivia, Some(LexErr::trivia(idx, err)));
+            }
         }
-        trivia
+        (trivia, None)
     }
 }
 
 impl<T: Iterator<Item = u8>> Iterator for Tokenizer<T> {
-    type Item = Token;
+    type Item = (Token, Option<LexErr>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let leading_trivia = self.consume_trivia();
+        let (trivia, trivia_diag) = self.consume_trivia();
+        let mut token_diag = None;
         let Some(current) = self.current else {
             if self.eof_emitted {
                 return None;
             }
             self.eof_emitted = true;
-            return Some(Token::eof(leading_trivia));
+            return Some((Token::eof(trivia), trivia_diag));
         };
         let (kind, text) = match current {
             b'a'..=b'z' | b'A'..=b'Z' => {
                 let mut ident_str = Latin1String::new();
-                let kind = self.identifier_keyword_or_bistring_literal(&mut ident_str);
-                if let Some(kind) = kind {
-                    (kind, ident_str)
-                } else if let Some(kw) =
-                    Kw::from_latin1(&ident_str).filter(|kw| kw.introduced_in() <= self.standard)
-                {
-                    (Keyword(kw), ident_str)
-                } else {
-                    (Identifier, ident_str)
-                }
+                let (kind, diag) = self.identifier_or_keyword(&mut ident_str);
+                token_diag = diag;
+                (kind, ident_str)
             }
             b'0'..=b'9' => {
                 let mut buf = Latin1String::new();
-                let kind = self.abstract_literal(&mut buf);
+                let (kind, diag) = self.abstract_literal(&mut buf);
+                token_diag = diag;
                 (kind, buf)
             }
             b':' => {
@@ -432,7 +499,8 @@ impl<T: Iterator<Item = u8>> Iterator for Tokenizer<T> {
             }
             b'"' => {
                 let mut buf = Latin1String::new();
-                let kind = self.quoted(&mut buf);
+                let (kind, diag) = self.quoted(&mut buf, QuoteKind::QuotationMark);
+                token_diag = diag;
                 (kind, buf)
             }
             b';' => {
@@ -585,7 +653,8 @@ impl<T: Iterator<Item = u8>> Iterator for Tokenizer<T> {
             }
             b'\\' => {
                 let mut buf = Latin1String::new();
-                let kind = self.quoted(&mut buf);
+                let (kind, diag) = self.quoted(&mut buf, QuoteKind::ExtendedIdentifier);
+                token_diag = diag;
                 (kind, buf)
             }
             b'`' => {
@@ -594,12 +663,21 @@ impl<T: Iterator<Item = u8>> Iterator for Tokenizer<T> {
                 (ToolDirective, buf)
             }
             ch => {
+                token_diag = Some(LexErr::token(LexErrKind::IllegalInput));
                 self.skip();
                 (Unknown, Latin1String::from(ch))
             }
         };
         self.last_token_kind = Some(kind);
-        Some(Token::new(kind, text, leading_trivia))
+        let diag = match (trivia_diag, token_diag) {
+            (Some(triv_diag), None) => Some(triv_diag),
+            (None, Some(token_diag)) => Some(token_diag),
+            (None, None) => None,
+            _ => {
+                unreachable!("Trivia diagnostics and token diagnostics should never occur together")
+            }
+        };
+        Some((Token::new(kind, text, trivia), diag))
     }
 }
 
@@ -617,7 +695,6 @@ fn can_be_char(last_token_kind: Option<TokenKind>) -> bool {
 #[cfg(test)]
 mod tests {
 
-    use crate::latin_1::Latin1String;
     use crate::tokens::tokenizer::Tokenize;
     use crate::tokens::trivia_piece::Comment;
     use crate::tokens::TokenKind;
@@ -626,7 +703,10 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn kinds_tokenize_remove_eof(code: &str) -> Vec<TokenKind> {
-        let mut val = code.tokenize().map(|tok| tok.kind()).collect::<Vec<_>>();
+        let mut val = code
+            .tokenize()
+            .map(|(tok, _)| tok.kind())
+            .collect::<Vec<_>>();
         assert_eq!(val.pop(), Some(TokenKind::Eof));
         val
     }
@@ -652,17 +732,17 @@ mod tests {
         T: Tokenize,
     {
         fn tokenize_vec(&self) -> Vec<Token> {
-            self.tokenize().collect()
+            self.tokenize().map(|(tok, _)| tok).collect()
         }
 
         fn tokenize_kind_value(&self) -> Vec<(TokenKind, String)> {
             self.tokenize()
-                .map(|tok| (tok.kind(), tok.text().to_string()))
+                .map(|(tok, _)| (tok.kind(), tok.text().to_string()))
                 .collect()
         }
 
         fn tokenize_kinds(&self) -> Vec<TokenKind> {
-            self.tokenize().map(|tok| tok.kind()).collect()
+            self.tokenize().map(|(tok, _)| tok.kind()).collect()
         }
     }
 
@@ -815,7 +895,7 @@ my_other_ident"
         assert_eq!(
             "0.1 -2_2.3_3 2.0e3 3.33E2 2.1e-2 4.4e+1 2.5E+3"
                 .tokenize()
-                .map(|tok| (tok.kind(), tok.text().to_string()))
+                .map(|(tok, _)| (tok.kind(), tok.text().to_string()))
                 .collect::<Vec<_>>(),
             vec![
                 (AbstractLiteral, "0.1".to_string()),
@@ -897,57 +977,44 @@ my_other_ident"
     fn tokenize_string_literal_error_on_early_eof() {
         assert_eq!(
             "\"string".tokenize_one(),
-            Token::simple(Unterminated, b"\"string")
+            Token::simple(StringLiteral, b"\"string")
         );
     }
 
     #[test]
-    fn tokenize_bit_string_literal() {
-        // Test all base specifiers
-        for &base in ["b", "o", "x", "d", "sb", "so", "sx", "ub", "uo", "ux"].iter() {
-            let (base_spec, value, length) = match base {
-                "b" => ("b", "10", 2),
-                "o" => ("o", "76543210", 8 * 3),
-                "x" => ("x", "fedcba987654321", 16 * 4),
-                "d" => ("d", "9876543210", 34),
-                "sb" => ("sb", "10", 2),
-                "so" => ("so", "76543210", 8 * 3),
-                "sx" => ("sx", "fedcba987654321", 16 * 4),
-                "ub" => ("ub", "10", 2),
-                "uo" => ("uo", "76543210", 8 * 3),
-                "ux" => ("ux", "fedcba987654321", 16 * 4),
-                _ => unreachable!(),
-            };
-
-            // Test with upper and lower case base specifier
-            for &upper_case in [true, false].iter() {
-                // Test with and without length prefix
-                for &use_length in [true, false].iter() {
-                    let length_str = if use_length {
-                        length.to_string()
-                    } else {
-                        "".to_owned()
-                    };
-
-                    let mut code =
-                        Latin1String::from_utf8(&format!("{length_str}{base_spec}\"{value}\""))
-                            .unwrap();
-
-                    if upper_case {
-                        code.make_uppercase()
-                    }
-
-                    let token = code.tokenize_one();
-                    assert_eq!(token, Token::simple(BitStringLiteral, code));
-                }
-            }
-        }
+    fn tokenize_base_specifier_then_string() {
+        // The tokenizer emits these as separate tokens; merging into
+        // BitStringLiteral happens in TokenStream.
+        assert_eq!(
+            "b\"0101\"".tokenize_kinds(),
+            vec![Identifier, StringLiteral, Eof]
+        );
+        assert_eq!(
+            "sx\"FF\"".tokenize_kinds(),
+            vec![Identifier, StringLiteral, Eof]
+        );
+        assert_eq!(
+            "10ub\"0101\"".tokenize_kinds(),
+            vec![AbstractLiteral, Identifier, StringLiteral, Eof]
+        );
     }
 
     #[test]
-    fn tokenize_illegal_bit_string() {
-        assert_eq!("10x".tokenize_one(), Token::simple(Unknown, b"10x"));
-        assert_eq!("10ux".tokenize_one(), Token::simple(Unknown, b"10ux"));
+    fn tokenize_number_followed_by_identifier() {
+        // Previously these were swallowed as Unknown; now the tokenizer emits
+        // separate tokens, allowing the parser/user to interpret `10s` etc.
+        assert_eq!(
+            "10x".tokenize_kinds(),
+            vec![AbstractLiteral, Identifier, Eof]
+        );
+        assert_eq!(
+            "10ux".tokenize_kinds(),
+            vec![AbstractLiteral, Identifier, Eof]
+        );
+        assert_eq!(
+            "10s".tokenize_kinds(),
+            vec![AbstractLiteral, Identifier, Eof]
+        );
     }
 
     #[test]
@@ -1205,6 +1272,7 @@ comment
         Tokenizer::with_standard(standard, input.bytes())
             .next()
             .unwrap()
+            .0
             .kind()
     }
 

--- a/vhdl_syntax/src/tokens/tokenizer.rs
+++ b/vhdl_syntax/src/tokens/tokenizer.rs
@@ -232,10 +232,7 @@ impl<T: Iterator<Item = u8>> Tokenizer<T> {
     }
 
     /// Tokenize an identifier or keyword.
-    fn identifier_or_keyword(
-        &mut self,
-        buf: &mut Latin1String,
-    ) -> (TokenKind, Option<LexErr>) {
+    fn identifier_or_keyword(&mut self, buf: &mut Latin1String) -> (TokenKind, Option<LexErr>) {
         self.fill_buffer_while(
             buf,
             |ch| matches!(ch, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'),


### PR DESCRIPTION
Previously, lexing errors were silently ignored or needed to be reconstructed at parsing time.
This PR changes that by adding an optional lexing error when tokenizing. The lexing error is then converted to a syntax error.