### PR TITLE
Add function return identifier parsing and analysis

### DIFF
--- a/vhdl_lang/src/analysis/subprogram.rs
+++ b/vhdl_lang/src/analysis/subprogram.rs
@@ -136,6 +136,23 @@ impl<'a> AnalyzeContext<'a, '_> {
                     &mut fun.return_type.item,
                     diagnostics,
                 );
+                if let (Some(return_identifier), Ok(return_type)) =
+                    (&mut fun.return_identifier, return_type.as_ref())
+                {
+                    let return_id_token = return_identifier.tree.token;
+                    let return_subtype = TypeEnt::define_with_opt_id(
+                        self.ctx,
+                        self.arena,
+                        None,
+                        return_identifier,
+                        ent,
+                        None,
+                        Type::Subtype(Subtype::new(*return_type)),
+                        TokenSpan::new(return_id_token, return_id_token),
+                        self.source(),
+                    );
+                    subpgm_region.add(return_subtype.into(), diagnostics);
+                }
                 match ParameterRegion::from_formal_region(params?) {
                     Ok(params) => (Signature::new(params, Some(return_type?)), generic_map),
                     Err(invalid_formals) => {

--- a/vhdl_lang/src/analysis/tests/subprogram_arguments.rs
+++ b/vhdl_lang/src/analysis/tests/subprogram_arguments.rs
@@ -6,6 +6,7 @@
 
 use super::*;
 use vhdl_lang::data::error_codes::ErrorCode;
+use vhdl_lang::VHDLStandard;
 
 #[test]
 fn wrong_number_of_arguments() {
@@ -428,5 +429,53 @@ end procedure;
             ErrorCode::AlreadyAssociated,
         )
         .related(code.s1("arg(0)"), "Previously associated here")],
+    );
+}
+
+#[test]
+fn function_return_identifier_declares_subtype_in_scope() {
+    let mut builder = LibraryBuilder::with_standard(VHDLStandard::VHDL2019);
+    builder.in_declarative_region(
+        "\
+function foo return ret of bit is
+    variable x : ret;
+begin
+end function;
+",
+    );
+    let diagnostics = builder.analyze();
+    check_no_diagnostics(&diagnostics);
+}
+
+#[test]
+fn function_return_identifier_find_all_references() {
+    let decl_name = "result_subtype";
+    let mut builder = LibraryBuilder::with_standard(VHDLStandard::VHDL2019);
+    let code = builder.in_declarative_region(
+        "\
+function foo return result_subtype of bit is
+    variable x : result_subtype;
+begin
+end function;
+",
+    );
+    let (root, diagnostics) = builder.get_analyzed_root();
+    check_no_diagnostics(&diagnostics);
+
+    // The declaration itself and the use in the variable subtype indication.
+    let occurences = 2;
+    let mut references = Vec::new();
+    for idx in 1..=occurences {
+        assert_eq!(
+            root.search_reference(code.source(), code.s(decl_name, idx).end())
+                .and_then(|ent| ent.declaration().decl_pos().cloned()),
+            Some(code.s(decl_name, 1).pos()),
+            "occurence {idx}"
+        );
+        references.push(code.s(decl_name, idx).pos());
+    }
+    assert_eq!(
+        root.find_all_references_pos(&code.s(decl_name, 1).pos()),
+        references,
     );
 }

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -721,6 +721,7 @@ pub struct FunctionSpecification {
     pub designator: WithDecl<WithToken<SubprogramDesignator>>,
     pub header: Option<SubprogramHeader>,
     pub parameter_list: Option<InterfaceList>,
+    pub return_identifier: Option<WithDecl<Ident>>,
     pub return_type: WithTokenSpan<Name>,
 }
 

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -853,7 +853,15 @@ impl Display for FunctionSpecification {
                 write!(f, "\n)")?;
             }
         }
-        write!(f, " return {}", self.return_type)
+        if let Some(return_identifier) = &self.return_identifier {
+            write!(
+                f,
+                " return {} of {}",
+                return_identifier.tree, self.return_type
+            )
+        } else {
+            write!(f, " return {}", self.return_type)
+        }
     }
 }
 
