### PR TITLE
Add conditional expressions

### DIFF
--- a/vhdl_lang/src/analysis/association.rs
+++ b/vhdl_lang/src/analysis/association.rs
@@ -528,7 +528,12 @@ impl<'a> AnalyzeContext<'a, '_> {
             match &mut actual.item {
                 ActualPart::Expression(expr) => {
                     let Some(resolved_formal) = resolved_formal else {
-                        self.expr_pos_unknown_ttyp(scope, actual.span, expr, &mut NullDiagnostics)?;
+                        self.cond_expr_pos_unknown_ttyp(
+                            scope,
+                            actual.span,
+                            expr,
+                            &mut NullDiagnostics,
+                        )?;
                         continue;
                     };
                     if formal_region.typ == InterfaceType::Parameter {
@@ -542,7 +547,9 @@ impl<'a> AnalyzeContext<'a, '_> {
                     }
                     match &resolved_formal.iface {
                         InterfaceEnt::Type(uninst_typ) => {
-                            let typ = if let Expression::Name(name) = expr {
+                            let typ = if let ConditionalExpression::Simple(Expression::Name(name)) =
+                                expr
+                            {
                                 match name.as_mut() {
                                     // Could be an array constraint such as integer_vector(0 to 3)
                                     // @TODO we ignore the suffix for now
@@ -598,7 +605,7 @@ impl<'a> AnalyzeContext<'a, '_> {
                             mapping.insert(uninst_typ.id(), typ);
                         }
                         InterfaceEnt::Subprogram(target) => match expr {
-                            Expression::Name(name) => {
+                            ConditionalExpression::Simple(Expression::Name(name)) => {
                                 let resolved =
                                     self.name_resolve(scope, actual.span, name, diagnostics)?;
                                 if let ResolvedName::Overloaded(des, overloaded) = resolved {
@@ -637,7 +644,9 @@ impl<'a> AnalyzeContext<'a, '_> {
                                     )
                                 }
                             }
-                            Expression::Literal(Literal::String(string)) => {
+                            ConditionalExpression::Simple(Expression::Literal(
+                                Literal::String(string),
+                            )) => {
                                 if Operator::from_latin1(string.clone()).is_none() {
                                     diagnostics.add(
                                         actual.pos(self.ctx),
@@ -653,7 +662,7 @@ impl<'a> AnalyzeContext<'a, '_> {
                             ),
                         },
                         InterfaceEnt::Package(_) => match expr {
-                            Expression::Name(name) => {
+                            ConditionalExpression::Simple(Expression::Name(name)) => {
                                 let resolved =
                                     self.name_resolve(scope, actual.span, name, diagnostics)?;
                                 // When a formal generic package is mapped to an actual package,
@@ -693,7 +702,7 @@ impl<'a> AnalyzeContext<'a, '_> {
                             let typ = resolved_formal
                                 .require_type_mark()
                                 .expect("Object or file interface without type");
-                            self.expr_pos_with_ttyp(
+                            self.cond_expr_pos_with_ttyp(
                                 scope,
                                 self.map_type_ent(mapping, typ, scope),
                                 actual.span,
@@ -717,7 +726,7 @@ impl<'a> AnalyzeContext<'a, '_> {
     fn check_interface_mode_mismatch(
         &self,
         resolved_formal: &ResolvedFormal<'a>,
-        expr: &mut Expression,
+        expr: &mut ConditionalExpression,
         scope: &Scope<'a>,
         actual_pos: TokenSpan,
         diagnostics: &mut dyn DiagnosticHandler,
@@ -799,13 +808,13 @@ impl<'a> AnalyzeContext<'a, '_> {
 
     fn expression_as_name(
         &self,
-        expr: &mut Expression,
+        expr: &mut ConditionalExpression,
         scope: &Scope<'a>,
         span: TokenSpan,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> EvalResult<ResolvedName<'_>> {
         match expr {
-            Expression::Name(name) => {
+            ConditionalExpression::Simple(Expression::Name(name)) => {
                 let resolved = self.name_resolve(scope, span, name, diagnostics)?;
                 Ok(resolved)
             }
@@ -824,7 +833,10 @@ fn to_formal_conversion_argument(
     {
         if formal.is_some() {
             return None;
-        } else if let ActualPart::Expression(Expression::Name(ref mut actual_name)) = actual.item {
+        } else if let ActualPart::Expression(ConditionalExpression::Simple(Expression::Name(
+            ref mut actual_name,
+        ))) = actual.item
+        {
             return Some((actual.span, actual_name));
         }
     }

--- a/vhdl_lang/src/analysis/declarative.rs
+++ b/vhdl_lang/src/analysis/declarative.rs
@@ -413,15 +413,9 @@ impl<'a> AnalyzeContext<'a, '_> {
 
                 if let Some(ref mut expr) = object_decl.expression {
                     if let Ok(ref subtype) = subtype {
-                        self.expr_pos_with_ttyp(
-                            scope,
-                            subtype.type_mark(),
-                            expr.span,
-                            &mut expr.item,
-                            diagnostics,
-                        )?;
+                        self.cond_expr_with_ttyp(scope, subtype.type_mark(), expr, diagnostics)?;
                     } else {
-                        self.expr_unknown_ttyp(scope, expr, diagnostics)?;
+                        self.cond_expr_unknown_ttyp(scope, expr, diagnostics)?;
                     }
                 }
 
@@ -749,13 +743,7 @@ impl<'a> AnalyzeContext<'a, '_> {
             Ok(NamedEntities::Single(ent)) => {
                 ident.set_unique_reference(ent);
                 if let Some(attr_ent) = AttributeEnt::from_any(ent) {
-                    self.expr_pos_with_ttyp(
-                        scope,
-                        attr_ent.typ(),
-                        expr.span,
-                        &mut expr.item,
-                        diagnostics,
-                    )?;
+                    self.cond_expr_with_ttyp(scope, attr_ent.typ(), expr, diagnostics)?;
                     attr_ent
                 } else {
                     diagnostics.add(
@@ -1151,15 +1139,9 @@ impl<'a> AnalyzeContext<'a, '_> {
 
         if let Some(ref mut expression) = mode.expression {
             if let Ok(ref subtype) = subtype {
-                self.expr_pos_with_ttyp(
-                    scope,
-                    subtype.type_mark(),
-                    expression.span,
-                    &mut expression.item,
-                    diagnostics,
-                )?;
+                self.cond_expr_with_ttyp(scope, subtype.type_mark(), expression, diagnostics)?;
             } else {
-                self.expr_unknown_ttyp(scope, expression, diagnostics)?
+                self.cond_expr_unknown_ttyp(scope, expression, diagnostics)?
             }
         }
 

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -81,7 +81,7 @@ fn combine_expression_types<'a>(types: Vec<ExpressionType<'a>>) -> Option<Expres
                 base_types.extend(set.iter().copied());
             }
             // TODO: String / aggregate / null
-            _ => continue,
+            _ => return None,
         }
     }
     // A union that collapses to a single base type is unambiguous.

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -505,7 +505,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                     .map(|typ| ExpressionType::Unambiguous(typ.type_mark())),
             },
             Expression::Parenthesized(expr) => {
-                self.expr_pos_type(scope, expr.span, &mut expr.item, diagnostics)
+                self.cond_expr_pos_type(scope, expr.span, &mut expr.item, diagnostics)
             }
             Expression::Literal(ref mut literal) => match literal {
                 Literal::Physical(PhysicalLiteral { ref mut unit, .. }) => {
@@ -586,6 +586,101 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
     ) -> FatalResult {
         as_fatal(self.expr_pos_type(scope, span, expr, diagnostics))?;
         Ok(())
+    }
+
+    pub fn cond_expr_with_ttyp(
+        &self,
+        scope: &Scope<'a>,
+        target_type: TypeEnt<'a>,
+        expr: &mut WithTokenSpan<ConditionalExpression>,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> FatalResult {
+        self.cond_expr_pos_with_ttyp(scope, target_type, expr.span, &mut expr.item, diagnostics)
+    }
+
+    pub fn cond_expr_pos_with_ttyp(
+        &self,
+        scope: &Scope<'a>,
+        target_type: TypeEnt<'a>,
+        span: TokenSpan,
+        expr: &mut ConditionalExpression,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> FatalResult {
+        match expr {
+            ConditionalExpression::Simple(inner) => {
+                self.expr_pos_with_ttyp(scope, target_type, span, inner, diagnostics)
+            }
+            ConditionalExpression::Conditional(conditionals) => {
+                for conditional in &mut conditionals.conditionals {
+                    self.expr_with_ttyp(scope, target_type, &mut conditional.item, diagnostics)?;
+                    self.boolean_expr(scope, &mut conditional.condition, diagnostics)?;
+                }
+                if let Some((else_item, _)) = &mut conditionals.else_item {
+                    self.expr_with_ttyp(scope, target_type, else_item, diagnostics)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn cond_expr_unknown_ttyp(
+        &self,
+        scope: &Scope<'a>,
+        expr: &mut WithTokenSpan<ConditionalExpression>,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> FatalResult {
+        self.cond_expr_pos_unknown_ttyp(scope, expr.span, &mut expr.item, diagnostics)
+    }
+
+    pub fn cond_expr_pos_unknown_ttyp(
+        &self,
+        scope: &Scope<'a>,
+        span: TokenSpan,
+        expr: &mut ConditionalExpression,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> FatalResult {
+        match expr {
+            ConditionalExpression::Simple(inner) => {
+                self.expr_pos_unknown_ttyp(scope, span, inner, diagnostics)
+            }
+            ConditionalExpression::Conditional(conditionals) => {
+                for conditional in &mut conditionals.conditionals {
+                    self.expr_unknown_ttyp(scope, &mut conditional.item, diagnostics)?;
+                    self.boolean_expr(scope, &mut conditional.condition, diagnostics)?;
+                }
+                if let Some((else_item, _)) = &mut conditionals.else_item {
+                    self.expr_unknown_ttyp(scope, else_item, diagnostics)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn cond_expr_pos_type(
+        &self,
+        scope: &Scope<'a>,
+        span: TokenSpan,
+        expr: &mut ConditionalExpression,
+        diagnostics: &mut dyn DiagnosticHandler,
+    ) -> EvalResult<ExpressionType<'a>> {
+        match expr {
+            ConditionalExpression::Simple(inner) => {
+                self.expr_pos_type(scope, span, inner, diagnostics)
+            }
+            ConditionalExpression::Conditional(conditionals) => {
+                let mut result = None;
+                for conditional in &mut conditionals.conditionals {
+                    let typ = as_fatal(self.expr_type(scope, &mut conditional.item, diagnostics))?;
+                    self.boolean_expr(scope, &mut conditional.condition, diagnostics)?;
+                    result = result.or(typ);
+                }
+                if let Some((else_item, _)) = &mut conditionals.else_item {
+                    let typ = as_fatal(self.expr_type(scope, else_item, diagnostics))?;
+                    result = result.or(typ);
+                }
+                result.ok_or(EvalError::Unknown)
+            }
+        }
     }
 
     fn analyze_qualified_expression(
@@ -869,13 +964,7 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 self.analyze_allocation(scope, alloc, diagnostics)?;
             }
             Expression::Parenthesized(ref mut expr) => {
-                self.expr_pos_with_ttyp(
-                    scope,
-                    target_type,
-                    expr.span,
-                    &mut expr.item,
-                    diagnostics,
-                )?;
+                self.cond_expr_with_ttyp(scope, target_type, expr, diagnostics)?;
             }
         }
 

--- a/vhdl_lang/src/analysis/expression.rs
+++ b/vhdl_lang/src/analysis/expression.rs
@@ -60,6 +60,38 @@ impl<'a> From<DisambiguatedType<'a>> for ExpressionType<'a> {
     }
 }
 
+/// Combine the types of all branches of a conditional expression into a single
+/// [ExpressionType]. Since every branch must ultimately share one type, the set
+/// of types presented to overload resolution is the union of the branches'
+/// possible base types
+fn combine_expression_types<'a>(types: Vec<ExpressionType<'a>>) -> Option<ExpressionType<'a>> {
+    if types.is_empty() {
+        return None;
+    }
+    if types.iter().all(|typ| *typ == types[0]) {
+        return types.into_iter().next();
+    }
+    let mut base_types: FnvHashSet<BaseType<'a>> = FnvHashSet::default();
+    for typ in &types {
+        match typ {
+            ExpressionType::Unambiguous(typ) => {
+                base_types.insert(typ.base());
+            }
+            ExpressionType::Ambiguous(set) => {
+                base_types.extend(set.iter().copied());
+            }
+            // TODO: String / aggregate / null
+            _ => continue,
+        }
+    }
+    // A union that collapses to a single base type is unambiguous.
+    Some(if base_types.len() == 1 {
+        ExpressionType::Unambiguous(base_types.into_iter().next().unwrap().into())
+    } else {
+        ExpressionType::Ambiguous(base_types)
+    })
+}
+
 pub(super) struct TypeMatcher<'c, 'a, 't> {
     // Allow implicit type conversion from universal real/integer to other integer types
     implicit_type_conversion: bool,
@@ -668,17 +700,21 @@ impl<'a, 't> AnalyzeContext<'a, 't> {
                 self.expr_pos_type(scope, span, inner, diagnostics)
             }
             ConditionalExpression::Conditional(conditionals) => {
-                let mut result = None;
+                let mut types = Vec::new();
                 for conditional in &mut conditionals.conditionals {
-                    let typ = as_fatal(self.expr_type(scope, &mut conditional.item, diagnostics))?;
+                    if let Some(typ) =
+                        as_fatal(self.expr_type(scope, &mut conditional.item, diagnostics))?
+                    {
+                        types.push(typ);
+                    }
                     self.boolean_expr(scope, &mut conditional.condition, diagnostics)?;
-                    result = result.or(typ);
                 }
                 if let Some((else_item, _)) = &mut conditionals.else_item {
-                    let typ = as_fatal(self.expr_type(scope, else_item, diagnostics))?;
-                    result = result.or(typ);
+                    if let Some(typ) = as_fatal(self.expr_type(scope, else_item, diagnostics))? {
+                        types.push(typ);
+                    }
                 }
-                result.ok_or(EvalError::Unknown)
+                combine_expression_types(types).ok_or(EvalError::Unknown)
             }
         }
     }

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -464,11 +464,9 @@ fn could_be_indexed_name(assocs: &[AssociationElement]) -> bool {
 
 pub fn as_type_conversion(
     assocs: &mut [AssociationElement],
-) -> Option<(TokenSpan, &mut Expression)> {
+) -> Option<(TokenSpan, &mut ConditionalExpression)> {
     if assocs.len() == 1 && could_be_indexed_name(assocs) {
-        if let ActualPart::Expression(ConditionalExpression::Simple(ref mut expr)) =
-            assocs[0].actual.item
-        {
+        if let ActualPart::Expression(ref mut expr) = assocs[0].actual.item {
             return Some((assocs[0].actual.span, expr));
         }
     }
@@ -722,25 +720,40 @@ impl<'a> AnalyzeContext<'a, '_> {
                         for (idx, AssociationElement { actual, .. }) in
                             assocs.iter_mut().enumerate()
                         {
-                            // LRM 8.5: `indexed_name ::= prefix ( expression { , expression } )`.
-                            if let ActualPart::Expression(ConditionalExpression::Simple(
-                                ref mut expr,
-                            )) = actual.item
-                            {
-                                if let Some(ttyp) = indexes.get(idx) {
-                                    if let Some(ttyp) = *ttyp {
-                                        self.expr_pos_with_ttyp(
+                            if let ActualPart::Expression(ref mut index_expr) = actual.item {
+                                match index_expr {
+                                    ConditionalExpression::Simple(expr) => {
+                                        if let Some(ttyp) = indexes.get(idx) {
+                                            if let Some(ttyp) = *ttyp {
+                                                self.expr_pos_with_ttyp(
+                                                    scope,
+                                                    ttyp.into(),
+                                                    actual.span,
+                                                    expr,
+                                                    diagnostics,
+                                                )?;
+                                            } else {
+                                                self.expr_pos_unknown_ttyp(
+                                                    scope,
+                                                    actual.span,
+                                                    expr,
+                                                    diagnostics,
+                                                )?;
+                                            }
+                                        }
+                                    }
+                                    // LRM 8.4: `indexed_name ::= prefix ( expression { , expression } )`,
+                                    // i.e., a conditional expression is not a valid index.
+                                    conditional => {
+                                        diagnostics.add(
+                                            actual.span.pos(self.ctx),
+                                            "Conditional expression cannot be used as an index",
+                                            ErrorCode::SyntaxError,
+                                        );
+                                        self.cond_expr_pos_unknown_ttyp(
                                             scope,
-                                            ttyp.into(),
                                             actual.span,
-                                            expr,
-                                            diagnostics,
-                                        )?;
-                                    } else {
-                                        self.expr_pos_unknown_ttyp(
-                                            scope,
-                                            actual.span,
-                                            expr,
+                                            conditional,
                                             diagnostics,
                                         )?;
                                     }
@@ -1706,9 +1719,22 @@ impl<'a> AnalyzeContext<'a, '_> {
         scope: &Scope<'a>,
         typ: TypeEnt<'a>,
         pos: TokenSpan,
-        expr: &mut Expression,
+        expr: &mut ConditionalExpression,
         diagnostics: &mut dyn DiagnosticHandler,
     ) -> FatalResult {
+        let expr = match expr {
+            ConditionalExpression::Simple(expr) => expr,
+            // LRM 9.3.6: `type_conversion ::= type_mark ( expression )`,
+            // i.e., a conditional expression is not a valid operand.
+            conditional => {
+                diagnostics.add(
+                    pos.pos(self.ctx),
+                    "Conditional expression cannot be the argument of type conversion",
+                    ErrorCode::SyntaxError,
+                );
+                return self.cond_expr_pos_unknown_ttyp(scope, pos, conditional, diagnostics);
+            }
+        };
         if let Some(types) = as_fatal(self.expr_pos_type(scope, pos, expr, diagnostics))? {
             match types {
                 ExpressionType::Unambiguous(ctyp) => {

--- a/vhdl_lang/src/analysis/names.rs
+++ b/vhdl_lang/src/analysis/names.rs
@@ -466,7 +466,9 @@ pub fn as_type_conversion(
     assocs: &mut [AssociationElement],
 ) -> Option<(TokenSpan, &mut Expression)> {
     if assocs.len() == 1 && could_be_indexed_name(assocs) {
-        if let ActualPart::Expression(ref mut expr) = assocs[0].actual.item {
+        if let ActualPart::Expression(ConditionalExpression::Simple(ref mut expr)) =
+            assocs[0].actual.item
+        {
             return Some((assocs[0].actual.span, expr));
         }
     }
@@ -591,7 +593,9 @@ impl<'a> AnalyzeContext<'a, '_> {
         }
 
         if let [ref mut assoc] = assocs {
-            if let ActualPart::Expression(expr) = &mut assoc.actual.item {
+            if let ActualPart::Expression(ConditionalExpression::Simple(expr)) =
+                &mut assoc.actual.item
+            {
                 return self.expr_as_discrete_range_type(
                     scope,
                     assoc.actual.span,
@@ -718,7 +722,11 @@ impl<'a> AnalyzeContext<'a, '_> {
                         for (idx, AssociationElement { actual, .. }) in
                             assocs.iter_mut().enumerate()
                         {
-                            if let ActualPart::Expression(ref mut expr) = actual.item {
+                            // LRM 8.5: `indexed_name ::= prefix ( expression { , expression } )`.
+                            if let ActualPart::Expression(ConditionalExpression::Simple(
+                                ref mut expr,
+                            )) = actual.item
+                            {
                                 if let Some(ttyp) = indexes.get(idx) {
                                     if let Some(ttyp) = *ttyp {
                                         self.expr_pos_with_ttyp(

--- a/vhdl_lang/src/analysis/overloaded.rs
+++ b/vhdl_lang/src/analysis/overloaded.rs
@@ -260,7 +260,7 @@ impl<'a> AnalyzeContext<'a, '_> {
             match &mut assoc.actual.item {
                 ActualPart::Expression(expr) => {
                     let actual_type =
-                        self.expr_pos_type(scope, assoc.actual.span, expr, diagnostics)?;
+                        self.cond_expr_pos_type(scope, assoc.actual.span, expr, diagnostics)?;
                     actual_types.push(Some(actual_type));
                 }
                 ActualPart::Open => {

--- a/vhdl_lang/src/analysis/semantic.rs
+++ b/vhdl_lang/src/analysis/semantic.rs
@@ -87,7 +87,7 @@ impl<'a> AnalyzeContext<'a, '_> {
         for AssociationElement { actual, .. } in elems.iter_mut() {
             match actual.item {
                 ActualPart::Expression(ref mut expr) => {
-                    self.expr_pos_unknown_ttyp(scope, actual.span, expr, diagnostics)?;
+                    self.cond_expr_pos_unknown_ttyp(scope, actual.span, expr, diagnostics)?;
                 }
                 ActualPart::Open => {}
             }

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -2030,3 +2030,114 @@ constant bad : integer := 1 when cond else true;
         )],
     );
 }
+
+#[test]
+fn conditional_expression_cannot_be_used_as_index() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.in_declarative_region(
+        "
+constant cond : boolean := true;
+constant arr : integer_vector(0 to 3) := (others => 0);
+constant bad : integer := arr(0 when cond else 1);
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![Diagnostic::new(
+            code.s1("0 when cond else 1"),
+            "Conditional expression cannot be used as an index",
+            ErrorCode::SyntaxError,
+        )],
+    );
+}
+
+#[test]
+fn conditional_expression_index_contents_are_analyzed() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.in_declarative_region(
+        "
+constant cond : boolean := true;
+constant arr : integer_vector(0 to 3) := (others => 0);
+constant bad : integer := arr(missing when cond else 1);
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![
+            Diagnostic::new(
+                code.s1("missing when cond else 1"),
+                "Conditional expression cannot be used as an index",
+                ErrorCode::SyntaxError,
+            ),
+            Diagnostic::new(
+                code.s1("missing"),
+                "No declaration of 'missing'",
+                ErrorCode::Unresolved,
+            ),
+        ],
+    );
+}
+
+#[test]
+fn conditional_expression_cannot_be_type_conversion_argument() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.in_declarative_region(
+        "
+constant cond : boolean := true;
+constant bad : integer := integer(1.0 when cond else 2.0);
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![Diagnostic::new(
+            code.s1("1.0 when cond else 2.0"),
+            "Conditional expression cannot be the argument of type conversion",
+            ErrorCode::SyntaxError,
+        )],
+    );
+}
+
+#[test]
+fn conditional_expression_all_branches_disambiguate_overloaded_calls() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.in_declarative_region(
+        "
+function fun1(arg : integer) return natural is
+begin
+    return 0;
+end function;
+
+function fun1(arg : real) return natural is
+begin
+    return 0;
+end function;
+
+constant cond : boolean := true;
+constant bad : natural := fun1(1 when cond else 1.0);
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![Diagnostic::new(
+            code.s1(":= fun1").s1("fun1"),
+            "Ambiguous call to 'fun1'",
+            ErrorCode::AmbiguousCall,
+        )
+        .related(
+            code.s("fun1", 1),
+            "Might be function fun1[INTEGER return NATURAL]",
+        )
+        .related(
+            code.s("fun1", 2),
+            "Might be function fun1[REAL return NATURAL]",
+        )],
+    );
+}

--- a/vhdl_lang/src/analysis/tests/typecheck_expression.rs
+++ b/vhdl_lang/src/analysis/tests/typecheck_expression.rs
@@ -7,6 +7,7 @@
 use super::*;
 use std::vec;
 use vhdl_lang::data::error_codes::ErrorCode;
+use vhdl_lang::VHDLStandard::VHDL2019;
 
 #[test]
 fn test_integer_literal_expression_typecheck() {
@@ -1990,6 +1991,41 @@ end package;",
         vec![Diagnostic::new(
             code.s1("true"),
             "'true' does not match array type 'BIT_VECTOR'",
+            ErrorCode::TypeMismatch,
+        )],
+    );
+}
+
+#[test]
+fn conditional_expression_is_typechecked() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    builder.in_declarative_region(
+        "
+constant cond : boolean := true;
+constant good : integer := 1 when cond else 2;
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_no_diagnostics(&diagnostics);
+}
+
+#[test]
+fn conditional_expression_candidates_must_match_target_type() {
+    let mut builder = LibraryBuilder::with_standard(VHDL2019);
+    let code = builder.in_declarative_region(
+        "
+constant cond : boolean := true;
+constant bad : integer := 1 when cond else true;
+        ",
+    );
+
+    let diagnostics = builder.analyze();
+    check_diagnostics(
+        diagnostics,
+        vec![Diagnostic::new(
+            code.s1("else true").s1("true"),
+            "'true' does not match integer type 'INTEGER'",
             ErrorCode::TypeMismatch,
         )],
     );

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -288,9 +288,9 @@ pub struct QualifiedExpression {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub enum ConditionalExpression<E = Expression> {
-    Simple(E),
-    Conditional(Conditionals<WithTokenSpan<E>>),
+pub enum ConditionalExpression {
+    Simple(Expression),
+    Conditional(Box<Conditionals<WithTokenSpan<Expression>>>),
 }
 
 /// LRM 9. Expressions

--- a/vhdl_lang/src/ast.rs
+++ b/vhdl_lang/src/ast.rs
@@ -230,7 +230,7 @@ pub enum ElementAssociation {
 /// LRM 6.5.7 Association Lists
 #[derive(PartialEq, Debug, Clone)]
 pub enum ActualPart {
-    Expression(Expression),
+    Expression(ConditionalExpression),
     Open,
 }
 
@@ -287,6 +287,12 @@ pub struct QualifiedExpression {
     pub expr: WithTokenSpan<Expression>,
 }
 
+#[derive(PartialEq, Debug, Clone)]
+pub enum ConditionalExpression<E = Expression> {
+    Simple(E),
+    Conditional(Conditionals<WithTokenSpan<E>>),
+}
+
 /// LRM 9. Expressions
 #[derive(PartialEq, Debug, Clone)]
 pub enum Expression {
@@ -311,7 +317,7 @@ pub enum Expression {
 
     /// LRM 9.3.7 Allocators
     New(Box<WithTokenSpan<Allocator>>),
-    Parenthesized(Box<WithTokenSpan<Expression>>),
+    Parenthesized(Box<WithTokenSpan<ConditionalExpression>>),
 }
 
 /// An identifier together with the lexical source location it occurs in.
@@ -569,7 +575,7 @@ pub struct AttributeSpecification {
     pub entity_name: EntityName,
     pub colon_token: TokenId,
     pub entity_class: EntityClass,
-    pub expr: WithTokenSpan<Expression>,
+    pub expr: WithTokenSpan<ConditionalExpression>,
 }
 
 /// LRM 7.2 Attribute specification
@@ -679,7 +685,7 @@ pub struct ObjectDeclaration {
     pub colon_token: TokenId,
     pub idents: Vec<WithDecl<Ident>>,
     pub subtype_indication: SubtypeIndication,
-    pub expression: Option<WithTokenSpan<Expression>>,
+    pub expression: Option<WithTokenSpan<ConditionalExpression>>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -814,7 +820,7 @@ pub struct SimpleModeIndication {
     pub class: ObjectClass,
     pub subtype_indication: SubtypeIndication,
     pub bus: bool,
-    pub expression: Option<WithTokenSpan<Expression>>,
+    pub expression: Option<WithTokenSpan<ConditionalExpression>>,
 }
 
 #[derive(PartialEq, Debug, Clone, Copy)]

--- a/vhdl_lang/src/ast/display.rs
+++ b/vhdl_lang/src/ast/display.rs
@@ -457,6 +457,26 @@ impl Display for Expression {
     }
 }
 
+impl Display for ConditionalExpression {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            ConditionalExpression::Simple(expr) => write!(f, "{expr}"),
+            ConditionalExpression::Conditional(conditionals) => {
+                for (i, conditional) in conditionals.conditionals.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " else ")?;
+                    }
+                    write!(f, "{} when {}", conditional.item, conditional.condition)?;
+                }
+                if let Some((else_item, _)) = &conditionals.else_item {
+                    write!(f, " else {else_item}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 impl Display for Direction {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -963,14 +963,7 @@ fn search_pos_conditional_expr(
     match expr {
         ConditionalExpression::Simple(expr) => search_pos_expr(ctx, pos, expr, searcher),
         ConditionalExpression::Conditional(conditionals) => {
-            for conditional in &conditionals.conditionals {
-                return_if_found!(conditional.item.search(ctx, searcher));
-                return_if_found!(conditional.condition.search(ctx, searcher));
-            }
-            if let Some((else_item, _)) = &conditionals.else_item {
-                return_if_found!(else_item.search(ctx, searcher));
-            }
-            NotFound
+            search_conditionals(conditionals, true, searcher, ctx)
         }
     }
 }

--- a/vhdl_lang/src/ast/search.rs
+++ b/vhdl_lang/src/ast/search.rs
@@ -949,8 +949,35 @@ fn search_pos_expr(
             _ => NotFound,
         },
         Expression::Parenthesized(expr) => {
-            search_pos_expr(ctx, &expr.span.pos(ctx), &expr.item, searcher)
+            search_pos_conditional_expr(ctx, &expr.span.pos(ctx), &expr.item, searcher)
         }
+    }
+}
+
+fn search_pos_conditional_expr(
+    ctx: &dyn TokenAccess,
+    pos: &SrcPos,
+    expr: &ConditionalExpression,
+    searcher: &mut impl Searcher,
+) -> SearchResult {
+    match expr {
+        ConditionalExpression::Simple(expr) => search_pos_expr(ctx, pos, expr, searcher),
+        ConditionalExpression::Conditional(conditionals) => {
+            for conditional in &conditionals.conditionals {
+                return_if_found!(conditional.item.search(ctx, searcher));
+                return_if_found!(conditional.condition.search(ctx, searcher));
+            }
+            if let Some((else_item, _)) = &conditionals.else_item {
+                return_if_found!(else_item.search(ctx, searcher));
+            }
+            NotFound
+        }
+    }
+}
+
+impl Search for WithTokenSpan<ConditionalExpression> {
+    fn search(&self, ctx: &dyn TokenAccess, searcher: &mut impl Searcher) -> SearchResult {
+        search_pos_conditional_expr(ctx, &self.span.pos(ctx), &self.item, searcher)
     }
 }
 
@@ -992,7 +1019,12 @@ impl Search for AssociationElement {
 
         match actual.item {
             ActualPart::Expression(ref expr) => {
-                return_if_found!(search_pos_expr(ctx, &actual.pos(ctx), expr, searcher));
+                return_if_found!(search_pos_conditional_expr(
+                    ctx,
+                    &actual.pos(ctx),
+                    expr,
+                    searcher
+                ));
             }
             ActualPart::Open => {}
         }

--- a/vhdl_lang/src/ast/util.rs
+++ b/vhdl_lang/src/ast/util.rs
@@ -391,7 +391,9 @@ impl CallOrIndexed {
         let mut indexes: Vec<Index<'_>> = Vec::with_capacity(parameters.items.len());
 
         for elem in parameters.items.iter_mut() {
-            if let ActualPart::Expression(ref mut expr) = &mut elem.actual.item {
+            if let ActualPart::Expression(ConditionalExpression::Simple(ref mut expr)) =
+                &mut elem.actual.item
+            {
                 indexes.push(Index {
                     pos: elem.actual.span,
                     expr,

--- a/vhdl_lang/src/formatting/declaration.rs
+++ b/vhdl_lang/src/formatting/declaration.rs
@@ -462,7 +462,7 @@ impl VHDLFormatter<'_> {
             buffer,
         );
         buffer.push_whitespace();
-        self.format_expression(attribute.expr.as_ref(), buffer);
+        self.format_conditional_expression(attribute.expr.as_ref(), buffer);
         self.format_token_id(span.end_token, buffer);
     }
 

--- a/vhdl_lang/src/formatting/expression.rs
+++ b/vhdl_lang/src/formatting/expression.rs
@@ -65,27 +65,11 @@ impl VHDLFormatter<'_> {
                 self.format_expression(WithTokenSpan::new(expr, span), buffer);
             }
             ConditionalExpression::Conditional(conditionals) => {
-                for (i, conditional) in conditionals.conditionals.iter().enumerate() {
-                    if i > 0 {
-                        buffer.push_whitespace();
-                        // else
-                        self.format_token_id(conditional.item.span.start_token - 1, buffer);
-                        buffer.push_whitespace();
-                    }
-                    self.format_expression(conditional.item.as_ref(), buffer);
-                    buffer.push_whitespace();
-                    // when
-                    self.format_token_id(conditional.condition.span.start_token - 1, buffer);
-                    buffer.push_whitespace();
-                    self.format_expression(conditional.condition.as_ref(), buffer);
-                }
-                if let Some((else_item, else_token)) = &conditionals.else_item {
-                    buffer.push_whitespace();
-                    // else
-                    self.format_token_id(*else_token, buffer);
-                    buffer.push_whitespace();
-                    self.format_expression(else_item.as_ref(), buffer);
-                }
+                self.format_assignment_right_hand_conditionals(
+                    conditionals,
+                    |formatter, item, buffer| formatter.format_expression(item.as_ref(), buffer),
+                    buffer,
+                );
             }
         }
     }

--- a/vhdl_lang/src/formatting/expression.rs
+++ b/vhdl_lang/src/formatting/expression.rs
@@ -7,8 +7,8 @@
 
 use crate::ast::token_range::WithTokenSpan;
 use crate::ast::{
-    ElementAssociation, ElementResolution, Expression, Operator, ResolutionIndication,
-    SubtypeConstraint, SubtypeIndication,
+    ConditionalExpression, ElementAssociation, ElementResolution, Expression, Operator,
+    ResolutionIndication, SubtypeConstraint, SubtypeIndication,
 };
 use crate::formatting::buffer::Buffer;
 use crate::formatting::VHDLFormatter;
@@ -48,8 +48,44 @@ impl VHDLFormatter<'_> {
             New(allocator) => self.format_allocator(allocator, buffer),
             Parenthesized(expression) => {
                 self.format_token_id(span.start_token, buffer);
-                self.format_expression(expression.as_ref().as_ref(), buffer);
+                self.format_conditional_expression(expression.as_ref().as_ref(), buffer);
                 self.format_token_id(span.end_token, buffer);
+            }
+        }
+    }
+
+    pub fn format_conditional_expression(
+        &self,
+        expression: WithTokenSpan<&ConditionalExpression>,
+        buffer: &mut Buffer,
+    ) {
+        let span = expression.span;
+        match expression.item {
+            ConditionalExpression::Simple(expr) => {
+                self.format_expression(WithTokenSpan::new(expr, span), buffer);
+            }
+            ConditionalExpression::Conditional(conditionals) => {
+                for (i, conditional) in conditionals.conditionals.iter().enumerate() {
+                    if i > 0 {
+                        buffer.push_whitespace();
+                        // else
+                        self.format_token_id(conditional.item.span.start_token - 1, buffer);
+                        buffer.push_whitespace();
+                    }
+                    self.format_expression(conditional.item.as_ref(), buffer);
+                    buffer.push_whitespace();
+                    // when
+                    self.format_token_id(conditional.condition.span.start_token - 1, buffer);
+                    buffer.push_whitespace();
+                    self.format_expression(conditional.condition.as_ref(), buffer);
+                }
+                if let Some((else_item, else_token)) = &conditionals.else_item {
+                    buffer.push_whitespace();
+                    // else
+                    self.format_token_id(*else_token, buffer);
+                    buffer.push_whitespace();
+                    self.format_expression(else_item.as_ref(), buffer);
+                }
             }
         }
     }
@@ -141,14 +177,14 @@ impl VHDLFormatter<'_> {
     // Helper to format ` := <expression>`
     pub(crate) fn format_default_expression(
         &self,
-        expression: Option<&WithTokenSpan<Expression>>,
+        expression: Option<&WithTokenSpan<ConditionalExpression>>,
         buffer: &mut Buffer,
     ) {
         if let Some(expr) = expression {
             buffer.push_whitespace();
             self.format_token_id(expr.span.start_token - 1, buffer);
             buffer.push_whitespace();
-            self.format_expression(expr.as_ref(), buffer);
+            self.format_conditional_expression(expr.as_ref(), buffer);
         }
     }
 

--- a/vhdl_lang/src/formatting/interface.rs
+++ b/vhdl_lang/src/formatting/interface.rs
@@ -100,9 +100,10 @@ impl VHDLFormatter<'_> {
 
     pub fn format_actual_part(&self, actual_part: &WithTokenSpan<ActualPart>, buffer: &mut Buffer) {
         match &actual_part.item {
-            ActualPart::Expression(expression) => {
-                self.format_expression(WithTokenSpan::new(expression, actual_part.span), buffer)
-            }
+            ActualPart::Expression(expression) => self.format_conditional_expression(
+                WithTokenSpan::new(expression, actual_part.span),
+                buffer,
+            ),
             ActualPart::Open => self.format_token_span(actual_part.span, buffer),
         }
     }

--- a/vhdl_lang/src/lint/sensitivity_list.rs
+++ b/vhdl_lang/src/lint/sensitivity_list.rs
@@ -26,9 +26,10 @@ use crate::ast::search::{
 use crate::ast::token_range::WithTokenSpan;
 use crate::ast::{
     ActualPart, Allocator, AssignmentRightHand, AttributeDesignator, AttributeName,
-    ConcurrentStatement, Conditionals, Designator, DiscreteRange, ElementAssociation, Expression,
-    HasUnitId, IterationScheme, LabeledConcurrentStatement, Name, ProcessStatement, Range,
-    SensitivityList, SequentialStatement, SignalAttribute, UnitId, UnitKey, Waveform, WithRef,
+    ConcurrentStatement, ConditionalExpression, Conditionals, Designator, DiscreteRange,
+    ElementAssociation, Expression, HasUnitId, IterationScheme, LabeledConcurrentStatement, Name,
+    ProcessStatement, Range, SensitivityList, SequentialStatement, SignalAttribute, UnitId,
+    UnitKey, Waveform, WithRef,
 };
 use crate::data::{DiagnosticHandler, ErrorCode, Symbol};
 use crate::{
@@ -285,8 +286,34 @@ impl SensitivityListChecker<'_> {
                 }
                 Allocator::Subtype(_) => {}
             },
-            Expression::Parenthesized(expr) => self.analyze_expression(&expr.item, expr.span, ctx),
+            Expression::Parenthesized(expr) => {
+                self.analyze_conditional_expression(&expr.item, expr.span, ctx)
+            }
             Expression::Literal(_) => {}
+        }
+    }
+
+    fn analyze_conditional_expression(
+        &mut self,
+        expr: &ConditionalExpression,
+        span: TokenSpan,
+        ctx: &dyn TokenAccess,
+    ) {
+        match expr {
+            ConditionalExpression::Simple(expr) => self.analyze_expression(expr, span, ctx),
+            ConditionalExpression::Conditional(conditionals) => {
+                for conditional in &conditionals.conditionals {
+                    self.analyze_expression(&conditional.item.item, conditional.item.span, ctx);
+                    self.analyze_expression(
+                        &conditional.condition.item,
+                        conditional.condition.span,
+                        ctx,
+                    );
+                }
+                if let Some((else_item, _)) = &conditionals.else_item {
+                    self.analyze_expression(&else_item.item, else_item.span, ctx);
+                }
+            }
         }
     }
 
@@ -314,7 +341,7 @@ impl SensitivityListChecker<'_> {
                 for item in &coi.parameters.items {
                     match &item.actual.item {
                         ActualPart::Expression(expr) => {
-                            self.analyze_expression(expr, item.actual.span, ctx)
+                            self.analyze_conditional_expression(expr, item.actual.span, ctx)
                         }
                         ActualPart::Open => {}
                     }
@@ -516,7 +543,7 @@ impl Searcher for SensitivityListChecker<'_> {
                     for item in &call_or_indexed.item.parameters.items {
                         match &item.actual.item {
                             ActualPart::Expression(expr) => {
-                                self.analyze_expression(expr, call_or_indexed.span, ctx)
+                                self.analyze_conditional_expression(expr, call_or_indexed.span, ctx)
                             }
                             ActualPart::Open => {}
                         }
@@ -624,7 +651,22 @@ fn is_likely_clocked(root: &DesignRoot, expression: &Expression) -> bool {
         },
         Expression::Literal(_) => false,
         Expression::New(_) => false,
-        Expression::Parenthesized(expr) => is_likely_clocked(root, &expr.item),
+        Expression::Parenthesized(expr) => is_likely_clocked_conditional(root, &expr.item),
+    }
+}
+
+fn is_likely_clocked_conditional(root: &DesignRoot, expression: &ConditionalExpression) -> bool {
+    match expression {
+        ConditionalExpression::Simple(expr) => is_likely_clocked(root, expr),
+        ConditionalExpression::Conditional(conditionals) => {
+            conditionals.conditionals.iter().any(|conditional| {
+                is_likely_clocked(root, &conditional.item.item)
+                    || is_likely_clocked(root, &conditional.condition.item)
+            }) || conditionals
+                .else_item
+                .as_ref()
+                .is_some_and(|(else_item, _)| is_likely_clocked(root, &else_item.item))
+        }
     }
 }
 

--- a/vhdl_lang/src/syntax/attributes.rs
+++ b/vhdl_lang/src/syntax/attributes.rs
@@ -185,13 +185,13 @@ mod tests {
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
                     expr: WithTokenSpan::new(
-                        ConditionalExpression::Conditional(Conditionals {
+                        ConditionalExpression::Conditional(Box::new(Conditionals {
                             conditionals: vec![Conditional {
                                 condition: code.s1("cond").expr(),
                                 item: code.s1("0").expr(),
                             }],
                             else_item: Some((code.s1("1").expr(), code.s1("else").token())),
-                        }),
+                        })),
                         code.s1("0 when cond else 1").token_span(),
                     )
                 }),

--- a/vhdl_lang/src/syntax/attributes.rs
+++ b/vhdl_lang/src/syntax/attributes.rs
@@ -123,7 +123,9 @@ pub fn parse_attribute(ctx: &mut ParsingContext<'_>) -> ParseResult<Vec<WithToke
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ast::ConditionalExpression, syntax::test::Code};
+    use crate::ast::{Conditional, ConditionalExpression, Conditionals};
+    use crate::syntax::test::Code;
+    use crate::VHDLStandard;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -159,6 +161,39 @@ mod tests {
                         .s1("0+1")
                         .expr()
                         .map_into(ConditionalExpression::Simple)
+                }),
+                code.token_span()
+            )]
+        )
+    }
+
+    #[test]
+    fn parse_attribute_specification_with_conditional_expression() {
+        let code = Code::with_standard(
+            "attribute attr_name of foo : signal is 0 when cond else 1;",
+            VHDLStandard::VHDL2019,
+        );
+        assert_eq!(
+            code.with_stream(parse_attribute),
+            vec![WithTokenSpan::new(
+                Attribute::Specification(AttributeSpecification {
+                    ident: WithRef::new(code.s1("attr_name").ident()),
+                    entity_name: EntityName::Name(EntityTag {
+                        designator: code.s1("foo").ref_designator(),
+                        signature: None
+                    }),
+                    colon_token: code.s1(":").token(),
+                    entity_class: EntityClass::Signal,
+                    expr: WithTokenSpan::new(
+                        ConditionalExpression::Conditional(Conditionals {
+                            conditionals: vec![Conditional {
+                                condition: code.s1("cond").expr(),
+                                item: code.s1("0").expr(),
+                            }],
+                            else_item: Some((code.s1("1").expr(), code.s1("else").token())),
+                        }),
+                        code.s1("0 when cond else 1").token_span(),
+                    )
                 }),
                 code.token_span()
             )]

--- a/vhdl_lang/src/syntax/attributes.rs
+++ b/vhdl_lang/src/syntax/attributes.rs
@@ -5,7 +5,6 @@
 // Copyright (c) 2018, Olof Kraigher olof.kraigher@gmail.com
 
 use super::common::ParseResult;
-use super::expression::parse_expression;
 use super::names::parse_type_mark;
 use super::subprogram::parse_signature;
 use super::tokens::{Kind::*, TokenSpan};
@@ -14,6 +13,7 @@ use crate::ast::{
     Attribute, AttributeDeclaration, AttributeSpecification, Designator, EntityClass, EntityName,
     EntityTag, WithRef,
 };
+use crate::syntax::expression::parse_conditional_expression;
 use crate::syntax::recover::expect_semicolon_or_last;
 use vhdl_lang::syntax::parser::ParsingContext;
 
@@ -99,7 +99,7 @@ pub fn parse_attribute(ctx: &mut ParsingContext<'_>) -> ParseResult<Vec<WithToke
             let colon_token = ctx.stream.expect_kind(Colon)?;
             let entity_class = parse_entity_class(ctx)?;
             ctx.stream.expect_kind(Is)?;
-            let expr = parse_expression(ctx)?;
+            let expr = parse_conditional_expression(ctx)?;
             let end_token = expect_semicolon_or_last(ctx);
 
             entity_names
@@ -123,7 +123,7 @@ pub fn parse_attribute(ctx: &mut ParsingContext<'_>) -> ParseResult<Vec<WithToke
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::syntax::test::Code;
+    use crate::{ast::ConditionalExpression, syntax::test::Code};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -155,7 +155,10 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code.s1("0+1").expr()
+                    expr: code
+                        .s1("0+1")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
                 }),
                 code.token_span()
             )]
@@ -176,7 +179,10 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Function,
-                    expr: code.s1("0+1").expr()
+                    expr: code
+                        .s1("0+1")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
                 }),
                 code.token_span()
             )]
@@ -198,7 +204,10 @@ mod tests {
                         }),
                         colon_token: code.s1(":").token(),
                         entity_class: EntityClass::Signal,
-                        expr: code.s1("0+1").expr()
+                        expr: code
+                            .s1("0+1")
+                            .expr()
+                            .map_into(ConditionalExpression::Simple)
                     }),
                     code.token_span()
                 ),
@@ -211,7 +220,10 @@ mod tests {
                         }),
                         colon_token: code.s1(":").token(),
                         entity_class: EntityClass::Signal,
-                        expr: code.s1("0+1").expr()
+                        expr: code
+                            .s1("0+1")
+                            .expr()
+                            .map_into(ConditionalExpression::Simple)
                     }),
                     code.token_span()
                 )
@@ -230,7 +242,10 @@ mod tests {
                     entity_name: EntityName::All,
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code.s1("0+1").expr()
+                    expr: code
+                        .s1("0+1")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
                 }),
                 code.token_span()
             )]
@@ -248,7 +263,10 @@ mod tests {
                     entity_name: EntityName::Others,
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code.s1("0+1").expr()
+                    expr: code
+                        .s1("0+1")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
                 }),
                 code.token_span()
             )]
@@ -269,7 +287,10 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Function,
-                    expr: code.s1("0+1").expr()
+                    expr: code
+                        .s1("0+1")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
                 }),
                 code.token_span()
             )]

--- a/vhdl_lang/src/syntax/attributes.rs
+++ b/vhdl_lang/src/syntax/attributes.rs
@@ -157,10 +157,7 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code
-                        .s1("0+1")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
+                    expr: code.s1("0+1").cond_expr()
                 }),
                 code.token_span()
             )]
@@ -214,10 +211,7 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Function,
-                    expr: code
-                        .s1("0+1")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
+                    expr: code.s1("0+1").cond_expr()
                 }),
                 code.token_span()
             )]
@@ -239,10 +233,7 @@ mod tests {
                         }),
                         colon_token: code.s1(":").token(),
                         entity_class: EntityClass::Signal,
-                        expr: code
-                            .s1("0+1")
-                            .expr()
-                            .map_into(ConditionalExpression::Simple)
+                        expr: code.s1("0+1").cond_expr()
                     }),
                     code.token_span()
                 ),
@@ -255,10 +246,7 @@ mod tests {
                         }),
                         colon_token: code.s1(":").token(),
                         entity_class: EntityClass::Signal,