@@ -1272,6 +1280,19 @@ mod tests {
         F: FnOnce(&Code) -> R,
     {
         assert_format_eq(code, code, code_fun);
+    }
+
+    pub fn assert_format_with_standard<F, R: Display>(
+        code: &str,
+        standard: crate::VHDLStandard,
+        code_fun: F,
+    ) where
+        F: FnOnce(&Code) -> R,
+    {
+        assert_eq!(
+            format!("{}", code_fun(&Code::with_standard(code, standard))),
+            code
+        );
     }
 
     #[test]
@@ -1946,6 +1967,15 @@ end units;",
     pub fn test_function_specification() {
         assert_format(
             "function foo return lib.foo.natural",
+            Code::subprogram_specification,
+        );
+    }
+
+    #[test]
+    pub fn test_function_specification_with_return_identifier() {
+        assert_format_with_standard(
+            "function foo return ret of lib.foo.natural",
+            crate::VHDLStandard::VHDL2019,
             Code::subprogram_specification,
         );
     }

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -53,6 +53,7 @@ pub enum DeclarationItem<'a> {
     Attribute(&'a AttributeDeclaration),
     Alias(&'a AliasDeclaration),
     SubprogramDecl(&'a SubprogramSpecification),
+    ReturnIdentifier(&'a WithDecl<Ident>),
     Subprogram(&'a SubprogramBody),
     SubprogramInstantiation(&'a SubprogramInstantiation),
     Package(&'a PackageDeclaration),
@@ -1376,6 +1377,17 @@ fn search_subpgm_inner(
         SubprogramSpecification::Function(ref decl) => {
             return_if_found!(decl.header.search(ctx, searcher));
             return_if_found!(decl.parameter_list.search(ctx, searcher));
+            if let Some(return_identifier) = &decl.return_identifier {
+                return_if_found!(searcher
+                    .search_decl(
+                        ctx,
+                        FoundDeclaration::new(
+                            &return_identifier.decl,
+                            DeclarationItem::ReturnIdentifier(return_identifier)
+                        )
+                    )
+                    .or_not_found());
+            }
             decl.return_type.search(ctx, searcher)
         }
         SubprogramSpecification::Procedure(ref decl) => {
@@ -1830,6 +1842,7 @@ impl FoundDeclaration<'_> {
             DeclarationItem::ForGenerateIndex(..) => None,
             DeclarationItem::Subprogram(value) => value.end_ident_pos,
             DeclarationItem::SubprogramDecl(..) => None,
+            DeclarationItem::ReturnIdentifier(..) => None,
             DeclarationItem::Object(..) => None,
             DeclarationItem::ElementDeclaration(..) => None,
             DeclarationItem::EnumerationLiteral(..) => None,
@@ -1898,6 +1911,9 @@ impl std::fmt::Display for DeclarationItem<'_> {
             }
             DeclarationItem::SubprogramDecl(ref value) => {
                 write!(f, "{value}")
+            }
+            DeclarationItem::ReturnIdentifier(value) => {
+                write!(f, "subtype {}", value.tree)
             }
             DeclarationItem::SubprogramInstantiation(ref value) => {
                 write!(f, "{value};")

--- a/vhdl_lang/src/formatting/subprogram.rs
+++ b/vhdl_lang/src/formatting/subprogram.rs
@@ -89,8 +89,19 @@ impl VHDLFormatter<'_> {
             self.format_interface_list(parameter, buffer);
         }
         buffer.push_whitespace();
-        // return
-        self.format_token_id(specification.return_type.span.start_token - 1, buffer);
+        if let Some(return_identifier) = &specification.return_identifier {
+            // return <identifier> of
+            self.format_token_span(
+                TokenSpan::new(
+                    return_identifier.tree.token - 1,
+                    specification.return_type.span.start_token - 1,
+                ),
+                buffer,
+            );
+        } else {
+            // return
+            self.format_token_id(specification.return_type.span.start_token - 1, buffer);
+        }
         buffer.push_whitespace();
         self.format_name(specification.return_type.as_ref(), buffer);
     }

--- a/vhdl_lang/src/syntax/interface_declaration.rs
+++ b/vhdl_lang/src/syntax/interface_declaration.rs
@@ -1136,6 +1136,7 @@ function foo() return bit;
                         span: code.s1("()").token_span()
                     }),
                     return_type: code.s1("bit").type_mark(),
+                    return_identifier: None,
                     span: code.s1("function foo() return bit").token_span()
                 })
             }

--- a/vhdl_lang/src/syntax/subprogram.rs
+++ b/vhdl_lang/src/syntax/subprogram.rs
@@ -11,12 +11,12 @@ use super::names::parse_type_mark;
 use super::sequential_statement::parse_labeled_sequential_statements;
 use super::tokens::{kinds_error, Kind::*, TokenId, TokenSpan};
 use crate::ast::token_range::{WithToken, WithTokenSpan};
-use crate::ast::*;
 use crate::data::*;
 use crate::syntax::concurrent_statement::parse_map_aspect;
 use crate::syntax::interface_declaration::parse_generic_interface_list;
 use crate::syntax::names::parse_name;
 use crate::syntax::recover::expect_semicolon_or_last;
+use crate::{ast::*, VHDLStandard};
 use vhdl_lang::syntax::parser::ParsingContext;
 
 pub fn parse_signature(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<Signature>> {
@@ -180,6 +180,15 @@ pub fn parse_subprogram_specification(
 
     if is_function {
         ctx.stream.expect_kind(Return)?;
+        let return_identifier = if ctx.standard >= VHDLStandard::VHDL2019
+            && ctx.stream.next_kinds_are(&[Identifier, Of])
+        {
+            let ident = ctx.stream.expect_ident()?;
+            ctx.stream.expect_kind(Of)?;
+            Some(WithDecl::new(ident))
+        } else {
+            None
+        };
         let return_type = parse_type_mark(ctx)?;
         let end_token = ctx.stream.get_last_token_id();
         Ok(SubprogramSpecification::Function(FunctionSpecification {
@@ -188,6 +197,7 @@ pub fn parse_subprogram_specification(
             header,
             parameter_list,
             return_type,
+            return_identifier,
             span: TokenSpan::new(start_token, end_token),
         }))
     } else {
@@ -349,6 +359,7 @@ function foo return lib.foo.natural;
                     header: None,
                     parameter_list: None,
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("function", ".natural").token_span(),
                 })
             }
@@ -376,6 +387,7 @@ function \"+\" return lib.foo.natural;
                     header: None,
                     parameter_list: None,
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("function", ".natural").token_span(),
                 })
             }
@@ -403,6 +415,7 @@ impure function foo return lib.foo.natural;
                     header: None,
                     parameter_list: None,
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("impure", ".natural").token_span(),
                 })
             }
@@ -429,6 +442,7 @@ pure function foo return lib.foo.natural;
                     header: None,
                     parameter_list: None,
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("pure", ".natural").token_span(),
                 })
             }
@@ -491,6 +505,7 @@ function foo(foo : natural) return lib.foo.natural;
                         span: code.between("(", ")").token_span()
                     }),
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("function", ".natural").token_span(),
                 })
             }
@@ -522,6 +537,7 @@ function foo parameter (foo : natural) return lib.foo.natural;
                         span: code.between("parameter (", ")").token_span()
                     }),
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("function", ".natural").token_span(),
                 })
             }
@@ -560,10 +576,57 @@ function foo generic (abc_def: natural) parameter (foo : natural) return lib.foo
                         span: code.s1("parameter (foo : natural)").token_span()
                     }),
                     return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: None,
                     span: code.between("function", ".natural").token_span(),
                 })
             }
         );
+    }
+
+    #[test]
+    pub fn parses_function_specification_with_return_identifier() {
+        let code = Code::with_standard(
+            "\
+function foo return retval of lib.foo.natural;
+",
+            VHDLStandard::VHDL2019,
+        );
+        assert_eq!(
+            code.with_stream_no_diagnostics(parse_subprogram_declaration),
+            SubprogramDeclaration {
+                span: code.token_span(),
+                specification: SubprogramSpecification::Function(FunctionSpecification {
+                    pure: true,
+                    designator: code
+                        .s1("foo")
+                        .ident()
+                        .map_into(SubprogramDesignator::Identifier)
+                        .into(),
+                    header: None,
+                    parameter_list: None,
+                    return_type: code.s1("lib.foo.natural").type_mark(),
+                    return_identifier: Some(code.s1("retval").decl_ident()),
+                    span: code.between("function", ".natural").token_span(),
+                })
+            }
+        );
+    }
+
+    #[test]
+    pub fn return_identifier_is_not_parsed_before_vhdl2019() {
+        let code = Code::with_standard(
+            "\
+function foo return retval of lib.foo.natural;
+",
+            VHDLStandard::VHDL2008,
+        );
+        let spec = code
+            .with_partial_stream(parse_subprogram_specification)
+            .expect("Expected successful parse");
+        let SubprogramSpecification::Function(spec) = spec else {
+            panic!("Expected function specification");
+        };
+        assert_eq!(spec.return_identifier, None);
     }
 
     #[test]


### PR DESCRIPTION
Add the VHDL-2019 "function return identifier" enabling the syntax

```vhdl
function foo return result_subtype of bit
```

Relates to #287 