-                        expr: code
-                            .s1("0+1")
-                            .expr()
-                            .map_into(ConditionalExpression::Simple)
+                        expr: code.s1("0+1").cond_expr()
                     }),
                     code.token_span()
                 )
@@ -277,10 +265,7 @@ mod tests {
                     entity_name: EntityName::All,
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code
-                        .s1("0+1")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
+                    expr: code.s1("0+1").cond_expr()
                 }),
                 code.token_span()
             )]
@@ -298,10 +283,7 @@ mod tests {
                     entity_name: EntityName::Others,
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Signal,
-                    expr: code
-                        .s1("0+1")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
+                    expr: code.s1("0+1").cond_expr()
                 }),
                 code.token_span()
             )]
@@ -322,10 +304,7 @@ mod tests {
                     }),
                     colon_token: code.s1(":").token(),
                     entity_class: EntityClass::Function,
-                    expr: code
-                        .s1("0+1")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
+                    expr: code.s1("0+1").cond_expr()
                 }),
                 code.token_span()
             )]

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -257,7 +257,7 @@ constant x: natural := 5;
                     idents: vec![code.s1("x").decl_ident()],
                     colon_token: code.s(":", 2).token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("5").expr().map_into(ConditionalExpression::Simple))
+                    expression: Some(code.s1("5").cond_expr())
                 }),
                 code.s1("constant x: natural := 5;").token_span()
             )])

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -189,7 +189,7 @@ pub fn parse_declarative_part(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{ObjectClass, ObjectDeclaration};
+    use crate::ast::{ConditionalExpression, ObjectClass, ObjectDeclaration};
     use crate::data::Diagnostic;
     use crate::syntax::test::{check_diagnostics, Code};
     use crate::VHDLStandard::VHDL2019;
@@ -257,7 +257,7 @@ constant x: natural := 5;
                     idents: vec![code.s1("x").decl_ident()],
                     colon_token: code.s(":", 2).token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("5").expr())
+                    expression: Some(code.s1("5").expr().map_into(ConditionalExpression::Simple))
                 }),
                 code.s1("constant x: natural := 5;").token_span()
             )])

--- a/vhdl_lang/src/syntax/declarative_part.rs
+++ b/vhdl_lang/src/syntax/declarative_part.rs
@@ -189,7 +189,7 @@ pub fn parse_declarative_part(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{ConditionalExpression, ObjectClass, ObjectDeclaration};
+    use crate::ast::{ObjectClass, ObjectDeclaration};
     use crate::data::Diagnostic;
     use crate::syntax::test::{check_diagnostics, Code};
     use crate::VHDLStandard::VHDL2019;

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -1559,4 +1559,28 @@ mod tests {
             Ok(code.s1("1").expr().map_into(ConditionalExpression::Simple))
         );
     }
+
+    #[test]
+    fn parse_conditional_expression_with_alternatives() {
+        let code = Code::with_standard("1 when a else 2 when b else 3", VHDLStandard::VHDL2019);
+        assert_eq!(
+            code.with_stream(parse_conditional_expression),
+            WithTokenSpan::new(
+                ConditionalExpression::Conditional(Conditionals {
+                    conditionals: vec![
+                        Conditional {
+                            condition: code.s1("a").expr(),
+                            item: code.s1("1").expr(),
+                        },
+                        Conditional {
+                            condition: code.s1("b").expr(),
+                            item: code.s1("2").expr(),
+                        },
+                    ],
+                    else_item: Some((code.s1("3").expr(), code.s("else", 2).token())),
+                }),
+                code.token_span(),
+            )
+        );
+    }
 }

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -619,7 +619,7 @@ fn parse_conditional_expression_continuation(
         else_item,
     };
     Ok(WithTokenSpan::new(
-        ConditionalExpression::Conditional(conditionals),
+        ConditionalExpression::Conditional(Box::new(conditionals)),
         TokenSpan::new(start_token, ctx.stream.get_last_token_id()),
     ))
 }
@@ -1566,7 +1566,7 @@ mod tests {
         assert_eq!(
             code.with_stream(parse_conditional_expression),
             WithTokenSpan::new(
-                ConditionalExpression::Conditional(Conditionals {
+                ConditionalExpression::Conditional(Box::new(Conditionals {
                     conditionals: vec![
                         Conditional {
                             condition: code.s1("a").expr(),
@@ -1578,7 +1578,7 @@ mod tests {
                         },
                     ],
                     else_item: Some((code.s1("3").expr(), code.s("else", 2).token())),
-                }),
+                })),
                 code.token_span(),
             )
         );

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -1543,9 +1543,7 @@ mod tests {
         let code = Code::with_standard("1 + 2", VHDLStandard::VHDL2019);
         assert_eq!(
             code.with_stream(parse_conditional_expression),
-            code.s1("1 + 2")
-                .expr()
-                .map_into(ConditionalExpression::Simple)
+            code.s1("1 + 2").cond_expr()
         );
     }
 
@@ -1556,7 +1554,7 @@ mod tests {
         let code = Code::with_standard("1 when 0 else 2", VHDLStandard::VHDL2008);
         assert_eq!(
             code.with_partial_stream(parse_conditional_expression),
-            Ok(code.s1("1").expr().map_into(ConditionalExpression::Simple))
+            Ok(code.s1("1").cond_expr())
         );
     }
 

--- a/vhdl_lang/src/syntax/expression.rs
+++ b/vhdl_lang/src/syntax/expression.rs
@@ -12,7 +12,7 @@ use crate::ast::token_range::{WithToken, WithTokenSpan};
 use crate::ast::{Literal, *};
 use crate::data::Diagnostic;
 use crate::syntax::TokenAccess;
-use crate::{ast, HasTokenSpan, TokenId, TokenSpan};
+use crate::{ast, HasTokenSpan, TokenId, TokenSpan, VHDLStandard};
 use vhdl_lang::syntax::parser::ParsingContext;
 
 impl WithTokenSpan<Name> {
@@ -337,7 +337,7 @@ fn name_to_selected_name(name: Name) -> Option<Name> {
 
 fn parse_expression_or_aggregate(
     ctx: &mut ParsingContext<'_>,
-    start_token: TokenId,
+    start_token: TokenId, // LeftPar
 ) -> ParseResult<WithTokenSpan<Expression>> {
     let mut choices = parse_choices(ctx)?;
 
@@ -373,8 +373,19 @@ fn parse_expression_or_aggregate(
             // Was expression with parenthesis
             RightPar => {
                 ctx.stream.skip();
-                let expr = WithTokenSpan::new(Expression::Parenthesized(Box::new(WithTokenSpan::new(expr, span))), TokenSpan::new(start_token, token_id));
+                let expr = WithTokenSpan::new(Expression::Parenthesized(Box::new(WithTokenSpan::new(ConditionalExpression::Simple(expr), span))), TokenSpan::new(start_token, token_id));
                 Ok(expr)
+            },
+
+            // Was conditional expression (primary)
+            When => {
+                let conditional =
+                    parse_conditional_expression_continuation(ctx, WithTokenSpan::new(expr, span))?;
+                let right_par = ctx.stream.expect_kind(RightPar)?;
+                Ok(WithTokenSpan::new(
+                    Expression::Parenthesized(Box::new(conditional)),
+                    TokenSpan::new(start_token, right_par),
+                ))
             }
         )
     } else {
@@ -555,6 +566,62 @@ fn parse_expr(
 pub fn parse_expression(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<Expression>> {
     let state = ctx.stream.state();
     parse_expr(ctx, 0).inspect_err(|_| ctx.stream.set_state(state))
+}
+
+pub fn parse_conditional_expression(
+    ctx: &mut ParsingContext<'_>,
+) -> ParseResult<WithTokenSpan<ConditionalExpression>> {
+    let expr = parse_expression(ctx)?;
+    if ctx.stream.next_kind_is(When) {
+        parse_conditional_expression_continuation(ctx, expr)
+    } else {
+        Ok(expr.map_into(ConditionalExpression::Simple))
+    }
+}
+
+/// Parse the remainder of a conditional expression, assuming the first item
+/// expression has already been parsed and that the next token is `when`.
+fn parse_conditional_expression_continuation(
+    ctx: &mut ParsingContext<'_>,
+    expr: WithTokenSpan<Expression>,
+) -> ParseResult<WithTokenSpan<ConditionalExpression>> {
+    if ctx.standard < VHDLStandard::VHDL2019 {
+        return Ok(expr.map_into(ConditionalExpression::Simple));
+    }
+    let start_token = expr.get_start_token();
+    // When
+    ctx.stream.skip();
+    let condition = parse_expression(ctx)?;
+    let mut conditionals = vec![Conditional {
+        condition,
+        item: expr,
+    }];
+    let mut else_item = None;
+    while ctx.stream.next_kind_is(Else) {
+        let else_id = ctx.stream.get_current_token_id();
+        ctx.stream.skip();
+        let expr = parse_expression(ctx)?;
+        if ctx.stream.next_kind_is(When) {
+            ctx.stream.expect_kind(When)?;
+            let condition = parse_expression(ctx)?;
+            conditionals.push(Conditional {
+                condition,
+                item: expr,
+            });
+        } else {
+            else_item = Some((expr, else_id));
+            break;
+        }
+    }
+
+    let conditionals = Conditionals {
+        conditionals,
+        else_item,
+    };
+    Ok(WithTokenSpan::new(
+        ConditionalExpression::Conditional(conditionals),
+        TokenSpan::new(start_token, ctx.stream.get_last_token_id()),
+    ))
 }
 
 #[cfg(test)]
@@ -1228,11 +1295,11 @@ mod tests {
         };
 
         let expr_add0 = WithTokenSpan {
-            item: Expression::Binary(
+            item: ConditionalExpression::Simple(Expression::Binary(
                 WithToken::new(WithRef::new(Operator::Plus), code.s("+", 2).token()),
                 Box::new(two),
                 Box::new(three),
-            ),
+            )),
             span: code.s1("2 + 3").token_span(),
         };
 
@@ -1273,11 +1340,11 @@ mod tests {
         };
 
         let expr_add0 = WithTokenSpan {
-            item: Expression::Binary(
+            item: ConditionalExpression::Simple(Expression::Binary(
                 WithToken::new(WithRef::new(Operator::Plus), code.s("+", 1).token()),
                 Box::new(one),
                 Box::new(two),
-            ),
+            )),
             span: code.s1("1 + 2").token_span(),
         };
 
@@ -1328,11 +1395,37 @@ mod tests {
                 }
             },
             Expression::Parenthesized(ref expr) => {
-                format!("({})", fmt(ctx, expr))
+                format!("({})", fmt_conditional(ctx, expr))
             }
             _ => {
                 println!("{}", expr.pos(ctx).code_context());
                 panic!("Cannot format {expr:?}");
+            }
+        }
+    }
+
+    fn fmt_conditional(
+        ctx: &dyn TokenAccess,
+        expr: &WithTokenSpan<ConditionalExpression>,
+    ) -> String {
+        match &expr.item {
+            ConditionalExpression::Simple(inner) => {
+                fmt(ctx, &WithTokenSpan::new(inner.clone(), expr.span))
+            }
+            ConditionalExpression::Conditional(conditionals) => {
+                let mut parts = Vec::new();
+                for conditional in &conditionals.conditionals {
+                    parts.push(format!(
+                        "{} when {}",
+                        fmt(ctx, &conditional.item),
+                        fmt(ctx, &conditional.condition)
+                    ));
+                }
+                let mut result = parts.join(" else ");
+                if let Some((else_item, _)) = &conditionals.else_item {
+                    result = format!("{result} else {}", fmt(ctx, else_item));
+                }
+                result
             }
         }
     }
@@ -1420,5 +1513,50 @@ mod tests {
         );
 
         assert_expression_is("and 1 + 2", "((And Integer(1)) Plus Integer(2))");
+    }
+
+    /// Like [assert_expression_is] but parses using the VHDL 2019 standard
+    fn assert_expression_is_2019(code: &str, expr_str: &str) {
+        let code = Code::with_standard(code, VHDLStandard::VHDL2019);
+        let ctx = code.tokenize();
+        assert_eq!(fmt(&ctx, &code.with_stream(parse_expression)), expr_str);
+    }
+
+    #[test]
+    fn parses_parenthesized_conditional_expression() {
+        assert_expression_is_2019(
+            "(1 when 0 else 2)",
+            "(Integer(1) when Integer(0) else Integer(2))",
+        );
+    }
+
+    #[test]
+    fn parses_parenthesized_conditional_expression_multiple_alternatives() {
+        assert_expression_is_2019(
+            "(1 when 0 else 2 when 3 else 4)",
+            "(Integer(1) when Integer(0) else Integer(2) when Integer(3) else Integer(4))",
+        );
+    }
+
+    #[test]
+    fn parse_conditional_expression_is_simple_without_when() {
+        let code = Code::with_standard("1 + 2", VHDLStandard::VHDL2019);
+        assert_eq!(
+            code.with_stream(parse_conditional_expression),
+            code.s1("1 + 2")
+                .expr()
+                .map_into(ConditionalExpression::Simple)
+        );
+    }
+
+    #[test]
+    fn parse_conditional_expression_before_2019_does_not_consume_when() {
+        // Before VHDL 2019 the `when` is not part of a conditional expression, so only the
+        // leading expression is consumed and the `when ...` tail is left in the stream.
+        let code = Code::with_standard("1 when 0 else 2", VHDLStandard::VHDL2008);
+        assert_eq!(
+            code.with_partial_stream(parse_conditional_expression),
+            Ok(code.s1("1").expr().map_into(ConditionalExpression::Simple))
+        );
     }
 }

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -15,6 +15,7 @@ use crate::ast::token_range::{WithToken, WithTokenSpan};
 use crate::ast::{Literal, *};
 use crate::data::error_codes::ErrorCode;
 use crate::data::Diagnostic;
+use crate::syntax::expression::parse_conditional_expression;
 use crate::syntax::separated_list::parse_list_with_separator_or_recover;
 use crate::syntax::TokenId;
 use vhdl_lang::syntax::parser::ParsingContext;
@@ -160,7 +161,9 @@ fn actual_to_expression(
     actual: WithTokenSpan<ActualPart>,
 ) -> ParseResult<WithTokenSpan<Expression>> {
     match actual.item {
-        ActualPart::Expression(expr) => Ok(WithTokenSpan::from(expr, actual.span)),
+        ActualPart::Expression(ConditionalExpression::Simple(expr)) => {
+            Ok(WithTokenSpan::from(expr, actual.span))
+        }
         _ => Err(Diagnostic::syntax_error(
             actual.pos(ctx),
             "Expected expression",
@@ -173,7 +176,7 @@ fn actual_part_to_name(
     actual: WithTokenSpan<ActualPart>,
 ) -> ParseResult<WithTokenSpan<Name>> {
     match actual.item {
-        ActualPart::Expression(expr) => {
+        ActualPart::Expression(ConditionalExpression::Simple(expr)) => {
             expression_to_name(ctx, WithTokenSpan::from(expr, actual.span))
         }
         _ => Err(Diagnostic::syntax_error(actual.pos(ctx), "Expected name")),
@@ -197,7 +200,7 @@ fn parse_actual_part(ctx: &mut ParsingContext<'_>) -> ParseResult<WithTokenSpan<
     if let Some(token) = ctx.stream.pop_if_kind(Open) {
         Ok(WithTokenSpan::from(ActualPart::Open, token))
     } else {
-        Ok(parse_expression(ctx)?.map_into(ActualPart::Expression))
+        Ok(parse_conditional_expression(ctx)?.map_into(ActualPart::Expression))
     }
 }
 
@@ -528,10 +531,15 @@ pub fn into_range(assoc: AssociationElement) -> Result<ast::Range, AssociationEl
         return Err(assoc);
     }
 
-    if let ActualPart::Expression(Expression::Name(ref name)) = &assoc.actual.item {
+    if let ActualPart::Expression(ConditionalExpression::Simple(Expression::Name(ref name))) =
+        &assoc.actual.item
+    {
         if let Name::Attribute(attr) = name.as_ref() {
             if attr.as_range().is_some() {
-                if let ActualPart::Expression(Expression::Name(name)) = assoc.actual.item {
+                if let ActualPart::Expression(ConditionalExpression::Simple(Expression::Name(
+                    name,
+                ))) = assoc.actual.item
+                {
                     if let Name::Attribute(attr) = *name {
                         return Ok(ast::Range::Attribute(attr));
                     }
@@ -983,7 +991,11 @@ mod tests {
                 name: foo,
                 parameters: SeparatedList::single(AssociationElement {
                     formal: None,
-                    actual: code.s1("0").expr().map_into(ActualPart::Expression),
+                    actual: code
+                        .s1("0")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
+                        .map_into(ActualPart::Expression),
                 }),
             })),
             span: code.s1("foo(0)").token_span(),
@@ -1008,11 +1020,19 @@ mod tests {
                     items: vec![
                         AssociationElement {
                             formal: None,
-                            actual: code.s1("0").expr().map_into(ActualPart::Expression),
+                            actual: code
+                                .s1("0")
+                                .expr()
+                                .map_into(ConditionalExpression::Simple)
+                                .map_into(ActualPart::Expression),
                         },
                         AssociationElement {
                             formal: None,
-                            actual: code.s1("1").expr().map_into(ActualPart::Expression),
+                            actual: code
+                                .s1("1")
+                                .expr()
+                                .map_into(ConditionalExpression::Simple)
+                                .map_into(ActualPart::Expression),
                         },
                     ],
                     tokens: vec![code.s1(",").token()],
@@ -1026,7 +1046,11 @@ mod tests {
                 name: prefix_index,
                 parameters: SeparatedList::single(AssociationElement {
                     formal: None,
-                    actual: code.s1("3").expr().map_into(ActualPart::Expression),
+                    actual: code
+                        .s1("3")
+                        .expr()
+                        .map_into(ConditionalExpression::Simple)
+                        .map_into(ActualPart::Expression),
                 }),
             })),
             span: code.s1("prefix(0, 1)(3)").token_span(),
@@ -1061,7 +1085,11 @@ mod tests {
 
         let assoc_elem = AssociationElement {
             formal: Some(arg),
-            actual: code.s1("0").expr().map_into(ActualPart::Expression),
+            actual: code
+                .s1("0")
+                .expr()
+                .map_into(ConditionalExpression::Simple)
+                .map_into(ActualPart::Expression),
         };
 
         let foo_call = WithTokenSpan {

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -991,11 +991,7 @@ mod tests {
                 name: foo,
                 parameters: SeparatedList::single(AssociationElement {
                     formal: None,
-                    actual: code
-                        .s1("0")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
-                        .map_into(ActualPart::Expression),
+                    actual: code.s1("0").cond_expr().map_into(ActualPart::Expression),
                 }),
             })),
             span: code.s1("foo(0)").token_span(),
@@ -1020,19 +1016,11 @@ mod tests {
                     items: vec![
                         AssociationElement {
                             formal: None,
-                            actual: code
-                                .s1("0")
-                                .expr()
-                                .map_into(ConditionalExpression::Simple)
-                                .map_into(ActualPart::Expression),
+                            actual: code.s1("0").cond_expr().map_into(ActualPart::Expression),
                         },
                         AssociationElement {
                             formal: None,
-                            actual: code
-                                .s1("1")
-                                .expr()
-                                .map_into(ConditionalExpression::Simple)
-                                .map_into(ActualPart::Expression),
+                            actual: code.s1("1").cond_expr().map_into(ActualPart::Expression),
                         },
                     ],
                     tokens: vec![code.s1(",").token()],
@@ -1046,11 +1034,7 @@ mod tests {
                 name: prefix_index,
                 parameters: SeparatedList::single(AssociationElement {
                     formal: None,
-                    actual: code
-                        .s1("3")
-                        .expr()
-                        .map_into(ConditionalExpression::Simple)
-                        .map_into(ActualPart::Expression),
+                    actual: code.s1("3").cond_expr().map_into(ActualPart::Expression),
                 }),
             })),
             span: code.s1("prefix(0, 1)(3)").token_span(),
@@ -1085,11 +1069,7 @@ mod tests {
 
         let assoc_elem = AssociationElement {
             formal: Some(arg),
-            actual: code
-                .s1("0")
-                .expr()
-                .map_into(ConditionalExpression::Simple)
-                .map_into(ActualPart::Expression),
+            actual: code.s1("0").cond_expr().map_into(ActualPart::Expression),
         };
 
         let foo_call = WithTokenSpan {

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -1127,6 +1127,31 @@ mod tests {
     }
 
     #[test]
+    fn parses_conditional_expression_as_actual() {
+        let code = Code::with_standard("(0 when cond else 1)", crate::VHDLStandard::VHDL2019);
+        let actual = WithTokenSpan::new(
+            ActualPart::Expression(ConditionalExpression::Conditional(Conditionals {
+                conditionals: vec![Conditional {
+                    condition: code.s1("cond").expr(),
+                    item: code.s1("0").expr(),
+                }],
+                else_item: Some((code.s1("1").expr(), code.s1("else").token())),
+            })),
+            code.s1("0 when cond else 1").token_span(),
+        );
+        assert_eq!(
+            code.with_stream_no_diagnostics(parse_association_list),
+            (
+                SeparatedList::single(AssociationElement {
+                    formal: None,
+                    actual,
+                }),
+                code.s1(")").token()
+            )
+        );
+    }
+
+    #[test]
     fn test_external_name_implicit_relative() {
         let code = Code::new("<< signal dut.foo : std_logic >>");
         let external_name = ExternalName {

--- a/vhdl_lang/src/syntax/names.rs
+++ b/vhdl_lang/src/syntax/names.rs
@@ -1130,13 +1130,13 @@ mod tests {
     fn parses_conditional_expression_as_actual() {
         let code = Code::with_standard("(0 when cond else 1)", crate::VHDLStandard::VHDL2019);
         let actual = WithTokenSpan::new(
-            ActualPart::Expression(ConditionalExpression::Conditional(Conditionals {
+            ActualPart::Expression(ConditionalExpression::Conditional(Box::new(Conditionals {
                 conditionals: vec![Conditional {
                     condition: code.s1("cond").expr(),
                     item: code.s1("0").expr(),
                 }],
                 else_item: Some((code.s1("1").expr(), code.s1("else").token())),
-            })),
+            }))),
             code.s1("0 when cond else 1").token_span(),
         );
         assert_eq!(

--- a/vhdl_lang/src/syntax/object_declaration.rs
+++ b/vhdl_lang/src/syntax/object_declaration.rs
@@ -143,6 +143,7 @@ mod tests {
     use super::*;
     use crate::syntax::test::{token_to_string, Code};
     use crate::HasTokenSpan;
+    use crate::VHDLStandard;
 
     #[test]
     fn parses_constant() {
@@ -298,6 +299,50 @@ mod tests {
                 code.token_span()
             )
         );
+    }
+
+    #[test]
+    fn parses_conditional_expression() {
+        let code = Code::with_standard(
+            "constant foo : natural := 0 when cond else 1;",
+            VHDLStandard::VHDL2019,
+        );
+        assert_eq!(
+            code.with_stream(parse_object_declaration),
+            WithTokenSpan::new(
+                ObjectDeclaration {
+                    class: ObjectClass::Constant,
+                    idents: vec![code.s1("foo").decl_ident()],
+                    colon_token: code.s1(":").token(),
+                    subtype_indication: code.s1("natural").subtype_indication(),
+                    expression: Some(WithTokenSpan::new(
+                        ConditionalExpression::Conditional(Conditionals {
+                            conditionals: vec![Conditional {
+                                condition: code.s1("cond").expr(),
+                                item: code.s1("0").expr(),
+                            }],
+                            else_item: Some((code.s1("1").expr(), code.s1("else").token())),
+                        }),
+                        code.s1("0 when cond else 1").token_span(),
+                    )),
+                },
+                code.token_span()
+            )
+        );
+    }
+
+    #[test]
+    fn conditional_expression_is_not_parsed_before_2019() {
+        let code = Code::with_standard(
+            "constant foo : natural := 0 when cond else 1;",
+            VHDLStandard::VHDL2008,
+        );
+        let (decl, diagnostics) = code.with_partial_stream_diagnostics(parse_object_declaration);
+        assert_eq!(
+            decl.unwrap().item.expression,
+            Some(code.s1("0").expr().map_into(ConditionalExpression::Simple))
+        );
+        assert!(!diagnostics.is_empty());
     }
 
     #[test]

--- a/vhdl_lang/src/syntax/object_declaration.rs
+++ b/vhdl_lang/src/syntax/object_declaration.rs
@@ -294,7 +294,7 @@ mod tests {
                     idents: vec![code.s1("foo").decl_ident()],
                     colon_token: code.s1(":").token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("0").expr().map_into(ConditionalExpression::Simple))
+                    expression: Some(code.s1("0").cond_expr())
                 },
                 code.token_span()
             )
@@ -340,7 +340,7 @@ mod tests {
         let (decl, diagnostics) = code.with_partial_stream_diagnostics(parse_object_declaration);
         assert_eq!(
             decl.unwrap().item.expression,
-            Some(code.s1("0").expr().map_into(ConditionalExpression::Simple))
+            Some(code.s1("0").cond_expr())
         );
         assert!(!diagnostics.is_empty());
     }
@@ -357,7 +357,7 @@ mod tests {
                     idents: vec![code.s1("foo").decl_ident(), code.s1("bar").decl_ident()],
                     colon_token: code.s1(":").token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("0").expr().map_into(ConditionalExpression::Simple)),
+                    expression: Some(code.s1("0").cond_expr()),
                 },
                 code.token_span(),
             )

--- a/vhdl_lang/src/syntax/object_declaration.rs
+++ b/vhdl_lang/src/syntax/object_declaration.rs
@@ -12,15 +12,16 @@ use super::subtype_indication::parse_subtype_indication;
 use super::tokens::{Kind::*, TokenSpan};
 use crate::ast::token_range::WithTokenSpan;
 use crate::ast::*;
+use crate::syntax::expression::parse_conditional_expression;
 use crate::syntax::recover::expect_semicolon_or_last;
 use crate::Diagnostic;
 use vhdl_lang::syntax::parser::ParsingContext;
 
 pub fn parse_optional_assignment(
     ctx: &mut ParsingContext<'_>,
-) -> ParseResult<Option<WithTokenSpan<Expression>>> {
+) -> ParseResult<Option<WithTokenSpan<ConditionalExpression>>> {
     if ctx.stream.pop_if_kind(ColonEq).is_some() {
-        let expr = parse_expression(ctx)?;
+        let expr = parse_conditional_expression(ctx)?;
         Ok(Some(expr))
     } else {
         Ok(None)
@@ -292,7 +293,7 @@ mod tests {
                     idents: vec![code.s1("foo").decl_ident()],
                     colon_token: code.s1(":").token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("0").expr())
+                    expression: Some(code.s1("0").expr().map_into(ConditionalExpression::Simple))
                 },
                 code.token_span()
             )
@@ -311,7 +312,7 @@ mod tests {
                     idents: vec![code.s1("foo").decl_ident(), code.s1("bar").decl_ident()],
                     colon_token: code.s1(":").token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
-                    expression: Some(code.s1("0").expr()),
+                    expression: Some(code.s1("0").expr().map_into(ConditionalExpression::Simple)),
                 },
                 code.token_span(),
             )

--- a/vhdl_lang/src/syntax/object_declaration.rs
+++ b/vhdl_lang/src/syntax/object_declaration.rs
@@ -316,13 +316,13 @@ mod tests {
                     colon_token: code.s1(":").token(),
                     subtype_indication: code.s1("natural").subtype_indication(),
                     expression: Some(WithTokenSpan::new(
-                        ConditionalExpression::Conditional(Conditionals {
+                        ConditionalExpression::Conditional(Box::new(Conditionals {
                             conditionals: vec![Conditional {
                                 condition: code.s1("cond").expr(),
                                 item: code.s1("0").expr(),
                             }],
                             else_item: Some((code.s1("1").expr(), code.s1("else").token())),
-                        }),
+                        })),
                         code.s1("0 when cond else 1").token_span(),
                     )),
                 },

--- a/vhdl_lang/src/syntax/recover.rs
+++ b/vhdl_lang/src/syntax/recover.rs
@@ -57,7 +57,7 @@ mod tests {
     use crate::ast::Declaration;
     use crate::syntax::declarative_part::parse_declarative_part;
     use crate::syntax::test::check_diagnostics;
-    use vhdl_lang::ast::{ConditionalExpression, ObjectClass, ObjectDeclaration};
+    use vhdl_lang::ast::{ObjectClass, ObjectDeclaration};
     use vhdl_lang::Diagnostic;
 
     #[test]

--- a/vhdl_lang/src/syntax/recover.rs
+++ b/vhdl_lang/src/syntax/recover.rs
@@ -57,7 +57,7 @@ mod tests {
     use crate::ast::Declaration;
     use crate::syntax::declarative_part::parse_declarative_part;
     use crate::syntax::test::check_diagnostics;
-    use vhdl_lang::ast::{ObjectClass, ObjectDeclaration};
+    use vhdl_lang::ast::{ConditionalExpression, ObjectClass, ObjectDeclaration};
     use vhdl_lang::Diagnostic;
 
     #[test]
@@ -78,7 +78,12 @@ signal y: bit;
                         idents: vec![code.s1("x").decl_ident()],
                         colon_token: code.s1(":").token(),
                         subtype_indication: code.s1("std_logic").subtype_indication(),
-                        expression: Some(code.s1("a.").s1("a").expr())
+                        expression: Some(
+                            code.s1("a.")
+                                .s1("a")
+                                .expr()
+                                .map_into(ConditionalExpression::Simple)
+                        )
                     }),
                     code.s1("signal x : std_logic := a.").token_span()
                 ),

--- a/vhdl_lang/src/syntax/recover.rs
+++ b/vhdl_lang/src/syntax/recover.rs
@@ -78,12 +78,7 @@ signal y: bit;
                         idents: vec![code.s1("x").decl_ident()],
                         colon_token: code.s1(":").token(),
                         subtype_indication: code.s1("std_logic").subtype_indication(),
-                        expression: Some(
-                            code.s1("a.")
-                                .s1("a")
-                                .expr()
-                                .map_into(ConditionalExpression::Simple)
-                        )
+                        expression: Some(code.s1("a.").s1("a").cond_expr())
                     }),
                     code.s1("signal x : std_logic := a.").token_span()
                 ),

--- a/vhdl_lang/src/syntax/test.rs
+++ b/vhdl_lang/src/syntax/test.rs
@@ -36,6 +36,7 @@ use crate::data::*;
 use crate::standard::VHDLStandard;
 use crate::syntax::concurrent_statement::parse_map_aspect;
 use crate::syntax::context::{parse_context, DeclarationOrReference};
+use crate::syntax::expression::parse_conditional_expression;
 use crate::syntax::names::parse_association_element;
 use crate::syntax::parser::ParsingContext;
 use crate::syntax::subprogram::{parse_optional_subprogram_header, parse_subprogram_instantiation};
@@ -586,6 +587,10 @@ impl Code {
     /// Can be used to test all but expression parsing
     pub fn expr(&self) -> WithTokenSpan<Expression> {
         self.parse_ok_no_diagnostics(parse_expression)
+    }
+
+    pub fn cond_expr(&self) -> WithTokenSpan<ConditionalExpression> {
+        self.parse_ok_no_diagnostics(parse_conditional_expression)
     }
 
     pub fn name(&self) -> WithTokenSpan<Name> {


### PR DESCRIPTION
Adds VHDL-2019 conditional expression. This enabled VHDL-LS to parse and analyse syntax like the following:
```vhdl
constant foo : std_logic := '1' when bar else '0';
attribute shreg_extract of my_srl : signal is "yes" when extract else "no";
```